### PR TITLE
release: bump version 0.24.0 → 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [0.25.1] — 2026-06-25
+
+Version bump only; same content as the v0.25.0 release notes — fixes the PyPI
+publish that failed on a duplicate filename in v0.25.0 (the package version was
+still `0.24.0`, so the wheel/sdist collided with an already-uploaded
+distribution). The v0.25.0 tag and GitHub Release are intentionally left in
+place. See the [v0.25.0 release](https://github.com/dshakes/distil/releases/tag/v0.25.0)
+for the substantive change (Phase 5 / E7 SWE-bench Verified end-to-end eval).
+
 ## [0.24.0] — Ecosystem hooks + on-motto gap-closing
 
 New surface area for agent frameworks and observability — every addition kept

--- a/distil/__init__.py
+++ b/distil/__init__.py
@@ -15,4 +15,4 @@ This package demonstrates the two highest-leverage techniques end-to-end:
      non-inferiority gate (distil.certify.stats).
 """
 
-__version__ = "0.24.0"
+__version__ = "0.25.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "0.24.0"
+version = "0.25.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "0.24.0"
+version = "0.25.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why

`v0.25.0` is already public (tag + [GitHub Release](https://github.com/dshakes/distil/releases/tag/v0.25.0) published, `main.pdf` attached), but its **`publish-pypi`** job failed: `pyproject.toml` was still pinned at `0.24.0`, so the built artifacts (`distil_llm-0.24.0-*`) collided with the already-uploaded `0.24.0` distribution and PyPI rejected the duplicate filename.

Rather than move or delete the public `v0.25.0` tag/release, this bumps the package version to **`0.25.1`** so a fresh tag produces correctly-versioned artifacts that PyPI will accept. `v0.25.1` carries the **same substantive content** as `v0.25.0` (Phase 5 / E7 SWE-bench Verified end-to-end eval).

## Files changed

- `pyproject.toml` — `[project].version` `0.24.0` → `0.25.1`
- `distil/__init__.py` — `__version__` `0.24.0` → `0.25.1`
- `uv.lock` — `distil-llm` package entry `0.24.0` → `0.25.1` (`uv lock --check` clean)
- `CHANGELOG.md` — new `## [0.25.1]` section

No code, paper LaTeX, or other non-version files touched. The `v0.25.0` tag and release are intentionally left in place.