### PR TITLE
docs: lead with the Claude Code use case, not the bench demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Every agent re-sends its whole context every turn — you pay for all of it, eve
 <p align="center"><sub><b>Honest scope:</b> the certificate is a <b>proxy</b> (next-action equivalence on a trajectory corpus), not end-to-end task success — under <em>aggressive lossy</em> compression it doesn't fully transfer (<a href="#-end-to-end-reality-swe-bench-verified-e7">E7</a>), which is why Distil calibrates per deployment and fails safe.</sub></p>
 
 <p align="center">
-  <a href="#-60-second-start">Quickstart</a> ·
+  <a href="#-use-it-now">Use it</a> ·
   <a href="#-works-with-every-sdk">Integrations</a> ·
   <a href="#-install-your-way">Install</a> ·
   <a href="https://dshakes.github.io/distil/getting-started.html"><b>Full Docs →</b></a>
@@ -40,6 +40,33 @@ Every agent re-sends its whole context every turn — you pay for all of it, eve
 </table>
 
 <p align="center"><b>Distil is the only compressor statistically tied with full context</b> — every lossy tool craters. And on the live head-to-head above (graded by <code>claude-opus-4-8</code>), it certifies <b>83.2% savings at a 0% decision-change rate</b>, ~1,000× faster than the nearest tool. <a href="#-long-horizon-reality-the-gate-where-it-belongs-e8">Full breakdown ↓</a></p>
+
+---
+
+## 🚀 Use it now
+
+**Claude Code · Codex · Gemini CLI · any agent.** Route your coding agent through Distil — **no config, no code change.** `distil wrap` launches your agent with its API traffic flowing through compression:
+
+```bash
+pipx install distil-llm
+
+# Claude Code on a metered API key — saves real $$:
+distil wrap --expand -- claude
+
+# Claude Code on a Pro/Max subscription — flat-rate, ToS-safe (trims context, not $):
+distil wrap --lossless-only -- claude
+
+# Codex, Gemini CLI, or any agent — same pattern:
+distil wrap --expand -- codex
+```
+
+Then watch genuine savings from **your** traffic — measured, not estimated:
+
+```bash
+distil leaderboard          # cumulative tokens + $ saved, from the local ledger
+```
+
+> **Will it actually save me money?** Only on **metered / pay-as-you-go** billing (an API key): fewer tokens → fewer dollars. On a **subscription** you're flat-rate, so there's no per-token bill to cut — Distil still trims context and latency. **Honest about coding agents:** on short sessions the win is *modest* (~7% — the agent re-expands most of what it edits, [E7](#-end-to-end-reality-swe-bench-verified-e7)); the real savings land on **long, many-turn sessions** with large context the model never re-reads. Want an in-process hook or an org-wide proxy instead? See [Works with every SDK](#-works-with-every-sdk).
 
 ---
 
@@ -93,7 +120,9 @@ This is the structural advantage: **compress more, lose nothing, and get better 
 
 ---
 
-## ⚡ 60-second start
+## ⚡ Prove the numbers yourself — no API key
+
+Don't take the table above on faith. `distil bench` re-certifies savings *and* decision-equivalence on a bundled 7-domain corpus, offline, in seconds — the same gate that runs in CI:
 
 ```bash
 uvx --from distil-llm distil bench   # certify savings + quality across 7 domains, in seconds

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -64,7 +64,7 @@
   <main class="content">
 
     <h1>Getting <span class="g">Started</span></h1>
-    <p class="lead">Install in one command, verify the corpus gate passes in 60 seconds, then drop compression into your agent with a single <code>wrap(client)</code> call. No API key required for the first two steps.</p>
+    <p class="lead">Install in one command, route your coding agent (Claude Code, Codex, Gemini CLI) through Distil with <code>distil wrap</code> — no code change — and watch genuine savings on your real traffic. Prefer to kick the tyres first? <code>distil bench</code> certifies the numbers offline with no API key.</p>
 
     <hr/>
 
@@ -133,6 +133,25 @@ pip install distil-llm</pre>
     <div class="callout good">
       <strong>Node / TypeScript / other languages?</strong> Run <code>distil proxy</code> (or <code>distil wrap -- &lt;your-agent&gt;</code>) and point your SDK's <code>baseURL</code> at it. No code changes, any language. The CLI needs Python 3.11+; your app does not.
     </div>
+
+    <hr/>
+
+    <!-- Use it on your agent -->
+    <h2>Use it on your agent <span class="g">— the 30-second path</span></h2>
+    <p>This is what most people actually want. <code>distil wrap</code> launches your coding agent with its API traffic routed through compression — <strong>no config, no code change</strong>.</p>
+    <pre class="term"><span class="d"># Claude Code on a metered API key — saves real $$:</span>
+distil wrap --expand -- claude
+<span class="d"># Claude Code on a Pro/Max subscription — flat-rate, ToS-safe (trims context, not $):</span>
+distil wrap --lossless-only -- claude
+<span class="d"># Codex, Gemini CLI, or any agent — same pattern:</span>
+distil wrap --expand -- codex</pre>
+    <p>Then watch genuine, measured savings from <em>your</em> traffic (not estimates):</p>
+    <pre class="term">distil leaderboard          <span class="d"># cumulative tokens + $ saved, from the local ledger</span></pre>
+    <div class="callout">
+      <strong>Will it save me money?</strong> Only on <strong>metered / pay-as-you-go</strong> billing (an API key): fewer tokens → fewer dollars. On a <strong>subscription</strong> you're flat-rate, so there's no per-token bill to cut — Distil still trims context and latency. <strong>Honest about coding agents:</strong> on short sessions the win is modest (~7% — the agent re-expands most of what it edits); the real savings land on <strong>long, many-turn sessions</strong> with large context the model never re-reads. Prefer an in-process hook or an org-wide proxy? See <a href="integrations.html">Integrations</a>.
+    </div>
+
+    <hr/>
 
     <h3>Billing-grade tokenizer (optional)</h3>
     <p>The default tokenizer is an offline heuristic — compression <em>ratios</em> are robust, but absolute dollar figures are approximate. For billing-grade token counts and live-model certification, install the <code>live</code> extra:</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,8 +149,11 @@
     real <a href="research.html#e7">SWE-bench Verified test (E7)</a> shows it does
     <b>not</b> transfer once compression gets aggressive. We publish that. <a href="research.html#e8">E8</a> (500-instance long-horizon, 5 conditions) shows
     relevance-gated reversible compression is <b>the only condition non-inferior to full context</b> (&minus;2.4&nbsp;pp, 95% CI [&minus;5.7, +0.9]; McNemar p=0.19), beats Headroom by +4.2&nbsp;pp (p=0.035), and beats LLMLingua-2 by 34&nbsp;points (36.8% vs 2.4% pass@1) despite removing nearly identical context fractions. We publish that too. <a href="research.html#e10"><b>E10</b></a> closes the loop with a trajectory-level certificate (the first of its kind): with 95% confidence, the gated compressor costs a solvable task on &le;11.4% of exchangeable runs — certified and proven out-of-sample. <a href="research.html#e11"><b>E11</b></a> extends this across <b>5 models / 3 vendors</b> (OpenAI, Anthropic, DeepSeek): the relevance gate shows no statistically significant degradation at gate@12 on any of them, and the safe aggressive point tracks <i>realized compression × the agent's reliance on aged-out context</i> — a workload×model interaction, not raw capability — which is why the operating point must be <b>auto-calibrated per deployment</b>, fail-safe to full context.</p>
+  <p class="sub" style="font-size:13.5px;margin-top:16px">Route Claude Code — or any agent — through it, no code change:<br>
+    <code>pipx install distil-llm &amp;&amp; distil wrap --expand -- claude</code></p>
   <div class="cta">
-    <a class="btn primary" href="#how">See how it works</a>
+    <a class="btn primary" href="getting-started.html">Get started →</a>
+    <a class="btn ghost" href="#how">How it works</a>
     <a class="btn ghost" href="#proof">Read the proof</a>
   </div>
 


### PR DESCRIPTION
The docs led with `distil bench` (proof on a bundled corpus) instead of how people actually use Distil. This makes the use case the first thing a reader sees.

- **README** — new '🚀 Use it now' section right after the proof block (`distil wrap --expand -- claude`, API-key vs subscription split, honest money caveat); bench section reframed to 'Prove the numbers yourself'; nav 'Quickstart' → 'Use it'.
- **getting-started** — reframed lead; new 'Use it on your agent — the 30-second path' section before the bench quickstart.
- **index (landing)** — hero shows the wrap one-liner + a 'Get started →' primary CTA.

Honest scope preserved: money saved only on metered/PAYG; coding savings modest on short sessions, real on long-horizon.