### PR TITLE
ci: build distil paper PDF on push + PR

### DIFF
--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -1,0 +1,72 @@
+name: paper-build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/paper/**"
+      - ".github/workflows/paper-build.yml"
+  pull_request:
+    paths:
+      - "docs/paper/**"
+      - ".github/workflows/paper-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One in-flight build per ref; new pushes cancel the previous run.
+concurrency:
+  group: paper-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-paper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TeX Live full ships every package main.tex needs (tikz, pgfplots,
+      # algorithm2e, cleveref, microtype...). The paper has no external images
+      # and a manual thebibliography, so latexmk alone is sufficient — no
+      # bibtex/biber pass required.
+      - name: Compile paper
+        uses: xu-cheng/latex-action@v3
+        with:
+          working_directory: docs/paper
+          root_file: main.tex
+          latexmk_use_xelatex: false
+          args: -pdf -interaction=nonstopmode -halt-on-error -file-line-error
+
+      # Visual-polish triage: undefined refs/citations and overfull/underfull
+      # boxes don't fail a -halt-on-error build, so surface them as annotations
+      # instead. Adjust to `exit 1` here if the repo decides these should block.
+      - name: Surface LaTeX warnings
+        if: always()
+        working-directory: docs/paper
+        run: |
+          log=main.log
+          [ -f "$log" ] || { echo "no log file produced"; exit 0; }
+          grep -nE 'LaTeX Warning: (Reference|Citation)|There were undefined references' "$log" \
+            | while IFS= read -r line; do echo "::warning title=Undefined ref/citation::$line"; done || true
+          grep -nE 'Overfull \\[hv]box|Underfull \\[hv]box' "$log" \
+            | while IFS= read -r line; do echo "::warning title=Over/underfull box::$line"; done || true
+          echo "Warning triage complete (non-blocking)."
+
+      - name: Upload paper PDF
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distil-paper-pdf
+          path: docs/paper/main.pdf
+          if-no-files-found: error
+
+      # On failure, ship the .log so the break is diagnosable without a local
+      # TeX toolchain.
+      - name: Upload build log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distil-paper-log
+          path: docs/paper/main.log
+          if-no-files-found: warn


### PR DESCRIPTION
## What

Adds `.github/workflows/paper-build.yml` — a CI job that compiles
`docs/paper/main.tex` (the *Certified Decision-Equivalent Context Compression*
paper) on every relevant change, so visual/structural issues surface in CI
instead of only when someone compiles locally.

**Why:** there's no local LaTeX toolchain on hand, so page overflow, cropped
figures, undefined refs, and runaway tables would otherwise go unnoticed until
submission. This catches them automatically.

## Triggers

- `push` to `main` touching `docs/paper/**` or this workflow file
- `pull_request` touching the same paths
- manual `workflow_dispatch`

## How it works

- Job name: **`build-paper`** on `ubuntu-latest`.
- Compiles with [`xu-cheng/latex-action@v3`](https://github.com/xu-cheng/latex-action)
  (ships TeX Live full) running
  `latexmk -pdf -interaction=nonstopmode -halt-on-error -file-line-error`.
  The paper is all TikZ/pgfplots with a manual `thebibliography`, so no external
  images and **no bibtex/biber pass** is needed.
- **PDF artifact** `distil-paper-pdf` uploaded on success.
- **Log artifact** `distil-paper-log` (the `.log`) uploaded on failure, so a
  broken build is diagnosable without a local TeX install.
- A non-blocking triage step annotates undefined refs/citations and
  over/underfull boxes as GitHub **warnings** (matching the conservative default
  — flip to `exit 1` later if the repo wants these to block).
- `concurrency` group keyed on workflow + ref dedupes rapid PR pushes.

## Conventions

Mirrors existing workflows: `actions/checkout@v4`, `actions/upload-artifact@v4`,
lowercase workflow name, paths-filtered triggers (like `pages.yml`), and a
`concurrency` block. No existing workflow or any `docs/paper/` content was
touched — this is CI-only.

## Files

- `.github/workflows/paper-build.yml`

## Caveat

First run is the real test of the TeX Live image against the paper's package
set. The preamble only uses mainstream packages (tikz, pgfplots, algorithm,
algpseudocode, cleveref, hyperref, microtype, booktabs, geometry), all present
in TeX Live full — so this should compile on the first try. If a package turns
out to be missing, ping me and I'll pin a fuller image or add the package.
