### PR TITLE
release: 1.0.0 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,70 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.0.0] — 2026-06-29 — General Availability
+
+**1.0 / GA.** The compression engine, the proxy/SDK integrations, and the
+decision-equivalence certificate machinery are production-grade, API-stable, and
+covered by **658 tests** with a zero-dependency stdlib core. This release folds in the
+cross-model, cost-frontier, and continuous-assurance work that landed after 0.28.0 and
+declares a stable public surface.
+
+**What "1.0 / GA" means (and what it doesn't).** It is a commitment to a stable API and
+to the contract that protects you — *certify decision-equivalence, or fall back to full
+context; never silently lossy*. It is **not** a claim that aggressive compression is safe
+on every agent untuned: E7/E11 show the opposite, which is precisely why the operating
+point is **auto-calibrated per deployment and fail-safe**. Honest scope, unchanged: the
+guarantee is distribution-free and finite-sample, **conditional on exchangeability** with
+your calibration distribution. See [`docs/GA_READINESS.md`](docs/GA_READINESS.md) for the
+full ledger of what is closed and what remains empirical breadth.
+
+### Added — cross-model generality (E11)
+- **Validated across 5 models / 3 vendors.** The long-horizon harness (30-turn ReAct,
+  SWE-bench Verified) now reports gpt-4o-mini and gpt-4.1 (OpenAI), Sonnet 4.6 (Anthropic),
+  Haiku 4.5 (Anthropic, n=500), and DeepSeek-V3 (n=200). **gate@12 shows no statistically
+  significant degradation on any of the five models.** The two well-powered runs (Haiku
+  n=500, DeepSeek n=200) confirm non-inferiority; the three n=50 runs are directionally
+  consistent with wide CIs (honestly marked as not powered).
+- **Corrected finding.** An earlier reading of DeepSeek alone ("aggressiveness must scale
+  with model capability") is **refuted** by the wider sweep: harm appears only as the
+  product of *realized compression × the agent's reliance on aged-out context* — a
+  workload×model interaction, not raw capability. A fixed `gate_recent` cannot predict it,
+  which is why you must calibrate on outcomes per deployment.
+- **OpenAI 429 handling** — retry on TPM rate-limits with backoff + `Retry-After`.
+
+### Added — auto-calibration, productionized (closes the headline GA risk)
+- `distil calibrate` selects the most aggressive working-set size whose task-success loss
+  is non-inferior to full context (paired McNemar), and **fails safe to full context** if
+  none certifies — the operating-point analogue of the certificate. Reproduces the manual
+  E11 choice automatically (selects gate@12, rejects gate@6 on DeepSeek). `distil/calibrate.py`,
+  `tests/test_calibrate.py`. The relevance gate is now a shippable library primitive
+  (`distil/gate.py`: `working_set_indices`, `gate_fraction`), not benchmark-only.
+
+### Added — cost frontier under the motto (E12)
+- **Cache-monotone gate** (`gate.py:monotone_gate`) — deterministic append-only digests so
+  the digested prefix is byte-stable and prompt-cache/KV reuse captures it.
+- **Graded gate** (`gate.py:graded_gate`) — per-distance compression tiers, certified with
+  the tighter empirical-Bernstein (Maurer–Pontil) bound (`conformal.py`).
+- **Speculative expansion** (`speculative.py`) and **constrained-bandit operating-point
+  search** (`calibrate.py:bandit_select_operating_point`) — fail-safe, shipped + tested.
+  All levers cut cost *inside* the certified envelope; they never trade the guarantee for
+  dollars.
+
+### Added — continuous assurance under drift (E13)
+- **Anytime-valid drift monitor** (`drift.py:DriftMonitor`) — a betting e-process for
+  `H0: risk ≤ α` (Waudby-Smith & Ramdas 2023) you may check after *every* turn with
+  false-alarm probability ≤ δ regardless of how often you peek (Ville's inequality). Trips
+  when live decision-change exceeds the certified budget → recalibrate or fall back.
+- **Cross-family grader ensemble** (`ensemble.py:EnsembleGrader`) — conservative "any-change"
+  aggregation keeps measured risk an upper bound even if one grader family is unfaithful.
+- **Anytime-valid certificate** for graded losses (`conformal.py:betting_upper_bound`).
+
+### Changed
+- Package version reconciled to **1.0.0** (`pyproject.toml`, `distil/__init__.py`,
+  `CITATION.cff`); PyPI classifier → **Production/Stable**.
+- Docs/site test counts corrected to 658; the landing page's E11 narrative updated to the
+  corrected (5-model) finding.
+
 ## [0.28.0] — 2026-06-26
 
 E10: trajectory-level decision-equivalence certificate — the first distribution-free,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 0.23.2
+version: 1.0.0
+date-released: 2026-06-29
 keywords:
   - llm
   - context-compression

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ savings/ablation/certification signals real rather than artifacts.
 Python 3.11+, full type hints, `from __future__ import annotations`, ruff
 (line-length 100). Match the surrounding code; keep comments earning their place.
 
+## Cutting a release
+
+See [`RELEASING.md`](RELEASING.md) — push a `v*` tag, CI publishes to PyPI via Trusted
+Publishing (no token anywhere). `./scripts/release.sh` drives it end to end.
+
 ## Conduct
 
 Be kind, be rigorous, report results faithfully (if a check failed, say so with

--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ client = wrap(anthropic.Anthropic())   # compresses the request, keeps the cache
 
 ## 📦 Install your way
 
+**New here? One command:** `pipx install distil-llm`, then `distil bench`. No pipx? Zero-install: `uvx --from distil-llm distil bench`. Everything below is an *alternative*, not a requirement.
+
+> ⚠️ **The one gotcha — the name.** The PyPI package is **`distil-llm`** but the command is **`distil`** (the bare name was taken). So `pipx install distil-llm` → run `distil …`. `pip install distil` installs something else.
+
 <p align="center"><img src="docs/assets/install.svg" alt="install options" width="100%"/></p>
 
 | Format | Command | Prereq |

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-8b7bff" alt="license"/></a>
   <img src="https://img.shields.io/badge/python-3.11%2B-5ad1c9" alt="python"/>
   <img src="https://img.shields.io/badge/runtime%20deps-0-5ad19a" alt="zero deps"/>
-  <img src="https://img.shields.io/badge/tests-532%20passing-5ad19a" alt="tests"/>
+  <img src="https://img.shields.io/badge/tests-658%20passing-5ad19a" alt="tests"/>
   <img src="https://img.shields.io/badge/corpus%20gate-PASS-5ad19a" alt="gate"/>
   <img src="https://img.shields.io/badge/works%20with-any%20SDK-8b7bff" alt="any sdk"/>
 </p>
 
-<h3 align="center">Cut LLM agent token costs — with a statistical <em>decision-equivalence</em> contract, measured on the same runs.</h3>
+<h3 align="center">The certified context compressor for AI agents.</h3>
 
 <p align="center">
-Most context compressors ship a token-savings <em>estimate</em>.<br/>
-<strong>Distil ships a quality contract:</strong> a strategy compresses only as far as a statistical non-inferiority test certifies the agent's <em>next action</em> is unchanged — across 7 domains, as a CI gate.</p>
+Every agent re-sends its <em>entire</em> conversation to the model on every single turn — and you pay for all of it, every turn. Compressing that context is easy. Compressing it <strong>without quietly changing what your agent decides to do</strong> is the part every other tool skips.</p>
 
-<p align="center"><sub><b>Honest scope (read this):</b> the contract certifies <b>decision-equivalence on a trajectory corpus</b> — a <em>proxy</em> (the agent's next action), not a guarantee of end-to-end task success. Our own real end-to-end test (<a href="docs/PAPER.md">SWE-bench Verified, E7</a>) shows the proxy <b>does not transfer</b> to task success under <em>aggressive</em> compression. Treat the savings numbers below as proxy/corpus results; see <a href="#-end-to-end-reality-swe-bench-verified-e7">End-to-end reality</a>.</sub>
+<p align="center">
+<strong>Distil ships a quality contract, not a vibe.</strong> A strategy compresses only as far as a statistical non-inferiority test <em>certifies the agent's next action is unchanged</em> — measured on the <em>same runs</em> as the savings, enforced as a merge gate across 7 domains. On a real <strong>500-instance long-horizon coding agent</strong>, Distil's reversible tier is the <strong>only compressor statistically non-inferior to full context</strong> (−2.4pp, 95% CI [−5.7, +0.9]); every lossy competitor craters. And when it <em>can't</em> certify safety, it falls back to full context — <strong>never silently lossy</strong>.</p>
+
+<p align="center"><sub><b>Honest scope (read this):</b> the contract certifies <b>decision-equivalence on a trajectory corpus</b> — a <em>proxy</em> (the agent's next action), not a guarantee of end-to-end task success. Our own real end-to-end test (<a href="docs/PAPER.md">SWE-bench Verified, E7</a>) shows the proxy <b>does not transfer</b> under <em>aggressive lossy</em> compression — which is exactly why Distil calibrates per deployment and falls back to full context when it can't certify. Treat the headline savings below as proxy/corpus results; see <a href="#-end-to-end-reality-swe-bench-verified-e7">End-to-end reality</a>.</sub>
 </p>
 
 <p align="center">
@@ -318,7 +320,7 @@ For periodic certification under drift: `distil ingest` your captured traffic �
 
 **Enforce it once, org-wide.** Run `distil proxy` as a sidecar and set `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` in managed settings or container env — every client (Claude Code via `ANTHROPIC_BASE_URL`, Codex, any SDK) routes through it with **zero per-developer change**. **Google Gemini** is supported too (point `--upstream` at `generativelanguage.googleapis.com`): the proxy compresses the `generateContent` shape (`contents` / `parts` / `functionResponse`) reversibly, and shadow-mode works for it.
 
-**Claude Code plugin.** A plugin ([`plugins/distil`](plugins/distil)) adds a live **savings status line** and a **`/distil`** command:
+**Claude Code plugin.** A plugin ([`plugins/distil`](plugins/distil)) adds a live **savings status line**, a **`/distil`** command, and a **`distil-setup` skill** (ask Claude Code to "set up distil" and it installs + routes your agent through compression):
 
 ```
 /plugin marketplace add dshakes/distil

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing Distil
+
+Distil publishes to PyPI via **Trusted Publishing (OIDC)** — CI proves its identity to
+PyPI directly, so **no API token exists anywhere** (not on a laptop, not in a GitHub
+secret). You push a `v*` tag; `.github/workflows/release.yml` gates, builds, attaches
+GitHub release artifacts, and publishes to PyPI.
+
+## One-time setup (do once, never again)
+
+1. **PyPI pending publisher** — pypi.org → project `distil-llm` → *Publishing* → *Add a
+   pending publisher*:
+   - Owner: `dshakes` · Repository: `distil` · Workflow: `release.yml` · Environment: `pypi`
+2. **Enable the publish job** — GitHub → repo *Settings* → *Secrets and variables* →
+   *Actions* → *Variables* → set `PUBLISH_TO_PYPI = true`.
+   (Until this is set, a tag still ships GitHub artifacts but skips the PyPI upload — safe.)
+
+## Cutting a release
+
+Work is version-stamped in the repo, so bump first if needed (must agree across all three):
+
+- `pyproject.toml` → `version`
+- `distil/__init__.py` → `__version__`
+- `CITATION.cff` → `version`
+- add a `## [X.Y.Z]` section to `CHANGELOG.md`
+
+Then, from a clean `main`:
+
+```bash
+./scripts/release.sh            # preflight → push main → push tag → CI publishes → Homebrew sha
+./scripts/release.sh --dry-run  # rehearse: prints every step, changes nothing
+```
+
+The driver fails fast before anything outward-facing: it checks you're on `main` with a
+clean tree, that the version agrees across all surfaces, that the tag is free, that the
+CHANGELOG has the entry, that tests pass, and that a **clean wheel install** (`--no-index`
+into a throwaway venv) yields a working `distil bench`. Every network step asks first.
+
+Pushing the tag triggers `release.yml`. Watch it:
+
+```bash
+gh run watch --repo dshakes/distil $(gh run list --repo dshakes/distil -w release -L1 --json databaseId -q '.[0].databaseId')
+# or: https://github.com/dshakes/distil/actions/workflows/release.yml
+```
+
+## After CI is green
+
+- **Verify PyPI:** `pipx install distil-llm && distil --version` → the new version.
+- **Homebrew:** `release.sh` patches `packaging/homebrew/distil.rb` with the tag tarball's
+  sha256. Copy that formula into the tap repo (`dshakes/homebrew-tap` → `Formula/distil.rb`)
+  so `brew install dshakes/tap/distil` serves it.
+- **GitHub release notes:** paste the `[X.Y.Z]` section of `CHANGELOG.md` into the release
+  at `https://github.com/dshakes/distil/releases`.
+- **Docs site** redeploys from `main` via `pages.yml` — confirm it's green.
+
+## Escape hatch (Trusted Publishing not set up yet)
+
+```bash
+export UV_PUBLISH_TOKEN=pypi-…           # a token from pypi.org
+./scripts/release.sh --local-publish     # uploads from this machine via `uv publish`
+```
+
+Only use this when CI is *not* publishing — uploading the same version twice fails (a PyPI
+version is immutable and can never be re-uploaded).

--- a/distil/__init__.py
+++ b/distil/__init__.py
@@ -15,4 +15,4 @@ This package demonstrates the two highest-leverage techniques end-to-end:
      non-inferiority gate (distil.certify.stats).
 """
 
-__version__ = "0.25.1"
+__version__ = "1.0.0"

--- a/docs/GA_READINESS.md
+++ b/docs/GA_READINESS.md
@@ -5,7 +5,17 @@ agent and trust it unattended" general-availability claim. Updated as items clos
 distil should never *silently* ship a lossy operating point — when it cannot certify safety,
 it falls back to full context.
 
-## Status: GA-track — every *design* blocker is closed; what remains is empirical breadth
+## Status: 1.0 GA — the engine, integrations, and certificate machinery are production-grade and API-stable
+
+**What "1.0 / GA" means here (and what it does not).** The compression engine, the proxy/SDK
+integrations, and the decision-equivalence certificate machinery are production-grade,
+API-stable, and covered by 658 tests with a zero-dependency stdlib core. The guarantee is
+**honestly scoped**: decision-equivalence is certified *distribution-free and finite-sample*,
+**conditional on exchangeability** with your calibration distribution — and when distil cannot
+certify safety it **falls back to full context**, never silently shipping a lossy operating
+point. 1.0 is a commitment to a stable surface and a never-silently-lossy contract; it is **not**
+a claim that aggressive compression is safe on every agent untuned (E7/E11 show the opposite —
+that is exactly why calibration is mandatory and fail-safe).
 
 The headline GA risk surfaced by E11 (the safe operating point is capability-dependent, and a
 hand-tuned constant can silently lose 31 pp on a stronger model) is **closed** by
@@ -15,7 +25,8 @@ ensemble; see "Recently closed"). What remains is not missing machinery but **em
 that requires live runs/compute we have not spent**: validating the shipped speculative,
 multi-grader, and RL-policy paths end-to-end, and broadening task-success beyond SWE-bench
 Verified + τ-bench to more domains and models. The design is domain-agnostic; closing these is
-*running it at scale*, not building more. We mark them honestly rather than claim them.
+*running it at scale*, not building more. We mark them honestly rather than claim them — and we
+ship 1.0 because the contract that protects you (certify-or-fall-back) is itself complete.
 
 ## Closed
 
@@ -25,7 +36,7 @@ Verified + τ-bench to more domains and models. The design is domain-agnostic; c
 | **Operating point is auto-calibrated to agent capability** | `distil/calibrate.py` selects the most aggressive `gate_recent` still non-inferior to full; `distil calibrate` CLI; validated on real E11 data (selects gate@12, rejects gate@6) in `tests/test_calibrate.py` |
 | **Fail-safe default (never silently lossy)** | If no operating point certifies non-inferior, calibration returns `fail_safe` → caller keeps full context (`test_fail_safe_when_nothing_certifies`, `test_real_e11_strict_margin_fails_safe`) |
 | **Cross-model generality demonstrated** | E11: non-inferiority transfers to DeepSeek-V3 (different vendor, far stronger) at a capability-appropriate point |
-| **Engineering maturity** | v0.25.x, 633 tests, full CI (ci/pages/paper-build/release), zero-dependency stdlib core, packaged (`distil` entrypoint) |
+| **Engineering maturity** | v1.0.0, 658 tests, full CI (ci/pages/paper-build/release), zero-dependency stdlib core, packaged (`distil` entrypoint) |
 | **Per-turn + trajectory certificates, validated out-of-sample** | E2 (coverage 96.6–100%), E10 (trajectory, coverage 95.4/96.7%) |
 
 ## Open (tracked GA items)

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -70,10 +70,20 @@
 
     <!-- Install -->
     <h2>Install</h2>
-    <p>Distil ships as a PyPI package (<code>distil-llm</code>) with a <strong>stdlib-only core — zero runtime dependencies</strong>. The corpus is bundled in every distribution. Pick the format that fits your workflow.</p>
+    <p>Distil ships as a PyPI package (<code>distil-llm</code>) with a <strong>stdlib-only core — zero runtime dependencies</strong>. The corpus is bundled in every distribution.</p>
+
+    <div class="callout good">
+      <strong>Just want it now?</strong> One command:
+      <pre class="term" style="margin:.6em 0 .4em">pipx install distil-llm   <span class="d"># then: distil bench</span></pre>
+      No pipx? Zero-install with <a href="https://docs.astral.sh/uv/">uv</a>: <code>uvx --from distil-llm distil bench</code>. Everything else below is an alternative, not a requirement.
+    </div>
 
     <div class="callout">
-      <strong>Python 3.11+ required.</strong> Install Distil <em>isolated</em> from your system Python — modern macOS and Linux reject system-wide <code>pip install</code> with <code>error: externally-managed-environment</code> (<a href="https://peps.python.org/pep-0668/">PEP&nbsp;668</a>). All methods below are safe.
+      <strong>The one gotcha — the name.</strong> The package is <code>distil-llm</code> but the command is <code>distil</code> (the bare <code>distil</code> name was taken on PyPI). So it's <code>pipx install distil-llm</code> → run <code>distil …</code>. <code>pipx install distil</code> installs the wrong thing.
+    </div>
+
+    <div class="callout">
+      <strong>Python 3.11+ required.</strong> Install Distil <em>isolated</em> from your system Python — modern macOS and Linux reject system-wide <code>pip install</code> with <code>error: externally-managed-environment</code> (<a href="https://peps.python.org/pep-0668/">PEP&nbsp;668</a>). Every method below is isolated and safe.
     </div>
 
     <div class="grid2">
@@ -154,7 +164,7 @@ data-analysis     data-analysis-sql          18.1%     <span class="g">PASS</spa
 devops            devops-rollback            25.0%     <span class="g">PASS</span>   <span class="w">FAIL</span>     857
 finance           finance-reconcile          29.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>    1014
 ---------------------------------------------------------------------------
-aggregate: distil cuts $0.14212 -> $0.10402 (26.8% cheaper) losslessly; 5761 tokens prunable.
+aggregate: distil cuts $0.14212 -> $0.10402 (26.8% cheaper) reversibly; 5761 tokens causally prunable.
 
 GATE: <span class="g">PASS</span> — every trajectory certified non-inferior; aggressive rejected on all.</pre>
 
@@ -201,7 +211,7 @@ client = wrap(anthropic.Anthropic())
 
 <span class="d"># Works exactly like the original client</span>
 response = client.messages.create(
-    model=<span class="g">"claude-opus-4-5"</span>,
+    model=<span class="g">"claude-opus-4-8"</span>,
     max_tokens=1024,
     system=<span class="g">"You are a helpful assistant."</span>,
     messages=[{<span class="g">"role"</span>: <span class="g">"user"</span>, <span class="g">"content"</span>: <span class="g">"Analyse this log output…"</span>}],

--- a/docs/index.html
+++ b/docs/index.html
@@ -148,7 +148,7 @@
     <b>decision-equivalence on a trajectory corpus</b>, not end-to-end task success — our
     real <a href="research.html#e7">SWE-bench Verified test (E7)</a> shows it does
     <b>not</b> transfer once compression gets aggressive. We publish that. <a href="research.html#e8">E8</a> (500-instance long-horizon, 5 conditions) shows
-    relevance-gated reversible compression is <b>the only condition non-inferior to full context</b> (&minus;2.4&nbsp;pp, 95% CI [&minus;5.7, +0.9]; McNemar p=0.19), beats Headroom by +4.2&nbsp;pp (p=0.035), and beats LLMLingua-2 by 34&nbsp;points (36.8% vs 2.4% pass@1) despite removing nearly identical context fractions. We publish that too. <a href="research.html#e10"><b>E10</b></a> closes the loop with a trajectory-level certificate (the first of its kind): with 95% confidence, the gated compressor costs a solvable task on &le;11.4% of exchangeable runs — certified and proven out-of-sample. <a href="research.html#e11"><b>E11</b></a> shows it generalizes across vendors to a far stronger model (DeepSeek-V3, full 60.0%): non-inferior at a capability-appropriate operating point (55.5%, &minus;4.5&nbsp;pp, p=0.15) — compression aggressiveness must scale with agent capability.</p>
+    relevance-gated reversible compression is <b>the only condition non-inferior to full context</b> (&minus;2.4&nbsp;pp, 95% CI [&minus;5.7, +0.9]; McNemar p=0.19), beats Headroom by +4.2&nbsp;pp (p=0.035), and beats LLMLingua-2 by 34&nbsp;points (36.8% vs 2.4% pass@1) despite removing nearly identical context fractions. We publish that too. <a href="research.html#e10"><b>E10</b></a> closes the loop with a trajectory-level certificate (the first of its kind): with 95% confidence, the gated compressor costs a solvable task on &le;11.4% of exchangeable runs — certified and proven out-of-sample. <a href="research.html#e11"><b>E11</b></a> extends this across <b>5 models / 3 vendors</b> (OpenAI, Anthropic, DeepSeek): the relevance gate shows no statistically significant degradation at gate@12 on any of them, and the safe aggressive point tracks <i>realized compression × the agent's reliance on aged-out context</i> — a workload×model interaction, not raw capability — which is why the operating point must be <b>auto-calibrated per deployment</b>, fail-safe to full context.</p>
   <div class="cta">
     <a class="btn primary" href="#how">See how it works</a>
     <a class="btn ghost" href="#proof">Read the proof</a>
@@ -173,7 +173,7 @@
     <div class="stat">
       <div class="n">0</div>
       <div class="l">Runtime dependencies</div>
-      <div class="foot">stdlib-only · 532 tests · pip · docker · pyz</div>
+      <div class="foot">stdlib-only · 658 tests · pip · docker · pyz</div>
     </div>
   </div>
   <p class="muted" style="font-size:12.5px;margin-top:14px">

--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -7,16 +7,18 @@
 # Or clone this file into your own tap at:
 #   $(brew --repo)/Library/Taps/<yourname>/homebrew-tap/Formula/distil.rb
 #
-# sha256 is for the v0.24.0 source tarball. To recompute for a new version:
-#   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+# RELEASE STEP: after pushing the v1.0.0 tag, recompute and paste the sha256 below:
+#   curl -sL https://github.com/dshakes/distil/archive/refs/tags/v1.0.0.tar.gz | shasum -a 256
+# (the placeholder sha256 will make `brew install` fail loudly until filled — by design,
+#  so a stale checksum can never silently install the wrong version.)
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v0.24.0.tar.gz"
-  sha256 "dac6259280ec9f762e2f4c04f6fb5b7782a4bca7fbc3351a14fc45eaa6cecf0d"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "REPLACE_WITH_v1.0.0_TARBALL_SHA256"
   license "Apache-2.0"
-  version "0.24.0"
+  version "1.0.0"
 
   depends_on "python@3.12"
 

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live token-savings status line + controls for distil context compression",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/plugins/distil/README.md
+++ b/plugins/distil/README.md
@@ -17,7 +17,9 @@ A live token-savings **status line** and a **`/distil`** command for
 /plugin install distil@distil
 ```
 
-This gives you the **`/distil`** command (savings report + setup help).
+This gives you the **`/distil`** command (savings report + setup help) and the
+**`distil-setup` skill** — ask Claude Code to "set up distil" or "route my agent
+through distil" and it installs the CLI and wires your agent/SDK through compression.
 
 ## Enable the live savings status line
 

--- a/plugins/distil/skills/distil-setup/SKILL.md
+++ b/plugins/distil/skills/distil-setup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: distil-setup
+description: >-
+  Install distil and route an AI coding agent or SDK app through it to cut LLM token
+  costs with certified, reversible context compression. Use when the user wants to set
+  up distil, install distil-llm, reduce their agent/Claude Code/Codex/Gemini token spend,
+  point a base_url at the distil proxy, or check how much distil has saved them.
+---
+
+# Set up distil
+
+Distil is a certified, reversible LLM context compressor. The CLI is `distil`; the PyPI
+package is `distil-llm` (the bare `distil` name was taken). Core is zero-dependency stdlib —
+it runs anywhere. Follow these steps; only report numbers the commands actually print.
+
+## 1. Install (isolated — never `pip install` system-wide)
+
+Pick the first that's available:
+
+```bash
+pipx install distil-llm        # isolated CLI (preferred)
+# or, zero-install:
+uvx --from distil-llm distil bench
+# or:
+brew install dshakes/tap/distil
+```
+
+Verify: `distil --version` (should print `distil 1.0.0` or later).
+
+## 2. See it work in seconds (offline, no API key)
+
+```bash
+distil bench    # certifies savings + decision-equivalence across 7 domains
+```
+
+## 3. Route real traffic through it — pick the user's situation
+
+**Coding agent (Claude Code / Codex / Gemini CLI)** — wrap it, zero code change:
+```bash
+distil wrap --lossless-only -- claude     # subscription/OAuth-safe (ToS-safe, no tool injection)
+distil wrap --expand -- claude            # PAYG: aggressive digest, model recovers detail on demand
+```
+`--lossless-only` is the safe default for subscription/OAuth sessions. Add `--verbatim` for
+interactive sessions where the model should see content un-digested.
+
+**Any SDK app (Python/TS/any language)** — point the client's `base_url` at the proxy:
+```bash
+distil proxy --upstream https://api.anthropic.com   # listens on 127.0.0.1:8788
+```
+Then set `base_url="http://127.0.0.1:8788"` (Anthropic) or `.../v1` (OpenAI-compatible). For
+Gemini: `distil proxy --upstream https://generativelanguage.googleapis.com`.
+
+**Org-wide, zero per-developer change** — run `distil proxy` as a sidecar and set
+`ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` in managed settings or container env.
+
+## 4. Prove the savings are real
+
+```bash
+distil leaderboard            # genuine cumulative savings from the local ledger
+distil proxy --shadow 0.05    # then: distil shadow-stats — live decision-equivalence on real traffic
+```
+
+## Honest scope (tell the user this — it's the point)
+
+The decision-equivalence guarantee is certified but **conditional on exchangeability** with
+the calibration distribution, and when distil can't certify safety it **falls back to full
+context** (never silently lossy). Aggressive *lossy* compression can cost end-to-end task
+success — distil's *reversible*, relevance-gated tier is the one validated non-inferior to full
+context on a real long-horizon agent. For an aggressive operating point, calibrate per
+deployment: `distil calibrate` (fail-safe to full context).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "0.25.1"
+version = "1.0.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "shakes", email = "chandu1221@gmail.com" }]
 keywords = ["llm", "context-compression", "prompt-caching", "agentic-runtime", "non-inferiority", "tokens", "cost"]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Programming Language :: Python :: 3.11",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,28 +1,40 @@
 #!/usr/bin/env bash
-# Distil release driver — push, tag, publish to PyPI, refresh the Homebrew sha256.
+# Distil release driver — push, tag, and let CI publish; refresh the Homebrew sha256.
 #
-# Outward-facing and mostly irreversible: every network step asks before it runs,
-# and the script fails fast if anything looks off. Run it from the repo root on a
-# clean `main`:
+# PUBLISHING MODEL (industry standard): this repo publishes to PyPI via
+# .github/workflows/release.yml using PyPA Trusted Publishing (OIDC) — there is NO
+# API token anywhere. You push a v* tag; CI gates, builds, attaches GitHub release
+# artifacts, and (when enabled) publishes to PyPI. So this script's job is to push
+# main + the tag; CI does the upload. No twine, no laptop token.
 #
+# ONE-TIME SETUP on pypi.org (per the footer of release.yml), then never again:
+#   1. pypi.org → distil-llm → Publishing → add a Trusted Publisher:
+#        owner dshakes · repo distil · workflow release.yml · environment pypi
+#   2. GitHub → repo → Settings → Variables → set  PUBLISH_TO_PYPI = true
+#      (until set, a tag still ships GitHub artifacts but skips the PyPI upload.)
+#
+# Run from the repo root on a clean `main`:
 #   ./scripts/release.sh
 #
-# Prereqs:
-#   - uv (build) and twine (upload) on PATH        # brew install uv twine
-#   - PyPI credentials: a ~/.pypirc, or TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-…
-#   - push rights to origin
+# Prereqs: uv on PATH (build/smoke-test) · push rights to origin · gh CLI (optional,
+# to watch the release run). No twine and no PyPI token required.
 #
 # Flags:
-#   --dry-run     print every action, change nothing (no push, no tag, no upload)
-#   --skip-tests  skip the pytest gate (NOT recommended)
+#   --dry-run        print every action, change nothing (no push, no tag)
+#   --skip-tests     skip the pytest gate (NOT recommended)
+#   --local-publish  ALSO upload from this machine via `uv publish` (escape hatch for
+#                    when Trusted Publishing isn't set up; needs UV_PUBLISH_TOKEN).
+#                    Leave OFF if CI publishes — double-upload of a version fails.
 set -euo pipefail
 
 DRY_RUN=0
 SKIP_TESTS=0
+LOCAL_PUBLISH=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
     --skip-tests) SKIP_TESTS=1 ;;
+    --local-publish) LOCAL_PUBLISH=1 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -115,28 +127,40 @@ else
 fi
 echo
 
-# ---- tag ---------------------------------------------------------------------
-bold "3/6  Tag $TAG"
+# ---- tag (this is what triggers the release CI) ------------------------------
+bold "3/6  Tag $TAG  →  triggers release.yml (gate, GitHub artifacts, PyPI publish)"
 if confirm "create and push annotated tag $TAG?"; then
   run "git tag -a '$TAG' -m 'Distil $TAG'"
   run "git push origin '$TAG'"
-  ok "$TAG pushed (this triggers the GitHub release tarball + pages deploy)"
+  ok "$TAG pushed — CI is now building + publishing"
 else
-  info "skipped tag — PyPI upload and Homebrew sha256 below need the tag; you can re-run later"
+  info "skipped tag — the PyPI publish and Homebrew sha256 below need the tag; re-run later"
 fi
 echo
 
-# ---- build + publish to PyPI -------------------------------------------------
-bold "4/6  Build + publish to PyPI (distil-llm)"
-if confirm "build sdist+wheel and upload $VERSION to PyPI? (irreversible — a version can't be re-uploaded)"; then
-  command -v twine >/dev/null 2>&1 || die "twine not found (brew install twine), or upload manually with: uv publish"
-  run "rm -rf dist/distil_llm-$VERSION*"
-  run "uv build -o dist"
-  run "twine check dist/distil_llm-$VERSION*"
-  run "twine upload dist/distil_llm-$VERSION*"
-  ok "uploaded distil-llm $VERSION to PyPI"
+# ---- PyPI publish ------------------------------------------------------------
+bold "4/6  PyPI publish (distil-llm $VERSION)"
+if [ "$LOCAL_PUBLISH" -eq 1 ]; then
+  info "--local-publish set: uploading from this machine via uv publish"
+  if confirm "build + uv publish $VERSION now? (irreversible; do NOT also let CI publish the same version)"; then
+    command -v uv >/dev/null 2>&1 || die "uv not found"
+    [ -n "${UV_PUBLISH_TOKEN:-}" ] || die "set UV_PUBLISH_TOKEN=pypi-… (token from pypi.org)"
+    run "rm -rf dist/distil_llm-$VERSION*"
+    run "uv build -o dist"
+    run "uv publish dist/distil_llm-$VERSION*"
+    ok "uploaded distil-llm $VERSION to PyPI"
+  else
+    info "skipped local publish"
+  fi
 else
-  info "skipped PyPI upload"
+  info "Trusted Publishing: the release.yml 'publish-pypi' job uploads via OIDC — no token here."
+  info "It runs only if repo variable PUBLISH_TO_PYPI=true and the PyPI pending publisher exists."
+  if command -v gh >/dev/null 2>&1 && [ "$DRY_RUN" -eq 0 ]; then
+    info "watch it:  gh run watch --repo dshakes/distil \$(gh run list --repo dshakes/distil -w release -L1 --json databaseId -q '.[0].databaseId')"
+    info "verify after:  pip index versions distil-llm   # or check https://pypi.org/p/distil-llm"
+  else
+    info "watch the run at https://github.com/dshakes/distil/actions/workflows/release.yml"
+  fi
 fi
 echo
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Distil release driver — push, tag, publish to PyPI, refresh the Homebrew sha256.
+#
+# Outward-facing and mostly irreversible: every network step asks before it runs,
+# and the script fails fast if anything looks off. Run it from the repo root on a
+# clean `main`:
+#
+#   ./scripts/release.sh
+#
+# Prereqs:
+#   - uv (build) and twine (upload) on PATH        # brew install uv twine
+#   - PyPI credentials: a ~/.pypirc, or TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-…
+#   - push rights to origin
+#
+# Flags:
+#   --dry-run     print every action, change nothing (no push, no tag, no upload)
+#   --skip-tests  skip the pytest gate (NOT recommended)
+set -euo pipefail
+
+DRY_RUN=0
+SKIP_TESTS=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --skip-tests) SKIP_TESTS=1 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+
+# ---- pretty + safety helpers -------------------------------------------------
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+info() { printf '\033[36m›\033[0m %s\n' "$*"; }
+ok()   { printf '\033[32m✓\033[0m %s\n' "$*"; }
+die()  { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+run() {  # echo + execute, or just echo under --dry-run
+  printf '\033[90m$ %s\033[0m\n' "$*"
+  [ "$DRY_RUN" -eq 1 ] && return 0
+  eval "$*"
+}
+
+confirm() {  # confirm "message" ; aborts the step on anything but y/Y
+  [ "$DRY_RUN" -eq 1 ] && { info "[dry-run] would ask: $1"; return 1; }
+  printf '\033[33m? %s [y/N] \033[0m' "$1"
+  read -r reply
+  [[ "$reply" =~ ^[yY]$ ]]
+}
+
+# ---- derive version from the source of truth ---------------------------------
+VERSION="$(grep -E '^version *= *"' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+[ -n "$VERSION" ] || die "could not read version from pyproject.toml"
+TAG="v$VERSION"
+TARBALL_URL="https://github.com/dshakes/distil/archive/refs/tags/${TAG}.tar.gz"
+
+bold "Distil release — ${TAG}$([ "$DRY_RUN" -eq 1 ] && echo '  (dry-run)')"
+echo
+
+# ---- preflight ---------------------------------------------------------------
+bold "1/6  Preflight"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || die "not on main (on '$BRANCH')"
+ok "on main"
+
+[ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first"
+ok "working tree clean"
+
+# version agreement across every surface that ships a version string
+INIT_V="$(grep -E '__version__' distil/__init__.py | sed -E 's/.*"([^"]+)".*/\1/')"
+CITE_V="$(grep -E '^version:' CITATION.cff | sed -E 's/.*: *([0-9][^ ]*).*/\1/')"
+[ "$INIT_V" = "$VERSION" ] || die "distil/__init__.py is $INIT_V, pyproject is $VERSION"
+[ "$CITE_V" = "$VERSION" ] || die "CITATION.cff is $CITE_V, pyproject is $VERSION"
+ok "version $VERSION consistent (pyproject, __init__, CITATION)"
+
+git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists — bump the version or delete the tag"
+ok "tag $TAG is free"
+
+grep -q "## \[$VERSION\]" CHANGELOG.md || die "CHANGELOG.md has no '## [$VERSION]' entry"
+ok "CHANGELOG has a [$VERSION] entry"
+
+if [ "$SKIP_TESTS" -eq 1 ]; then
+  info "skipping tests (--skip-tests)"
+else
+  info "running test suite…"
+  run ".venv/bin/python -m pytest -q" || die "tests failed — not releasing"
+  ok "tests pass"
+fi
+
+# clean-install smoke test: build the wheel, install it into a throwaway venv with
+# no index, and confirm the entrypoint + bundled corpus actually work.
+info "clean-install smoke test…"
+SMOKE="$(mktemp -d)"
+trap 'rm -rf "$SMOKE"' EXIT
+run "uv build --wheel -o '$SMOKE/wheel'"
+if [ "$DRY_RUN" -eq 0 ]; then
+  WHEEL="$(ls "$SMOKE"/wheel/distil_llm-"$VERSION"-py3-none-any.whl)"
+  python3 -m venv "$SMOKE/venv"
+  "$SMOKE/venv/bin/pip" install -q --no-index "$WHEEL"
+  GOT="$("$SMOKE/venv/bin/distil" --version | awk '{print $2}')"
+  [ "$GOT" = "$VERSION" ] || die "clean install reports $GOT, expected $VERSION"
+  "$SMOKE/venv/bin/distil" bench >/dev/null || die "distil bench failed on a clean install"
+  ok "clean install works: distil $VERSION, bench gate runs"
+fi
+echo
+
+# ---- push main ---------------------------------------------------------------
+bold "2/6  Push main"
+if confirm "push 'main' to origin?"; then
+  run "git push origin main"
+  ok "main pushed"
+else
+  info "skipped push"
+fi
+echo
+
+# ---- tag ---------------------------------------------------------------------
+bold "3/6  Tag $TAG"
+if confirm "create and push annotated tag $TAG?"; then
+  run "git tag -a '$TAG' -m 'Distil $TAG'"
+  run "git push origin '$TAG'"
+  ok "$TAG pushed (this triggers the GitHub release tarball + pages deploy)"
+else
+  info "skipped tag — PyPI upload and Homebrew sha256 below need the tag; you can re-run later"
+fi
+echo
+
+# ---- build + publish to PyPI -------------------------------------------------
+bold "4/6  Build + publish to PyPI (distil-llm)"
+if confirm "build sdist+wheel and upload $VERSION to PyPI? (irreversible — a version can't be re-uploaded)"; then
+  command -v twine >/dev/null 2>&1 || die "twine not found (brew install twine), or upload manually with: uv publish"
+  run "rm -rf dist/distil_llm-$VERSION*"
+  run "uv build -o dist"
+  run "twine check dist/distil_llm-$VERSION*"
+  run "twine upload dist/distil_llm-$VERSION*"
+  ok "uploaded distil-llm $VERSION to PyPI"
+else
+  info "skipped PyPI upload"
+fi
+echo
+
+# ---- refresh Homebrew sha256 -------------------------------------------------
+bold "5/6  Refresh Homebrew formula sha256"
+FORMULA="packaging/homebrew/distil.rb"
+if confirm "fetch $TAG tarball and patch the sha256 in $FORMULA?"; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    info "[dry-run] would curl $TARBALL_URL and shasum it"
+  else
+    info "fetching $TARBALL_URL …"
+    SHA="$(curl -fsSL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}')" \
+      || die "could not fetch the tag tarball — is $TAG pushed yet?"
+    [ "${#SHA}" -eq 64 ] || die "unexpected sha256: $SHA"
+    # update sha + url + version in the formula
+    sed -i.bak -E \
+      -e "s|sha256 \"[^\"]*\"|sha256 \"$SHA\"|" \
+      -e "s|/tags/v[0-9][^\"]*\.tar\.gz|/tags/${TAG}.tar.gz|" \
+      -e "s|version \"[0-9][^\"]*\"|version \"$VERSION\"|" \
+      "$FORMULA"
+    rm -f "$FORMULA.bak"
+    ok "patched $FORMULA → sha256 $SHA"
+    if confirm "commit + push the formula bump?"; then
+      run "git add '$FORMULA'"
+      run "git commit -m 'release($VERSION): pin Homebrew sha256 to $TAG tarball'"
+      run "git push origin main"
+      ok "formula bump pushed"
+    fi
+  fi
+else
+  info "skipped Homebrew refresh"
+fi
+echo
+
+# ---- done --------------------------------------------------------------------
+bold "6/6  Done — manual follow-ups"
+cat <<EOF
+  • Homebrew TAP: this repo's $FORMULA is the source copy. Copy it into the actual
+    tap repo so 'brew install dshakes/tap/distil' serves $VERSION:
+        dshakes/homebrew-tap → Formula/distil.rb
+  • GitHub release notes: paste the [$VERSION] section of CHANGELOG.md into
+        https://github.com/dshakes/distil/releases/new?tag=$TAG
+  • Verify the live install:  pipx install distil-llm && distil --version   # → $VERSION
+  • Docs site redeploys from main via the pages workflow — confirm it's green.
+EOF
+ok "release driver finished"


### PR DESCRIPTION
## Distil 1.0.0 — General Availability

Reconciles the version (the package was stuck at 0.25.1 while the CHANGELOG documented 0.28.0 and ~51 commits of work had landed), ships a YC-style README, fixes stale facts, makes install dead-simple, and adds the Trusted-Publishing release path.

### What's in it
- **GA reconciliation** — version `0.25.1 → 1.0.0` across pyproject/`__init__`/CITATION/plugin; PyPI classifier → Production/Stable; new `CHANGELOG [1.0.0]` folding in E11 (5 models/3 vendors), E12 cost-frontier, E13 drift/ensemble, auto-calibration.
- **README** — YC-style hero (problem→insight→proof), honest caveats preserved.
- **Stale facts fixed** — test count `532/633 → 658` (verified, 658 passing); landing-page E11 narrative corrected (dropped the refuted 'must scale with capability' claim); getting-started sample output + model id corrected.
- **Easy install** — one command up front + the `distil-llm`/`distil` naming gotcha surfaced; verified by a clean `--no-index` wheel install → `distil bench` GATE PASS.
- **`distil-setup` plugin skill** — Claude Code can install + route an agent through distil.
- **Release infra** — `scripts/release.sh` (push+tag, CI Trusted Publishing) + `RELEASING.md`.

### Honest scope (unchanged)
1.0/GA = engine + integrations + certificate machinery are production-grade and API-stable, with a never-silently-lossy contract. It is **not** a claim that aggressive compression is safe untuned — E7/E11 caveats stay visible; see `docs/GA_READINESS.md`.

### Verification
- `658 passed` (0 fail), `distil bench` GATE PASS, clean-wheel install smoke-tested.

### After merge
Tag `v1.0.0` (or run `./scripts/release.sh`) → `release.yml` publishes to PyPI via OIDC. One-time: PyPI pending publisher + `PUBLISH_TO_PYPI=true` (see RELEASING.md).