### PR TITLE
paper: fix two overfull \hbox warnings flagged by CI

### DIFF
--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -1,0 +1,72 @@
+name: paper-build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/paper/**"
+      - ".github/workflows/paper-build.yml"
+  pull_request:
+    paths:
+      - "docs/paper/**"
+      - ".github/workflows/paper-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One in-flight build per ref; new pushes cancel the previous run.
+concurrency:
+  group: paper-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-paper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TeX Live full ships every package main.tex needs (tikz, pgfplots,
+      # algorithm2e, cleveref, microtype...). The paper has no external images
+      # and a manual thebibliography, so latexmk alone is sufficient — no
+      # bibtex/biber pass required.
+      - name: Compile paper
+        uses: xu-cheng/latex-action@v3
+        with:
+          working_directory: docs/paper
+          root_file: main.tex
+          latexmk_use_xelatex: false
+          args: -pdf -interaction=nonstopmode -halt-on-error -file-line-error
+
+      # Visual-polish triage: undefined refs/citations and overfull/underfull
+      # boxes don't fail a -halt-on-error build, so surface them as annotations
+      # instead. Adjust to `exit 1` here if the repo decides these should block.
+      - name: Surface LaTeX warnings
+        if: always()
+        working-directory: docs/paper
+        run: |
+          log=main.log
+          [ -f "$log" ] || { echo "no log file produced"; exit 0; }
+          grep -nE 'LaTeX Warning: (Reference|Citation)|There were undefined references' "$log" \
+            | while IFS= read -r line; do echo "::warning title=Undefined ref/citation::$line"; done || true
+          grep -nE 'Overfull \\[hv]box|Underfull \\[hv]box' "$log" \
+            | while IFS= read -r line; do echo "::warning title=Over/underfull box::$line"; done || true
+          echo "Warning triage complete (non-blocking)."
+
+      - name: Upload paper PDF
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distil-paper-pdf
+          path: docs/paper/main.pdf
+          if-no-files-found: error
+
+      # On failure, ship the .log so the break is diagnosable without a local
+      # TeX toolchain.
+      - name: Upload build log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distil-paper-log
+          path: docs/paper/main.log
+          if-no-files-found: warn

--- a/docs/paper/main.tex
+++ b/docs/paper/main.tex
@@ -272,10 +272,11 @@ the runner identity and the LaTeX generator refuses non-evidential (smoke) repor
 
 \section{Results}
 \label{sec:results}
+{\sloppy
 All figures and tables are produced by the released harness
 (\texttt{benchmarks/prove.py}) on real traces; committed result JSONs live in
 \texttt{docs/paper/results/} and the generated LaTeX in
-\texttt{docs/paper/generated/}.
+\texttt{docs/paper/generated/}.\par}
 
 \subsection{E1: Decision-change frontier (real SWE-bench traces)}
 
@@ -341,12 +342,13 @@ decision-equivalence evaluation must control; each is now enforced or flagged.
   E1/E2 then measure a strawman. Grade with a same-family/strength model and publish
   the agreement number as a gate.
   \item \textbf{The reversible tier must be graded \emph{with} its recovery loop.}
+  {\sloppy
   Graded without \texttt{distil\_expand}, folding a decision-relevant tool output
   behind a handle changes the decision; graded with the loop, the model recovers the
   content and the decision is preserved (\Cref{fig:expand}). Reporting only the
   no-expand bound understates the reversible tier; reporting only perfect recovery
   overstates it---we report both on the 40-instance subset where we have both
-  measurements (11.2\% no-expand vs.\ 7.5\% $+$expand at 23.9\% savings).
+  measurements (11.2\% no-expand vs.\ 7.5\% $+$expand at 23.9\% savings).\par}
 \end{enumerate}
 
 \begin{figure}[t]


### PR DESCRIPTION
Fixes the two overfull `\hbox` warnings the `paper-build` CI surfaces on `docs/paper/main.tex`.

## Stacked-PR topology
This PR targets **`ci/paper-build`** (PR #1), **not `main`**. The `paper-build.yml` workflow only exists on the `ci/paper-build` branch (PR #1, still open), so this fix branches off `ci/paper-build` to inherit the workflow and get CI validation. No files under `.github/workflows/` are touched. Stacked on #1.

## What was overfull
Both warnings came from unbreakable `\texttt{}` monospace tokens that TeX would not rebreak around under the default `\tolerance`. The tokens themselves fit on a line; TeX just packed too much before them. Wrapping each affected paragraph in a scoped `{\sloppy ... \par}` group raises tolerance and adds 3em `\emergencystretch`, letting TeX break before the long token.

| Location | Overflow | Cause | Fix |
|---|---|---|---|
| `main.tex:275--279` | 34.30pt too wide | Results sentence listing three monospace paths (`benchmarks/prove.py`, `docs/paper/results/`, `docs/paper/generated/`) | `{\sloppy}` scope on the paragraph |
| `main.tex:343--350` | 11.32pt too wide | enumerate item (iii) containing the `\texttt{distil\_expand}` token | `{\sloppy}` scope on the item body |

## Scope
- Only `docs/paper/main.tex` changed (4 insertions, 2 deletions).
- **Layout-only** — no content, numbers, captions, or claims altered.
- CI gate: build still succeeds, both overfull `\hbox` annotations should be gone, PDF artifact still uploads.