### PR TITLE
feat: distil dissect — per-session deep-dive report (implements #26)

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -302,7 +302,9 @@ def cmd_dissect(args: argparse.Namespace) -> int:
     use_color = (
         (not args.no_color) and sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
     )
+    sid: str | None
     if not args.session:
+        sessions = dz.list_sessions()
         if args.json:
             rows = [
                 {
@@ -315,16 +317,33 @@ def cmd_dissect(args: argparse.Namespace) -> int:
                     "distil_input_tokens": o.distil_tokens,
                     "status": o.status,
                 }
-                for o in dz.list_sessions()
+                for o in sessions
             ]
             print(json.dumps(rows, indent=2))
+            return 0
+        print(dz.render_sessions_text(sessions, color=use_color))
+        # On a terminal, let the user pick right here instead of retyping the id.
+        if not (sessions and sys.stdin.isatty() and sys.stdout.isatty()):
+            return 0
+        try:
+            choice = input(f"\ndissect which session? [1-{len(sessions)}, Enter to quit] ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        if not choice:
+            return 0
+        if choice.isdigit() and 1 <= int(choice) <= len(sessions):
+            sid = sessions[int(choice) - 1].sid
         else:
-            print(dz.render_sessions_text(dz.list_sessions(), color=use_color))
-        return 0
-    sid = dz.resolve_sid(args.session)
-    if sid is None:
-        print(f"no session matches {args.session!r} — run `distil dissect` to list them")
-        return 2
+            sid = dz.resolve_sid(choice)
+        if sid is None:
+            print(f"no session matches {choice!r}")
+            return 2
+    else:
+        sid = dz.resolve_sid(args.session)
+        if sid is None:
+            print(f"no session matches {args.session!r} — run `distil dissect` to list them")
+            return 2
     d = dz.dissect(sid)
     peers = dz.list_sessions()
     if args.json:

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -291,6 +291,52 @@ def cmd_leaderboard(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_dissect(args: argparse.Namespace) -> int:
+    """Everything distil knows about one wrap session — or the picker when no
+    session is given. Works for any wrapped tool (claude/codex/gemini/...)."""
+    import os
+    import sys
+
+    from . import dissect as dz
+
+    use_color = (
+        (not args.no_color) and sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+    )
+    if not args.session:
+        if args.json:
+            rows = [
+                {
+                    "session": o.sid,
+                    "tool": o.tool,
+                    "started_ts": o.started,
+                    "last_ts": o.last_ts,
+                    "requests": o.requests,
+                    "baseline_input_tokens": o.baseline_tokens,
+                    "distil_input_tokens": o.distil_tokens,
+                    "status": o.status,
+                }
+                for o in dz.list_sessions()
+            ]
+            print(json.dumps(rows, indent=2))
+        else:
+            print(dz.render_sessions_text(dz.list_sessions(), color=use_color))
+        return 0
+    sid = dz.resolve_sid(args.session)
+    if sid is None:
+        print(f"no session matches {args.session!r} — run `distil dissect` to list them")
+        return 2
+    d = dz.dissect(sid)
+    if args.json:
+        print(json.dumps(dz.to_json(d), indent=2))
+        return 0
+    if args.html:
+        Path(args.html).write_text(dz.render_html(d), encoding="utf-8")
+        print(f"wrote {args.html}")
+        return 0
+    print(dz.render_text(d, color=use_color))
+    return 0
+
+
 def cmd_prune(args: argparse.Namespace) -> int:
     traj = _load(args.trajectory)
     report = discover(traj)
@@ -1958,6 +2004,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="print a shields.io badge URL + markdown of your measured savings",
     )
     lb.set_defaults(func=cmd_leaderboard)
+
+    di = sub.add_parser(
+        "dissect",
+        help="everything distil knows about one wrap session (savings, folds, quality loops)",
+    )
+    di.add_argument(
+        "session",
+        nargs="?",
+        help="session id, a unique prefix, or `latest` — omit to list sessions to pick from",
+    )
+    di.add_argument("--html", help="render the dissection as a self-contained HTML page")
+    di.add_argument("--json", action="store_true", help="machine-readable output")
+    di.add_argument("--no-color", action="store_true", help="disable ANSI colors")
+    di.set_defaults(func=cmd_dissect)
 
     rs = sub.add_parser(
         "reset",

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -302,6 +302,18 @@ def cmd_dissect(args: argparse.Namespace) -> int:
     use_color = (
         (not args.no_color) and sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
     )
+    if args.serve:
+        server = dz.make_server(args.host, args.port)
+        host, port = server.server_address[:2]
+        print(f"dissect portal: http://{host}:{port}/  (Ctrl-C to stop)")
+        print("sessions index at /, reports at /session/<sid>, JSON at /json/<sid>")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print()
+        finally:
+            server.server_close()
+        return 0
     sid: str | None
     if not args.session:
         sessions = dz.list_sessions()
@@ -2035,6 +2047,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="session id, a unique prefix, or `latest` — omit to list sessions to pick from",
     )
     di.add_argument("--html", help="render the dissection as a self-contained HTML page")
+    di.add_argument(
+        "--serve",
+        action="store_true",
+        help="serve a live localhost portal instead: / lists sessions, /session/<sid> reports",
+    )
+    di.add_argument("--host", default="127.0.0.1", help="bind address (default: localhost only)")
+    di.add_argument("--port", type=int, default=8790, help="portal port (default 8790)")
     di.add_argument("--json", action="store_true", help="machine-readable output")
     di.add_argument("--no-color", action="store_true", help="disable ANSI colors")
     di.set_defaults(func=cmd_dissect)

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -358,14 +358,30 @@ def cmd_dissect(args: argparse.Namespace) -> int:
             return 2
     d = dz.dissect(sid)
     peers = dz.list_sessions()
+    corr = None
+    if args.transcript:
+        from .correlate import correlate
+        from .transcripts import find_transcript
+
+        man = d.manifest or {}
+        tr = find_transcript(
+            str(man.get("tool") or ""),
+            (d.started, d.ended or d.started),
+            cwd=man.get("cwd"),
+            path=None if args.transcript == "auto" else args.transcript,
+        )
+        if tr is None:
+            print("note: no matching agent transcript found — report is uncorrelated\n")
+        else:
+            corr = correlate(d, tr)
     if args.json:
-        print(json.dumps(dz.to_json(d, peers), indent=2))
+        print(json.dumps(dz.to_json(d, peers, corr), indent=2))
         return 0
     if args.html:
-        Path(args.html).write_text(dz.render_html(d, peers), encoding="utf-8")
+        Path(args.html).write_text(dz.render_html(d, peers, corr), encoding="utf-8")
         print(f"wrote {args.html}")
         return 0
-    print(dz.render_text(d, color=use_color, peers=peers))
+    print(dz.render_text(d, color=use_color, peers=peers, corr=corr))
     return 0
 
 
@@ -2047,6 +2063,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="session id, a unique prefix, or `latest` — omit to list sessions to pick from",
     )
     di.add_argument("--html", help="render the dissection as a self-contained HTML page")
+    di.add_argument(
+        "--transcript",
+        nargs="?",
+        const="auto",
+        help="correlate with the agent's own conversation log (opt-in; names tools/prompts). "
+        "`auto` finds it by session window; or pass a transcript path",
+    )
     di.add_argument(
         "--serve",
         action="store_true",

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -303,7 +303,7 @@ def cmd_dissect(args: argparse.Namespace) -> int:
         (not args.no_color) and sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
     )
     if args.serve:
-        server = dz.make_server(args.host, args.port)
+        server = dz.make_server(args.host, args.port, transcript=args.transcript)
         host, port = server.server_address[:2]
         print(f"dissect portal: http://{host}:{port}/  (Ctrl-C to stop)")
         print("sessions index at /, reports at /session/<sid>, JSON at /json/<sid>")

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -326,14 +326,15 @@ def cmd_dissect(args: argparse.Namespace) -> int:
         print(f"no session matches {args.session!r} — run `distil dissect` to list them")
         return 2
     d = dz.dissect(sid)
+    peers = dz.list_sessions()
     if args.json:
-        print(json.dumps(dz.to_json(d), indent=2))
+        print(json.dumps(dz.to_json(d, peers), indent=2))
         return 0
     if args.html:
-        Path(args.html).write_text(dz.render_html(d), encoding="utf-8")
+        Path(args.html).write_text(dz.render_html(d, peers), encoding="utf-8")
         print(f"wrote {args.html}")
         return 0
-    print(dz.render_text(d, color=use_color))
+    print(dz.render_text(d, color=use_color, peers=peers))
     return 0
 
 

--- a/distil/correlate.py
+++ b/distil/correlate.py
@@ -1,0 +1,147 @@
+"""Correlate a wrap session with the agent's own conversation transcript.
+
+Everything here is adapter-independent: it consumes the normalized
+:class:`~distil.transcripts.base.Transcript` model, so a new agent gets all
+of it by writing one adapter. The join is content-derived, not guessed:
+digested blocks are matched into transcript tool results via the restore
+store's original bytes.
+
+Opt-in and read-only: transcripts are the agent's files, read at render time;
+nothing is copied into distil's state. This is the one dissect feature that
+crosses the content-free line — reports name tools, files and prompts — which
+is why it never runs unless asked for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .transcripts import Transcript
+
+if TYPE_CHECKING:  # pragma: no cover — import cycle guard (dissect imports us)
+    from .dissect import Dissection
+
+_MIN_MATCH = 40  # chars; below this substring matches are coincidence
+
+
+@dataclass
+class FoldSource:
+    """A digested block, named by where it came from in the conversation."""
+
+    handle: str
+    sig: str
+    tokens: int
+    folds: int
+    tool: str  # producing tool ("" when unattributed)
+    turn: int  # human turn it happened under (0 = before the first)
+    turn_text: str
+    refetches: int  # distinct transcript results carrying this content
+
+
+@dataclass
+class TurnCost:
+    index: int
+    text: str
+    requests: int
+    baseline_tokens: int
+    saved_tokens: int
+
+
+@dataclass
+class Correlation:
+    agent: str
+    label: str
+    path: str
+    fold_sources: list[FoldSource] = field(default_factory=list)
+    unnamed_blocks: int = 0
+    tools_defined: int = 0
+    tools_invoked: int = 0
+    unused_tools: list[tuple[str, int]] = field(default_factory=list)  # (name, tok/req)
+    refetched: list[FoldSource] = field(default_factory=list)
+    turns: list[TurnCost] = field(default_factory=list)  # costliest first
+
+    @property
+    def unused_tokens_per_request(self) -> int:
+        return sum(t for _n, t in self.unused_tools)
+
+
+def _contains(haystack: str, needle: str) -> bool:
+    if len(needle) < _MIN_MATCH:
+        return haystack == needle
+    return needle in haystack or haystack in needle
+
+
+def correlate(d: Dissection, tr: Transcript) -> Correlation:
+    """Join one Dissection with one Transcript. Best-effort throughout:
+    expired restore blobs and unmatched blocks degrade to counts, never errors."""
+    from .dissect import _state_dir
+
+    corr = Correlation(agent=tr.agent, label=tr.label, path=str(tr.path))
+    turn_text = {t.index: t.text for t in tr.turns}
+
+    # --- fold -> source, by content (restore blob matched into tool results)
+    restore = _state_dir() / "restore"
+    for handle, info in d.blocks.items():
+        try:
+            original = (restore / handle).read_text(encoding="utf-8").strip()
+        except OSError:
+            corr.unnamed_blocks += 1
+            continue
+        matches = [r for r in tr.tool_results if _contains(r.text, original)]
+        if not matches:
+            corr.unnamed_blocks += 1
+            continue
+        first = matches[0]
+        src = FoldSource(
+            handle=handle,
+            sig=str(info.get("sig") or "?"),
+            tokens=int(info.get("tokens") or 0),
+            folds=int(info.get("folds") or 0),
+            tool=first.tool,
+            turn=first.turn,
+            turn_text=turn_text.get(first.turn, ""),
+            refetches=len(matches),
+        )
+        corr.fold_sources.append(src)
+        if src.refetches >= 2:
+            corr.refetched.append(src)
+    corr.fold_sources.sort(key=lambda s: -s.tokens)
+    corr.refetched.sort(key=lambda s: -s.tokens * s.refetches)
+
+    # --- unused tools: defined on requests (paid for) but never invoked
+    defined: dict[str, int] = {}
+    for r in d.requests:
+        for t in r.get("tools") or []:
+            name = str(t.get("name") or "?")
+            defined[name] = max(defined.get(name, 0), int(t.get("tokens") or 0))
+    invoked = {c.name for c in tr.tool_calls}
+    corr.tools_defined = len(defined)
+    corr.tools_invoked = len(defined.keys() & invoked)
+    corr.unused_tools = sorted(
+        ((n, tok) for n, tok in defined.items() if n not in invoked),
+        key=lambda t: -t[1],
+    )
+
+    # --- cost per human turn: each request lands on the last turn before it
+    if tr.turns and d.requests:
+        buckets: dict[int, TurnCost] = {}
+        for r in d.requests:
+            ts = float(r.get("ts") or 0.0)
+            turn = 0
+            for t in tr.turns:
+                if t.ts <= ts:
+                    turn = t.index
+                else:
+                    break
+            b = buckets.setdefault(
+                turn, TurnCost(index=turn, text=turn_text.get(turn, ""), requests=0,
+                               baseline_tokens=0, saved_tokens=0)
+            )
+            b.requests += 1
+            b.baseline_tokens += int(r.get("compressible_tokens") or 0) + int(
+                r.get("overhead_tokens") or 0
+            )
+            b.saved_tokens += int(r.get("tokens_saved") or 0)
+        corr.turns = sorted(buckets.values(), key=lambda b: -b.baseline_tokens)
+    return corr

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -237,6 +237,176 @@ class Dissection:
     def expand_resolved(self) -> int:
         return sum(1 for r in self.requests if r.get("expanded"))
 
+    # ---- insight metrics (all derived; None/0 when the inputs are absent) ----
+    @property
+    def tokens_saved_total(self) -> int:
+        """Heuristic tokens saved across requests (digest folds + cache-delta)."""
+        return sum(int(r.get("tokens_saved") or 0) for r in self.requests)
+
+    @property
+    def digest_saved(self) -> int:
+        """Mechanism decomposition: the non-delta share of tokens_saved."""
+        return max(0, self.tokens_saved_total - self.delta_tokens_saved)
+
+    @property
+    def overhead_tokens_total(self) -> int:
+        return sum(int(r.get("overhead_tokens") or 0) for r in self.requests)
+
+    @property
+    def overhead_share(self) -> float:
+        """Fixed tax: system prompt + tool definitions as a share of everything sent."""
+        comp = sum(int(r.get("compressible_tokens") or 0) for r in self.requests)
+        total = self.overhead_tokens_total + comp
+        return 100.0 * self.overhead_tokens_total / total if total else 0.0
+
+    @property
+    def churn_tokens(self) -> int:
+        """Tokens re-folded after first sight — resent content the client keeps sending."""
+        return sum(
+            int(i.get("tokens") or 0) * (int(i.get("folds") or 1) - 1)
+            for i in self.blocks.values()
+        )
+
+    @property
+    def churned_blocks(self) -> int:
+        return sum(1 for i in self.blocks.values() if int(i.get("folds") or 0) >= 3)
+
+    @property
+    def usage_input_total(self) -> int:
+        return sum(int(r.get("usage_input_tokens") or 0) for r in self.requests)
+
+    @property
+    def usage_output_total(self) -> int:
+        return sum(int(r.get("usage_output_tokens") or 0) for r in self.requests)
+
+    @property
+    def usage_requests(self) -> int:
+        return sum(1 for r in self.requests if r.get("usage_input_tokens") is not None)
+
+    def calibration(self) -> tuple[int, int] | None:
+        """(heuristic_estimate, billed) input tokens over requests that carry usage.
+
+        Estimate = overhead + compressible-after-savings; billed = the API's own
+        usage.input_tokens. This is what turns "we think we saved X" into a
+        measured claim (and shows how honest the heuristic tokenizer is).
+        """
+        est = billed = 0
+        for r in self.requests:
+            u = r.get("usage_input_tokens")
+            if u is None:
+                continue
+            est += int(r.get("overhead_tokens") or 0) + max(
+                0, int(r.get("compressible_tokens") or 0) - int(r.get("tokens_saved") or 0)
+            )
+            billed += int(u)
+        return (est, billed) if billed else None
+
+    @property
+    def headroom_multiplier(self) -> float:
+        """How much further the same context budget goes (baseline/sent)."""
+        return self.baseline_tokens / self.distil_tokens if self.distil_tokens else 0.0
+
+    @property
+    def forced_buffered(self) -> int:
+        """Client asked to stream but the expand loop forced full buffering (TTFT tax)."""
+        return sum(
+            1 for r in self.requests if r.get("client_stream") and not r.get("stream")
+        )
+
+    def latency_by_path(self) -> list[tuple[str, int, int]]:
+        """[(path, requests, avg_ms)] — streamed / buffered (forced) / buffered."""
+        groups: dict[str, list[int]] = {}
+        for r in self.requests:
+            if r.get("duration_ms") is None:
+                continue
+            if r.get("stream"):
+                key = "streamed"
+            elif r.get("client_stream"):
+                key = "buffered (forced by expand)"
+            else:
+                key = "buffered"
+            groups.setdefault(key, []).append(int(r["duration_ms"]))
+        return [(k, len(v), sum(v) // len(v)) for k, v in sorted(groups.items())]
+
+    def expansion_regret(self) -> list[tuple[str, int, int]]:
+        """[(sig, expanded_blocks, folded_blocks)] — kinds the agent keeps pulling back."""
+        expanded: set[str] = set()
+        for r in self.requests:
+            expanded.update(h for h in r.get("expanded_handles") or [] if isinstance(h, str))
+        by_sig: dict[str, list[int]] = {}
+        for h, info in self.blocks.items():
+            m = by_sig.setdefault(str(info.get("sig") or "?"), [0, 0])
+            m[1] += 1
+            if h in expanded:
+                m[0] += 1
+        return sorted(
+            ((s, v[0], v[1]) for s, v in by_sig.items() if v[0]),
+            key=lambda t: -t[1],
+        )
+
+    def anomalies(self, peers: list[SessionOverview] | None = None) -> list[str]:
+        """Things worth your attention — each one is a misconfiguration, a silent
+        failure, or upstream weather that plain totals would hide."""
+        out: list[str] = []
+        flags = (self.manifest or {}).get("flags") or {}
+        n = len(self.requests)
+        if self.marker == "0" and not self.ledger_rows:
+            out.append(
+                "wrapped but no traffic went through distil — the agent may be "
+                "bypassing the proxy (check ANTHROPIC_BASE_URL overrides)"
+            )
+        rate = float(flags.get("shadow_rate") or 0.0)
+        if rate > 0 and n >= 10 and self.shadow_sampled == 0:
+            out.append(
+                f"shadow_rate={rate} but 0 of {n} requests were sampled "
+                f"(expected ~{rate * n:.0f}) — shadow may be silently failing"
+            )
+        if self.shadow_sampled > 0 and self.shadow_window_rows == 0:
+            out.append(
+                f"{self.shadow_sampled} requests were shadow-sampled but no verdicts "
+                "were recorded — replays may be failing upstream"
+            )
+        if flags.get("expand") and self.blocks and n >= 10 and self.expand_resolved == 0:
+            if self.forced_buffered == 0 and any(r.get("stream") for r in self.requests):
+                out.append(
+                    "expand is on and blocks were folded, but every request took the "
+                    "streaming pass-through — distil_expand calls could never be "
+                    "intercepted (an escaped call surfaces to the agent as "
+                    "'no such tool')"
+                )
+        if n >= 5 and self.unbooked_requests / n > 0.2:
+            out.append(
+                f"{self.unbooked_requests}/{n} requests were not booked (non-2xx or "
+                "SDK-retried) — upstream errors or rate limiting during this session"
+            )
+        if flags.get("lossless_only") and self.billing == "metered":
+            out.append(
+                "lossless-only mode on metered billing — the digest tier is off; "
+                "savings are limited to delta/dedup"
+            )
+        if peers and self.baseline_tokens > 10_000:
+            others = sorted(
+                100.0 * (p.baseline_tokens - p.distil_tokens) / p.baseline_tokens
+                for p in peers
+                if p.sid != self.sid and p.baseline_tokens > 10_000
+            )
+            if len(others) >= 3:
+                median = others[len(others) // 2]
+                if self.pct_saved < 0.5 * median:
+                    out.append(
+                        f"savings ({self.pct_saved:.1f}%) are well below your typical "
+                        f"session ({median:.1f}% median) — check the wrap flags"
+                    )
+        cal = self.calibration()
+        if cal is not None:
+            est, billed = cal
+            if est and (est / billed > 1.5 or est / billed < 0.67):
+                out.append(
+                    f"heuristic token estimate is off by >50% vs billed usage "
+                    f"({est:,} est vs {billed:,} billed) — treat % figures as rough"
+                )
+        return out
+
     def blocks_by_kind(self) -> list[tuple[str, int, int]]:
         """[(signature, unique_blocks, tokens)] biggest-token first."""
         agg: dict[str, list[int]] = {}
@@ -372,7 +542,9 @@ def _flags_line(man: dict[str, Any]) -> str:
     return ", ".join(on) or "defaults"
 
 
-def render_text(d: Dissection, *, color: bool = True) -> str:
+def render_text(
+    d: Dissection, *, color: bool = True, peers: list[SessionOverview] | None = None
+) -> str:
     """Terminal report. Sections degrade gracefully when a source is missing."""
 
     def c(code: str, s: str) -> str:
@@ -401,6 +573,13 @@ def render_text(d: Dissection, *, color: bool = True) -> str:
     elif d.marker == "1":
         out.append(f"  status   live (heartbeat: {d.heartbeat or '—'})")
 
+    warnings = d.anomalies(peers)
+    if warnings:
+        out.append("")
+        out.append(c("33;1", "worth your attention"))
+        for w in warnings:
+            out.append(c("33", f"  ⚠ {w}"))
+
     # Savings (ledger)
     out.append("")
     out.append(c("1", "savings (input tokens, booked 2xx only)"))
@@ -427,11 +606,50 @@ def render_text(d: Dissection, *, color: bool = True) -> str:
             f"  {n} proxied requests: {n - d.unbooked_requests} booked, {d.unbooked_requests} not booked "
             f"(non-2xx/retry), {d.verbatim_requests} verbatim (nothing worth compressing)"
         )
-        out.append(f"  cache-delta: {_human(d.delta_tokens_saved)} tokens referenced instead of resent")
+        saved = d.tokens_saved_total
+        if saved:
+            dig_pct = 100.0 * d.digest_saved / saved
+            out.append(
+                f"  savings by mechanism: digest folds {_human(d.digest_saved)} ({dig_pct:.0f}%), "
+                f"cache-delta {_human(d.delta_tokens_saved)} ({100 - dig_pct:.0f}%)"
+            )
         out.append(
-            f"  not optimized by design: ~{_human(d.overhead_tokens_avg)} tokens/request of system prompt "
-            "+ tool definitions (sent verbatim every request), plus recent turns kept for fidelity"
+            f"  fixed overhead (not optimizable): system prompt + tool definitions = "
+            f"{_human(d.overhead_tokens_total)} tokens, {d.overhead_share:.0f}% of everything sent "
+            f"(~{_human(d.overhead_tokens_avg)}/request) — trimming unused tools beats compression here"
         )
+        if d.churn_tokens:
+            out.append(
+                f"  re-fold churn: {_human(d.churn_tokens)} tokens re-digested after first sight "
+                f"({d.churned_blocks} blocks folded 3+ times — cache-delta/codec candidates)"
+            )
+        cal = d.calibration()
+        if cal is not None:
+            est, billed = cal
+            out.append(
+                f"  billed usage (from API responses): {_human(d.usage_input_total)} in / "
+                f"{_human(d.usage_output_total)} out over {d.usage_requests} requests; "
+                f"heuristic estimate {_human(est)} vs billed {_human(billed)} "
+                f"(x{est / billed:.2f})" if billed else ""
+            )
+        else:
+            out.append("  billed usage: not captured (older records or non-usage responses)")
+        if d.billing == "subscription" and d.headroom_multiplier > 1:
+            out.append(
+                f"  flat-rate headroom: the same context budget went ~{d.headroom_multiplier:.1f}x "
+                "further than unwrapped"
+            )
+        lat = d.latency_by_path()
+        if lat:
+            out.append(
+                "  latency: "
+                + ", ".join(f"{k} {n} req @ {ms / 1000:.1f}s avg" for k, n, ms in lat)
+            )
+            if d.forced_buffered:
+                out.append(
+                    f"  note: {d.forced_buffered} streamed requests were fully buffered so the "
+                    "expand loop could inspect them — that is the --expand time-to-first-token tax"
+                )
         if d.blocks:
             out.append("")
             out.append(c("1", "digested blocks (content-free: kind:size, tokens)"))
@@ -449,6 +667,11 @@ def render_text(d: Dissection, *, color: bool = True) -> str:
     out.append(c("1", "quality loops"))
     if d.detail_available:
         out.append(f"  expand: {d.expand_resolved} requests had distil_expand calls resolved in-proxy")
+        for sig, exp, total in d.expansion_regret():
+            out.append(
+                f"    regret: {sig} blocks pulled back {exp}/{total} — folding this kind "
+                "costs a round-trip more than it saves"
+            )
         out.append(f"  shadow: {d.shadow_sampled} requests sampled for decision-equivalence")
     if d.shadow_window_rows:
         out.append(
@@ -466,9 +689,38 @@ def render_text(d: Dissection, *, color: bool = True) -> str:
     return "\n".join(out)
 
 
-def to_json(d: Dissection) -> dict[str, Any]:
+def to_json(d: Dissection, peers: list[SessionOverview] | None = None) -> dict[str, Any]:
     """Machine-readable dissection (same numbers the text/html reports show)."""
+    cal = d.calibration()
     return {
+        "insights": {
+            "mechanism": {
+                "digest_tokens_saved": d.digest_saved,
+                "delta_tokens_saved": d.delta_tokens_saved,
+            },
+            "overhead": {
+                "tokens_total": d.overhead_tokens_total,
+                "share_pct": round(d.overhead_share, 1),
+            },
+            "churn": {"tokens": d.churn_tokens, "blocks": d.churned_blocks},
+            "usage": {
+                "input_tokens": d.usage_input_total,
+                "output_tokens": d.usage_output_total,
+                "requests_with_usage": d.usage_requests,
+                "calibration": (
+                    {"estimated": cal[0], "billed": cal[1]} if cal is not None else None
+                ),
+            },
+            "headroom_multiplier": round(d.headroom_multiplier, 2),
+            "latency_by_path": [
+                {"path": k, "requests": n, "avg_ms": ms} for k, n, ms in d.latency_by_path()
+            ],
+            "forced_buffered_requests": d.forced_buffered,
+            "expansion_regret": [
+                {"sig": s, "expanded": e, "blocks": t} for s, e, t in d.expansion_regret()
+            ],
+            "anomalies": d.anomalies(peers),
+        },
         "session": d.sid,
         "manifest": d.manifest,
         "window": {"started_ts": d.started, "ended_ts": d.ended},
@@ -512,7 +764,7 @@ def to_json(d: Dissection) -> dict[str, Any]:
     }
 
 
-def render_html(d: Dissection) -> str:
+def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> str:
     """Self-contained dark page in the ledger `render_html` style."""
     man = d.manifest or {}
     subscription = d.billing == "subscription"
@@ -534,13 +786,51 @@ def render_html(d: Dissection) -> str:
         f"<td class='r'>×{f}</td><td>{'recoverable' if r else '<span class=muted>expired</span>'}</td></tr>"
         for h, s, t, f, r in d.top_blocks()
     )
+    warn_html = "".join(f"<li>{e(w)}</li>" for w in d.anomalies(peers))
+    warn_card = (
+        f"<h2>Worth your attention</h2><ul class='warn'>{warn_html}</ul>" if warn_html else ""
+    )
+    cal = d.calibration()
+    cal_line = (
+        f"Billed usage: <b>{_human(d.usage_input_total)}</b> in / "
+        f"<b>{_human(d.usage_output_total)}</b> out over {d.usage_requests} requests; heuristic "
+        f"estimate x{cal[0] / cal[1]:.2f} of billed."
+        if cal is not None and cal[1]
+        else "Billed usage: not captured for this session."
+    )
+    saved = d.tokens_saved_total
+    mech_line = (
+        f"Mechanism: digest folds <b>{_human(d.digest_saved)}</b> "
+        f"({100.0 * d.digest_saved / saved:.0f}%), cache-delta "
+        f"<b>{_human(d.delta_tokens_saved)}</b>."
+        if saved
+        else ""
+    )
+    lat_line = " · ".join(f"{k}: {n} req @ {ms / 1000:.1f}s" for k, n, ms in d.latency_by_path())
+    headroom_line = (
+        f"Flat-rate headroom: context budget stretched ~<b>{d.headroom_multiplier:.1f}x</b>."
+        if d.billing == "subscription" and d.headroom_multiplier > 1
+        else ""
+    )
+    regret_line = (
+        "Expansion regret: "
+        + "; ".join(f"{e(s)} pulled back {x}/{t}" for s, x, t in d.expansion_regret())
+        + "."
+        if d.expansion_regret()
+        else ""
+    )
     detail_card = (
         f"""<h2>Request detail</h2>
 <p>{len(d.requests)} proxied requests — {d.unbooked_requests} not booked (non-2xx/retry),
 {d.verbatim_requests} verbatim (nothing worth compressing).
-Cache-delta referenced <b>{_human(d.delta_tokens_saved)}</b> tokens instead of resending them.
-Not optimized by design: ~{_human(d.overhead_tokens_avg)} tokens/request of system prompt + tool
-definitions, plus recent turns kept verbatim for fidelity.</p>
+{mech_line}
+Fixed overhead: system prompt + tool definitions = <b>{_human(d.overhead_tokens_total)}</b>
+tokens ({d.overhead_share:.0f}% of everything sent).
+Re-fold churn: <b>{_human(d.churn_tokens)}</b> tokens across {d.churned_blocks} blocks folded
+3+ times. {cal_line} {headroom_line}</p>
+<p class="muted">Latency — {lat_line or "not recorded"}.
+{f"{d.forced_buffered} streamed requests buffered for the expand loop (TTFT tax)." if d.forced_buffered else ""}
+{regret_line}</p>
 <h2>Digested blocks <span class="muted">(content-free: kind:size)</span></h2>
 <table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
 <h2>Largest folds</h2>
@@ -575,6 +865,7 @@ h2{{font-size:17px;font-weight:700;margin:26px 0 10px}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
 th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+ul.warn{{margin:0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:4px 0}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
 code{{color:#8b7bff}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
@@ -588,6 +879,7 @@ code{{color:#8b7bff}}
 <div class="card"><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div></div>
 <div class="card"><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div></div>
 </div>
+{warn_card}
 <h2>Per model</h2>
 <table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
 {detail_card}

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1,0 +1,599 @@
+"""Post-hoc dissection of one wrap session — everything distil knows about it.
+
+``distil dissect`` answers "what exactly happened to my session?": token and
+dollar accounting per model, what was digested (and is still recoverable), what
+was *not* optimized and why, plus cache-delta, shadow and expand activity.
+
+Data sources (all local; all content-free except restore-blob *existence*):
+
+- ``savings.jsonl`` rows tagged with the session id — token/dollar accounting.
+- ``sessions/<sid>.json`` — wrap manifest (tool, argv, flags, billing).
+- ``sessions/<sid>.requests.jsonl`` — per-request detail (token breakdown,
+  per-block digest signatures, shadow/expand flags).
+- ``sessions/<sid>`` / ``.hb`` / ``.exit`` — liveness breadcrumbs.
+- ``restore/<handle>`` existence — is a digested block still recoverable?
+- ``shadow.jsonl`` rows inside the session's time window (rows are not
+  session-tagged; the join is by time and is labelled as such).
+
+Manifest and request detail exist only for sessions wrapped by this version or
+newer; older sessions degrade to the ledger-only view with a note.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .ledger import (
+    default_path,
+    session_manifest_path,
+    session_marker_path,
+    session_requests_path,
+)
+
+
+def _state_dir() -> Path:
+    return default_path().parent
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Tolerant JSONL reader: missing file -> [], corrupt lines skipped."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    out: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict):
+            out.append(rec)
+    return out
+
+
+@dataclass
+class SessionOverview:
+    """One row of the no-argument session picker."""
+
+    sid: str
+    tool: str = ""
+    started: float = 0.0
+    last_ts: float = 0.0
+    requests: int = 0
+    baseline_tokens: int = 0
+    distil_tokens: int = 0
+    status: str = ""  # "live" | "exited" | ""
+
+
+def list_sessions() -> list[SessionOverview]:
+    """Every session distil has heard of: ledger rows ∪ session manifests.
+
+    Newest-last-activity first, so the session you just ran is on top.
+    """
+    by_sid: dict[str, SessionOverview] = {}
+    for rec in _read_jsonl(default_path()):
+        sid = rec.get("session")
+        if not sid or not isinstance(sid, str):
+            continue
+        ov = by_sid.setdefault(sid, SessionOverview(sid=sid))
+        ts = float(rec.get("ts") or 0.0)
+        ov.started = min(ov.started or ts, ts)
+        ov.last_ts = max(ov.last_ts, ts)
+        ov.requests += int(rec.get("turns") or 0)
+        ov.baseline_tokens += int(rec.get("baseline_input_tokens") or 0)
+        ov.distil_tokens += int(rec.get("distil_input_tokens") or 0)
+    sess_dir = _state_dir() / "sessions"
+    try:
+        manifests = sorted(sess_dir.glob("s*.json"))
+    except OSError:
+        manifests = []
+    for mp in manifests:
+        try:
+            man = json.loads(mp.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        sid = man.get("sid") or mp.stem
+        ov = by_sid.setdefault(sid, SessionOverview(sid=sid))
+        ov.tool = str(man.get("tool") or "")
+        started = float(man.get("started_ts") or 0.0)
+        if started:
+            ov.started = min(ov.started or started, started)
+            ov.last_ts = max(ov.last_ts, started)
+    for ov in by_sid.values():
+        marker = session_marker_path(ov.sid)
+        if marker is not None:
+            if marker.with_suffix(".exit").exists():
+                ov.status = "exited"
+            elif marker.exists():
+                ov.status = "live"
+    return sorted(by_sid.values(), key=lambda o: o.last_ts, reverse=True)
+
+
+def resolve_sid(query: str) -> str | None:
+    """Resolve ``latest`` or a unique session-id prefix to a full id."""
+    sessions = list_sessions()
+    if not sessions:
+        return None
+    if query == "latest":
+        return sessions[0].sid
+    hits = [o.sid for o in sessions if o.sid == query]
+    if hits:
+        return hits[0]
+    hits = [o.sid for o in sessions if o.sid.startswith(query)]
+    return hits[0] if len(hits) == 1 else None
+
+
+@dataclass
+class Dissection:
+    """Everything distil knows about one wrap session, joined and totalled."""
+
+    sid: str
+    manifest: dict[str, Any] | None
+    ledger_rows: list[dict[str, Any]]
+    requests: list[dict[str, Any]]
+    marker: str | None  # "0" (wrapped, no traffic yet), "1" (traffic seen), None
+    heartbeat: str | None
+    exit_note: str | None
+    shadow_window_rows: int = 0
+    shadow_window_agree: int = 0
+    # Derived digest inventory: handle -> {"sig", "tokens", "folds", "recoverable"}
+    blocks: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    # ---- ledger-derived totals (available even for pre-manifest sessions) ----
+    @property
+    def baseline_tokens(self) -> int:
+        return sum(int(r.get("baseline_input_tokens") or 0) for r in self.ledger_rows)
+
+    @property
+    def distil_tokens(self) -> int:
+        return sum(int(r.get("distil_input_tokens") or 0) for r in self.ledger_rows)
+
+    @property
+    def dollars_saved(self) -> float:
+        return sum(
+            float(r.get("baseline_dollars") or 0.0) - float(r.get("distil_dollars") or 0.0)
+            for r in self.ledger_rows
+        )
+
+    @property
+    def pct_saved(self) -> float:
+        b = self.baseline_tokens
+        return 100.0 * (b - self.distil_tokens) / b if b else 0.0
+
+    @property
+    def started(self) -> float:
+        cands = [float(r.get("ts") or 0.0) for r in self.ledger_rows]
+        cands += [float(r.get("ts") or 0.0) for r in self.requests]
+        if self.manifest:
+            cands.append(float(self.manifest.get("started_ts") or 0.0))
+        cands = [c for c in cands if c]
+        return min(cands) if cands else 0.0
+
+    @property
+    def ended(self) -> float:
+        cands = [float(r.get("ts") or 0.0) for r in self.ledger_rows]
+        cands += [float(r.get("ts") or 0.0) for r in self.requests]
+        return max(cands) if cands else 0.0
+
+    @property
+    def billing(self) -> str:
+        """Manifest billing mode, falling back to this machine's current mode
+        (labelled detection, not a session fact) for pre-manifest sessions."""
+        if self.manifest and self.manifest.get("billing"):
+            return str(self.manifest["billing"])
+        try:
+            from .doctor import subscription_mode
+
+            return "subscription" if subscription_mode() else "metered"
+        except Exception:  # noqa: BLE001 — billing detection is cosmetic
+            return "unknown"
+
+    def per_model(self) -> list[tuple[str, int, int, int]]:
+        """[(model, booked_requests, baseline_tokens, distil_tokens)] biggest first."""
+        agg: dict[str, list[int]] = {}
+        for r in self.ledger_rows:
+            m = agg.setdefault(str(r.get("model") or "unknown"), [0, 0, 0])
+            m[0] += int(r.get("turns") or 0)
+            m[1] += int(r.get("baseline_input_tokens") or 0)
+            m[2] += int(r.get("distil_input_tokens") or 0)
+        return sorted(((k, v[0], v[1], v[2]) for k, v in agg.items()), key=lambda t: -t[2])
+
+    # ---- request-detail-derived (needs sessions/<sid>.requests.jsonl) ----
+    @property
+    def detail_available(self) -> bool:
+        return bool(self.requests)
+
+    @property
+    def delta_tokens_saved(self) -> int:
+        return sum(int(r.get("delta_tokens_saved") or 0) for r in self.requests)
+
+    @property
+    def overhead_tokens_avg(self) -> int:
+        vals = [int(r.get("overhead_tokens") or 0) for r in self.requests]
+        return sum(vals) // len(vals) if vals else 0
+
+    @property
+    def verbatim_requests(self) -> int:
+        return sum(1 for r in self.requests if r.get("mode") in (None, "", "verbatim"))
+
+    @property
+    def unbooked_requests(self) -> int:
+        return sum(1 for r in self.requests if not r.get("booked"))
+
+    @property
+    def shadow_sampled(self) -> int:
+        return sum(1 for r in self.requests if r.get("shadow_sampled"))
+
+    @property
+    def expand_resolved(self) -> int:
+        return sum(1 for r in self.requests if r.get("expanded"))
+
+    def blocks_by_kind(self) -> list[tuple[str, int, int]]:
+        """[(signature, unique_blocks, tokens)] biggest-token first."""
+        agg: dict[str, list[int]] = {}
+        for info in self.blocks.values():
+            m = agg.setdefault(str(info.get("sig") or "?"), [0, 0])
+            m[0] += 1
+            m[1] += int(info.get("tokens") or 0)
+        return sorted(((k, v[0], v[1]) for k, v in agg.items()), key=lambda t: -t[2])
+
+    def top_blocks(self, n: int = 10) -> list[tuple[str, str, int, int, bool]]:
+        """[(handle, sig, tokens, folds, recoverable)] biggest first."""
+        rows = [
+            (
+                h,
+                str(i.get("sig") or "?"),
+                int(i.get("tokens") or 0),
+                int(i.get("folds") or 0),
+                bool(i.get("recoverable")),
+            )
+            for h, i in self.blocks.items()
+        ]
+        return sorted(rows, key=lambda t: -t[2])[:n]
+
+
+def dissect(sid: str) -> Dissection:
+    """Assemble a full Dissection for *sid* from every local source."""
+    ledger_rows = [r for r in _read_jsonl(default_path()) if r.get("session") == sid]
+    manifest: dict[str, Any] | None = None
+    mp = session_manifest_path(sid)
+    if mp is not None:
+        try:
+            loaded = json.loads(mp.read_text(encoding="utf-8"))
+            manifest = loaded if isinstance(loaded, dict) else None
+        except (OSError, json.JSONDecodeError):
+            manifest = None
+    rp = session_requests_path(sid)
+    requests = _read_jsonl(rp) if rp is not None else []
+
+    marker = heartbeat = exit_note = None
+    marker_p = session_marker_path(sid)
+    if marker_p is not None:
+        for attr, path in (
+            ("marker", marker_p),
+            ("heartbeat", marker_p.with_suffix(".hb")),
+            ("exit_note", marker_p.with_suffix(".exit")),
+        ):
+            try:
+                val = path.read_text(encoding="utf-8").strip()
+            except OSError:
+                val = None
+            if attr == "marker":
+                marker = val
+            elif attr == "heartbeat":
+                heartbeat = val
+            else:
+                exit_note = val
+
+    d = Dissection(
+        sid=sid,
+        manifest=manifest,
+        ledger_rows=ledger_rows,
+        requests=requests,
+        marker=marker,
+        heartbeat=heartbeat,
+        exit_note=exit_note,
+    )
+
+    restore_dir = _state_dir() / "restore"
+    for rec in requests:
+        for blk in rec.get("blocks") or []:
+            h = blk.get("h")
+            if not isinstance(h, str):
+                continue
+            info = d.blocks.setdefault(
+                h, {"sig": blk.get("sig"), "tokens": int(blk.get("tokens") or 0), "folds": 0}
+            )
+            info["folds"] += 1
+    for h, info in d.blocks.items():
+        info["recoverable"] = (restore_dir / h).exists()
+
+    if d.started and d.ended:
+        for row in _read_jsonl(_state_dir() / "shadow.jsonl"):
+            ts = float(row.get("ts") or 0.0)
+            if d.started - 1 <= ts <= d.ended + 300:
+                d.shadow_window_rows += 1
+                d.shadow_window_agree += 1 if row.get("equivalent") else 0
+    return d
+
+
+# --------------------------------------------------------------------------- render
+def _human(n: float) -> str:
+    for unit, div in (("B", 1e9), ("M", 1e6), ("k", 1e3)):
+        if abs(n) >= div:
+            return f"{n / div:.2f}{unit}"
+    return f"{n:.0f}"
+
+
+def _when(ts: float) -> str:
+    return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts)) if ts else "—"
+
+
+def render_sessions_text(sessions: list[SessionOverview], *, color: bool = True) -> str:
+    """The no-argument picker: one line per known session, newest first."""
+
+    def c(code: str, s: str) -> str:
+        return f"\x1b[{code}m{s}\x1b[0m" if color else s
+
+    if not sessions:
+        return (
+            "No wrap sessions recorded yet. Start one with:\n"
+            "  distil wrap -- claude   (or codex/gemini/any base-url-honoring tool)"
+        )
+    out = [c("1", "distil sessions — pick one to dissect"), ""]
+    hdr = f"{'session':<22} {'tool':<10} {'started':<17} {'last':<17} {'reqs':>5} {'saved':>7}  status"
+    out.append(c("2", hdr))
+    for o in sessions:
+        pct = 100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens if o.baseline_tokens else 0.0
+        out.append(
+            f"{o.sid:<22} {(o.tool or '?'):<10} {_when(o.started):<17} {_when(o.last_ts):<17} "
+            f"{o.requests:>5} {pct:>6.1f}%  {o.status}"
+        )
+    out += ["", "dissect one:  distil dissect <session>   (a unique prefix or `latest` works)"]
+    return "\n".join(out)
+
+
+def _flags_line(man: dict[str, Any]) -> str:
+    flags = man.get("flags") or {}
+    on = [k for k in ("expand", "session_delta", "lossless_only", "verbatim") if flags.get(k)]
+    if float(flags.get("shadow_rate") or 0.0) > 0:
+        on.append(f"shadow={flags['shadow_rate']}")
+    if (flags.get("shape_output") or "off") != "off":
+        on.append(f"shape_output={flags['shape_output']}")
+    return ", ".join(on) or "defaults"
+
+
+def render_text(d: Dissection, *, color: bool = True) -> str:
+    """Terminal report. Sections degrade gracefully when a source is missing."""
+
+    def c(code: str, s: str) -> str:
+        return f"\x1b[{code}m{s}\x1b[0m" if color else s
+
+    man = d.manifest or {}
+    subscription = d.billing == "subscription"
+    out: list[str] = []
+    tool = man.get("tool") or "unknown tool"
+    out.append(c("1", f"distil dissect — {d.sid} ({tool})"))
+
+    # Session card
+    dur = ""
+    if d.started and d.ended and d.ended > d.started:
+        dur = f"  ({(d.ended - d.started) / 60:.0f} min)"
+    out.append(f"  window   {_when(d.started)} → {_when(d.ended)}{dur}")
+    if man:
+        out.append(f"  wrap     {' '.join(man.get('argv') or [])}  [{_flags_line(man)}]")
+        out.append(f"  distil   v{man.get('distil_version', '?')}, billing: {d.billing}")
+    else:
+        out.append("  wrap     manifest not recorded (session predates dissect logging)")
+    if d.exit_note:
+        out.append(f"  exit     {d.exit_note}")
+    elif d.marker == "0":
+        out.append(c("33", "  status   marker=0 — wrapped but NO traffic went through distil (bypass?)"))
+    elif d.marker == "1":
+        out.append(f"  status   live (heartbeat: {d.heartbeat or '—'})")
+
+    # Savings (ledger)
+    out.append("")
+    out.append(c("1", "savings (input tokens, booked 2xx only)"))
+    if not d.ledger_rows:
+        out.append("  no booked requests in the ledger for this session")
+    else:
+        note = " (notional — flat-rate plan)" if subscription else ""
+        out.append(
+            f"  {_human(d.baseline_tokens)} → {_human(d.distil_tokens)}"
+            f"  ({d.pct_saved:.1f}% saved, ${d.dollars_saved:.2f}{note})"
+        )
+        for model, reqs, bt, dt in d.per_model():
+            pct = 100.0 * (bt - dt) / bt if bt else 0.0
+            out.append(f"    {model:<34} {reqs:>4} req  {_human(bt):>8} → {_human(dt):>8}  {pct:>5.1f}%")
+
+    # Request detail
+    out.append("")
+    out.append(c("1", "request detail"))
+    if not d.detail_available:
+        out.append("  not recorded — per-request detail needs a wrap from this distil version or newer")
+    else:
+        n = len(d.requests)
+        out.append(
+            f"  {n} proxied requests: {n - d.unbooked_requests} booked, {d.unbooked_requests} not booked "
+            f"(non-2xx/retry), {d.verbatim_requests} verbatim (nothing worth compressing)"
+        )
+        out.append(f"  cache-delta: {_human(d.delta_tokens_saved)} tokens referenced instead of resent")
+        out.append(
+            f"  not optimized by design: ~{_human(d.overhead_tokens_avg)} tokens/request of system prompt "
+            "+ tool definitions (sent verbatim every request), plus recent turns kept for fidelity"
+        )
+        if d.blocks:
+            out.append("")
+            out.append(c("1", "digested blocks (content-free: kind:size, tokens)"))
+            for sig, uniq, toks in d.blocks_by_kind():
+                out.append(f"    {sig:<12} {uniq:>4} blocks  {_human(toks):>8} tokens")
+            recoverable = sum(1 for i in d.blocks.values() if i.get("recoverable"))
+            out.append(f"  recoverable now: {recoverable}/{len(d.blocks)} blocks still in restore/")
+            out.append("  largest folds:")
+            for h, sig, toks, folds, rec in d.top_blocks(5):
+                mark = "✓" if rec else "expired"
+                out.append(f"    {h}  {sig:<12} {_human(toks):>8} tokens  ×{folds} requests  [{mark}]")
+
+    # Quality loops
+    out.append("")
+    out.append(c("1", "quality loops"))
+    if d.detail_available:
+        out.append(f"  expand: {d.expand_resolved} requests had distil_expand calls resolved in-proxy")
+        out.append(f"  shadow: {d.shadow_sampled} requests sampled for decision-equivalence")
+    if d.shadow_window_rows:
+        out.append(
+            f"  shadow verdicts in this session's time window (time-joined, not session-tagged): "
+            f"{d.shadow_window_agree}/{d.shadow_window_rows} equivalent"
+        )
+    elif not d.detail_available:
+        out.append("  no session-scoped signal recorded for this session")
+
+    out.append("")
+    out.append(
+        c("2", "sources: savings.jsonl, sessions/<sid>{.json,.requests.jsonl,.hb,.exit}, restore/, shadow.jsonl")
+    )
+    out.append(c("2", "retention: session detail follows the sessions/ TTL sweep; restore blobs are pruned separately"))
+    return "\n".join(out)
+
+
+def to_json(d: Dissection) -> dict[str, Any]:
+    """Machine-readable dissection (same numbers the text/html reports show)."""
+    return {
+        "session": d.sid,
+        "manifest": d.manifest,
+        "window": {"started_ts": d.started, "ended_ts": d.ended},
+        "savings": {
+            "baseline_input_tokens": d.baseline_tokens,
+            "distil_input_tokens": d.distil_tokens,
+            "pct_saved": round(d.pct_saved, 2),
+            "dollars_saved": round(d.dollars_saved, 4),
+            "dollars_notional": d.billing == "subscription",
+            "per_model": [
+                {"model": m, "requests": r, "baseline_tokens": b, "distil_tokens": t}
+                for m, r, b, t in d.per_model()
+            ],
+        },
+        "detail_available": d.detail_available,
+        "requests": {
+            "total": len(d.requests),
+            "unbooked": d.unbooked_requests,
+            "verbatim": d.verbatim_requests,
+            "delta_tokens_saved": d.delta_tokens_saved,
+            "overhead_tokens_avg": d.overhead_tokens_avg,
+        },
+        "blocks": {
+            "by_kind": [
+                {"sig": s, "unique": u, "tokens": t} for s, u, t in d.blocks_by_kind()
+            ],
+            "recoverable": sum(1 for i in d.blocks.values() if i.get("recoverable")),
+            "unique": len(d.blocks),
+            "top": [
+                {"handle": h, "sig": s, "tokens": t, "folds": f, "recoverable": r}
+                for h, s, t, f, r in d.top_blocks()
+            ],
+        },
+        "quality": {
+            "expand_resolved_requests": d.expand_resolved,
+            "shadow_sampled_requests": d.shadow_sampled,
+            "shadow_window_rows": d.shadow_window_rows,
+            "shadow_window_agree": d.shadow_window_agree,
+        },
+        "liveness": {"marker": d.marker, "heartbeat": d.heartbeat, "exit": d.exit_note},
+    }
+
+
+def render_html(d: Dissection) -> str:
+    """Self-contained dark page in the ledger `render_html` style."""
+    man = d.manifest or {}
+    subscription = d.billing == "subscription"
+    e = _html.escape
+    dol_note = " (notional — flat-rate plan)" if subscription else ""
+
+    model_rows = "".join(
+        f"<tr><td>{e(m)}</td><td class='r'>{r}</td><td class='r'>{_human(b)}</td>"
+        f"<td class='r'>{_human(t)}</td><td class='r'>{100.0 * (b - t) / b if b else 0.0:.1f}%</td></tr>"
+        for m, r, b, t in d.per_model()
+    ) or "<tr><td class='muted' colspan='5'>no booked requests</td></tr>"
+
+    kind_rows = "".join(
+        f"<tr><td>{e(s)}</td><td class='r'>{u}</td><td class='r'>{_human(t)}</td></tr>"
+        for s, u, t in d.blocks_by_kind()
+    )
+    top_rows = "".join(
+        f"<tr><td><code>{e(h)}</code></td><td>{e(s)}</td><td class='r'>{_human(t)}</td>"
+        f"<td class='r'>×{f}</td><td>{'recoverable' if r else '<span class=muted>expired</span>'}</td></tr>"
+        for h, s, t, f, r in d.top_blocks()
+    )
+    detail_card = (
+        f"""<h2>Request detail</h2>
+<p>{len(d.requests)} proxied requests — {d.unbooked_requests} not booked (non-2xx/retry),
+{d.verbatim_requests} verbatim (nothing worth compressing).
+Cache-delta referenced <b>{_human(d.delta_tokens_saved)}</b> tokens instead of resending them.
+Not optimized by design: ~{_human(d.overhead_tokens_avg)} tokens/request of system prompt + tool
+definitions, plus recent turns kept verbatim for fidelity.</p>
+<h2>Digested blocks <span class="muted">(content-free: kind:size)</span></h2>
+<table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
+<h2>Largest folds</h2>
+<table><tr><th>handle</th><th>kind</th><th>tokens</th><th>seen</th><th>restore</th></tr>{top_rows}</table>"""
+        if d.detail_available
+        else "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
+        "wrap from this distil version or newer.</p>"
+    )
+    quality = (
+        f"<p>expand: {d.expand_resolved} requests resolved in-proxy · shadow: {d.shadow_sampled} "
+        f"sampled · window verdicts (time-joined): {d.shadow_window_agree}/{d.shadow_window_rows} equivalent</p>"
+        if (d.detail_available or d.shadow_window_rows)
+        else "<p class='muted'>no session-scoped quality signal recorded</p>"
+    )
+    exit_line = f"<p class='muted'>exit: {e(d.exit_note)}</p>" if d.exit_note else ""
+
+    return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="icon" type="image/svg+xml" href="https://dshakes.github.io/distil/assets/logo.svg"/>
+<title>Distil — dissect {e(d.sid)}</title><style>
+body{{margin:0;background:#06070b;color:#f2f3f7;font:15px/1.6 Inter,ui-sans-serif,sans-serif;
+ -webkit-font-smoothing:antialiased}}
+.wrap{{max-width:760px;margin:0 auto;padding:48px 24px}}
+h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
+h2{{font-size:17px;font-weight:700;margin:26px 0 10px}}
+.sub{{color:#9aa1b3;margin:0 0 28px}}
+.tot{{display:flex;gap:14px;margin:0 0 28px;flex-wrap:wrap}}
+.card{{flex:1;min-width:150px;background:linear-gradient(180deg,#12151f,#0b0d15);
+ border:1px solid #252c3e;border-radius:14px;padding:20px}}
+.card .l{{color:#9aa1b3;font-size:12px}} .card .v{{font-size:30px;font-weight:800;margin-top:4px}}
+.g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
+table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
+th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
+th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
+code{{color:#8b7bff}}
+.foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+</style></head><body><div class="wrap">
+<h1>Session <span class="g">dissected</span></h1>
+<p class="sub">{e(d.sid)} — {e(man.get("tool") or "unknown tool")},
+{e(_when(d.started))} → {e(_when(d.ended))} · wrap flags: {e(_flags_line(man)) if man else "unknown"}
+· billing: {e(d.billing)}</p>
+<div class="tot">
+<div class="card"><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div></div>
+<div class="card"><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div></div>
+<div class="card"><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div></div>
+</div>
+<h2>Per model</h2>
+<table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
+{detail_card}
+<h2>Quality loops</h2>
+{quality}
+{exit_line}
+<p class="foot">Local-first: assembled from savings.jsonl, sessions/&lt;sid&gt;*, restore/ and
+shadow.jsonl on this machine. Content-free — handles and kind:size signatures only.</p>
+</div></body></html>"""

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -269,7 +269,8 @@ class Dissection:
 
     @property
     def churned_blocks(self) -> int:
-        return sum(1 for i in self.blocks.values() if int(i.get("folds") or 0) >= 3)
+        """Blocks folded more than once — the same count churn_tokens sums over."""
+        return sum(1 for i in self.blocks.values() if int(i.get("folds") or 0) >= 2)
 
     @property
     def usage_input_total(self) -> int:
@@ -407,6 +408,38 @@ class Dissection:
                 )
         return out
 
+    @property
+    def system_tokens_avg(self) -> int:
+        vals = [int(r.get("system_tokens") or 0) for r in self.requests]
+        return sum(vals) // len(vals) if vals else 0
+
+    @property
+    def tools_tokens_avg(self) -> int:
+        vals = [int(r.get("tools_tokens") or 0) for r in self.requests]
+        return sum(vals) // len(vals) if vals else 0
+
+    def system_growth(self) -> tuple[int, int] | None:
+        """(first, last) system-prompt size — memory/context injections show up here."""
+        vals = [int(r.get("system_tokens") or 0) for r in self.requests if r.get("system_tokens")]
+        return (vals[0], vals[-1]) if len(vals) >= 2 else None
+
+    def tool_costs(self) -> list[tuple[str, int, int]]:
+        """[(tool_name, tokens_per_request, session_total)] biggest total first.
+
+        A tool definition is resent on every request, so its session cost is
+        its size × the requests that carried it — the "trim this" worklist.
+        """
+        per: dict[str, list[int]] = {}
+        for r in self.requests:
+            for t in r.get("tools") or []:
+                name = str(t.get("name") or "?")
+                m = per.setdefault(name, [0, 0])
+                m[0] = max(m[0], int(t.get("tokens") or 0))
+                m[1] += 1
+        return sorted(
+            ((name, v[0], v[0] * v[1]) for name, v in per.items()), key=lambda t: -t[2]
+        )
+
     def blocks_by_kind(self) -> list[tuple[str, int, int]]:
         """[(signature, unique_blocks, tokens)] biggest-token first."""
         agg: dict[str, list[int]] = {}
@@ -520,15 +553,18 @@ def render_sessions_text(sessions: list[SessionOverview], *, color: bool = True)
             "  distil wrap -- claude   (or codex/gemini/any base-url-honoring tool)"
         )
     out = [c("1", "distil sessions — pick one to dissect"), ""]
-    hdr = f"{'session':<22} {'tool':<10} {'started':<17} {'last':<17} {'reqs':>5} {'saved':>7}  status"
+    hdr = (
+        f"{'#':>3}  {'session':<22} {'tool':<10} {'started':<17} {'last':<17} "
+        f"{'reqs':>5} {'saved':>7}  status"
+    )
     out.append(c("2", hdr))
-    for o in sessions:
+    for i, o in enumerate(sessions, 1):
         pct = 100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens if o.baseline_tokens else 0.0
         out.append(
-            f"{o.sid:<22} {(o.tool or '?'):<10} {_when(o.started):<17} {_when(o.last_ts):<17} "
-            f"{o.requests:>5} {pct:>6.1f}%  {o.status}"
+            f"{i:>3}  {o.sid:<22} {(o.tool or '?'):<10} {_when(o.started):<17} "
+            f"{_when(o.last_ts):<17} {o.requests:>5} {pct:>6.1f}%  {o.status}"
         )
-    out += ["", "dissect one:  distil dissect <session>   (a unique prefix or `latest` works)"]
+    out += ["", "dissect one:  distil dissect <session>   (a number above, a unique prefix, or `latest`)"]
     return "\n".join(out)
 
 
@@ -618,10 +654,23 @@ def render_text(
             f"{_human(d.overhead_tokens_total)} tokens, {d.overhead_share:.0f}% of everything sent "
             f"(~{_human(d.overhead_tokens_avg)}/request) — trimming unused tools beats compression here"
         )
+        tools = d.tool_costs()
+        if tools:
+            out.append(
+                f"  tool definitions ({len(tools)}): "
+                + ", ".join(f"{name} {_human(per)}/req" for name, per, _t in tools[:5])
+                + (" …" if len(tools) > 5 else "")
+            )
+        growth = d.system_growth()
+        if growth and growth[1] != growth[0]:
+            out.append(
+                f"  system prompt: {_human(growth[0])} → {_human(growth[1])} tokens over the session"
+            )
         if d.churn_tokens:
             out.append(
                 f"  re-fold churn: {_human(d.churn_tokens)} tokens re-digested after first sight "
-                f"({d.churned_blocks} blocks folded 3+ times — cache-delta/codec candidates)"
+                f"({d.churned_blocks} block{'s' if d.churned_blocks != 1 else ''} re-folded — "
+                "cache-delta/codec candidates)"
             )
         cal = d.calibration()
         if cal is not None:
@@ -701,6 +750,13 @@ def to_json(d: Dissection, peers: list[SessionOverview] | None = None) -> dict[s
             "overhead": {
                 "tokens_total": d.overhead_tokens_total,
                 "share_pct": round(d.overhead_share, 1),
+                "system_tokens_avg": d.system_tokens_avg,
+                "tools_tokens_avg": d.tools_tokens_avg,
+                "system_growth": d.system_growth(),
+                "tools": [
+                    {"name": n, "tokens_per_request": p, "session_tokens": t}
+                    for n, p, t in d.tool_costs()
+                ],
             },
             "churn": {"tokens": d.churn_tokens, "blocks": d.churned_blocks},
             "usage": {
@@ -764,6 +820,136 @@ def to_json(d: Dissection, peers: list[SessionOverview] | None = None) -> dict[s
     }
 
 
+# ---------------------------------------------------------------- svg charts
+# Categorical series, fixed order, validated (dataviz six checks) against the
+# report's dark card surface #0b0d15: overhead / sent / saved.
+_C_OVERHEAD, _C_SENT, _C_SAVED = "#3987e5", "#199e70", "#c98500"
+_GRID = "#1b2030"
+_INK_MUTED = "#9aa1b3"
+
+
+def _svg_hbars(rows: list[tuple[str, int]], *, color: str = _C_OVERHEAD) -> str:
+    """Horizontal bar chart (single measure, one hue): label, thin bar, value."""
+    if not rows:
+        return ""
+    top = max(v for _, v in rows) or 1
+    rh, bar_h, label_w, val_w, width = 26, 12, 220, 64, 640
+    plot_w = width - label_w - val_w
+    parts = [
+        f'<svg viewBox="0 0 {width} {len(rows) * rh + 6}" role="img" '
+        f'style="width:100%;height:auto;font:12px Inter,ui-sans-serif,sans-serif">'
+    ]
+    for i, (label, val) in enumerate(rows):
+        y = i * rh + 4
+        w = max(2, round(plot_w * val / top))
+        name = label if len(label) <= 30 else label[:29] + "…"
+        parts.append(
+            f'<text x="{label_w - 8}" y="{y + bar_h - 2}" text-anchor="end" '
+            f'fill="{_INK_MUTED}">{_html.escape(name)}</text>'
+            f'<rect class="mark" x="{label_w}" y="{y}" width="{w}" height="{bar_h}" '
+            f'rx="2" fill="{color}"><title>{_html.escape(label)}: {val:,} tokens</title></rect>'
+            f'<text x="{label_w + w + 6}" y="{y + bar_h - 2}" fill="{_INK_MUTED}">'
+            f"{_human(val)}</text>"
+        )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _svg_stack_timeline(requests: list[dict[str, Any]]) -> str:
+    """Per-request composition: overhead + sent content + saved, stacked bars.
+
+    2px surface gaps between bars and between segments; rounded data-end on the
+    top segment only; native <title> tooltips carry the per-request numbers.
+    """
+    if not requests:
+        return ""
+    comp = []
+    for r in requests:
+        overhead = int(r.get("overhead_tokens") or 0)
+        saved = int(r.get("tokens_saved") or 0)
+        sent = max(0, int(r.get("compressible_tokens") or 0) - saved)
+        comp.append((overhead, sent, saved, r))
+    top = max(o + s + v for o, s, v, _ in comp) or 1
+    width, height, pad_l, pad_b = 640, 190, 52, 18
+    plot_w, plot_h = width - pad_l - 8, height - pad_b - 8
+    n = len(comp)
+    step = plot_w / n
+    bar_w = max(2, min(28, round(step - 2)))
+    parts = [
+        f'<svg viewBox="0 0 {width} {height}" role="img" '
+        f'style="width:100%;height:auto;font:11px Inter,ui-sans-serif,sans-serif">'
+    ]
+    for frac in (0.0, 0.5, 1.0):  # recessive grid, three lines
+        y = 8 + plot_h * (1 - frac)
+        parts.append(
+            f'<line x1="{pad_l}" y1="{y:.1f}" x2="{width - 8}" y2="{y:.1f}" '
+            f'stroke="{_GRID}" stroke-width="1"/>'
+            f'<text x="{pad_l - 6}" y="{y + 3:.1f}" text-anchor="end" '
+            f'fill="{_INK_MUTED}">{_human(top * frac)}</text>'
+        )
+    for i, (overhead, sent, saved, r) in enumerate(comp):
+        x = pad_l + i * step + (step - bar_w) / 2
+        tip = (
+            f"request {i + 1} · {r.get('model', '?')} · overhead {overhead:,} · "
+            f"sent {sent:,} · saved {saved:,}"
+        )
+        y = 8 + plot_h
+        segs = [(_C_OVERHEAD, overhead), (_C_SENT, sent), (_C_SAVED, saved)]
+        drawn = [(c, v) for c, v in segs if v > 0]
+        for j, (color, val) in enumerate(drawn):
+            h = max(1.0, plot_h * val / top)
+            y -= h
+            topmost = j == len(drawn) - 1
+            # 2px surface gap between segments, shaved off each non-top segment's
+            # top edge — bottoms stay anchored (baseline for the first segment).
+            gap = 0.0 if topmost else min(2.0, h - 0.5)
+            parts.append(
+                f'<rect class="mark" x="{x:.1f}" y="{y + gap:.1f}" width="{bar_w}" '
+                f'height="{h - gap:.1f}" rx="{2 if topmost else 0}" fill="{color}">'
+                f"<title>{_html.escape(tip)}</title></rect>"
+            )
+    parts.append(
+        f'<text x="{pad_l}" y="{height - 4}" fill="{_INK_MUTED}">1</text>'
+        f'<text x="{width - 8}" y="{height - 4}" text-anchor="end" '
+        f'fill="{_INK_MUTED}">{n}</text>'
+        f'<text x="{pad_l + plot_w / 2:.0f}" y="{height - 4}" text-anchor="middle" '
+        f'fill="{_INK_MUTED}">request</text>'
+    )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _legend() -> str:
+    items = (
+        (_C_OVERHEAD, "overhead (system + tools)"),
+        (_C_SENT, "sent content"),
+        (_C_SAVED, "saved by distil"),
+    )
+    spans = "".join(
+        f'<span style="margin-right:16px"><span style="display:inline-block;width:10px;'
+        f'height:10px;border-radius:2px;background:{c};margin-right:6px"></span>{t}</span>'
+        for c, t in items
+    )
+    return f'<p class="muted" style="font-size:12.5px">{spans}</p>'
+
+
+def _timeline_table(requests: list[dict[str, Any]]) -> str:
+    rows = "".join(
+        f"<tr><td>{i + 1}</td><td>{_html.escape(str(r.get('model', '?')))}</td>"
+        f"<td class='r'>{int(r.get('overhead_tokens') or 0):,}</td>"
+        f"<td class='r'>{max(0, int(r.get('compressible_tokens') or 0) - int(r.get('tokens_saved') or 0)):,}</td>"
+        f"<td class='r'>{int(r.get('tokens_saved') or 0):,}</td>"
+        f"<td class='r'>{r.get('usage_input_tokens') if r.get('usage_input_tokens') is not None else '—'}</td>"
+        f"<td class='r'>{r.get('duration_ms') if r.get('duration_ms') is not None else '—'}</td></tr>"
+        for i, r in enumerate(requests)
+    )
+    return (
+        "<details><summary class='muted'>data table</summary>"
+        "<table><tr><th>#</th><th>model</th><th>overhead</th><th>sent</th>"
+        f"<th>saved</th><th>billed in</th><th>ms</th></tr>{rows}</table></details>"
+    )
+
+
 def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> str:
     """Self-contained dark page in the ledger `render_html` style."""
     man = d.manifest or {}
@@ -819,19 +1005,43 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
         if d.expansion_regret()
         else ""
     )
+    tool_rows = [(name, per) for name, per, _tot in d.tool_costs()[:10]]
+    tools_chart = (
+        "<h2>Tool definitions <span class='muted'>(tokens per request — resent every "
+        f"time)</span></h2>{_svg_hbars(tool_rows)}"
+        if tool_rows
+        else ""
+    )
+    growth = d.system_growth()
+    prompt_line = (
+        f"System prompt grew {_human(growth[0])} → {_human(growth[1])} tokens over the "
+        "session (memory/context injections accumulate there)."
+        if growth and growth[1] != growth[0]
+        else ""
+    )
+    kind_chart = _svg_hbars(
+        [(sig, toks) for sig, _u, toks in d.blocks_by_kind()[:10]], color=_C_SAVED
+    )
     detail_card = (
         f"""<h2>Request detail</h2>
 <p>{len(d.requests)} proxied requests — {d.unbooked_requests} not booked (non-2xx/retry),
 {d.verbatim_requests} verbatim (nothing worth compressing).
 {mech_line}
-Fixed overhead: system prompt + tool definitions = <b>{_human(d.overhead_tokens_total)}</b>
-tokens ({d.overhead_share:.0f}% of everything sent).
-Re-fold churn: <b>{_human(d.churn_tokens)}</b> tokens across {d.churned_blocks} blocks folded
-3+ times. {cal_line} {headroom_line}</p>
+Fixed overhead: system prompt ({_human(d.system_tokens_avg)}/req) + tool definitions
+({_human(d.tools_tokens_avg)}/req) = <b>{_human(d.overhead_tokens_total)}</b> tokens
+({d.overhead_share:.0f}% of everything sent). {prompt_line}
+Re-fold churn: <b>{_human(d.churn_tokens)}</b> tokens across {d.churned_blocks} re-folded
+block{'s' if d.churned_blocks != 1 else ''}. {cal_line} {headroom_line}</p>
 <p class="muted">Latency — {lat_line or "not recorded"}.
 {f"{d.forced_buffered} streamed requests buffered for the expand loop (TTFT tax)." if d.forced_buffered else ""}
 {regret_line}</p>
+<h2>Request composition <span class="muted">(tokens per request)</span></h2>
+{_legend()}
+{_svg_stack_timeline(d.requests)}
+{_timeline_table(d.requests)}
+{tools_chart}
 <h2>Digested blocks <span class="muted">(content-free: kind:size)</span></h2>
+{kind_chart}
 <table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
 <h2>Largest folds</h2>
 <table><tr><th>handle</th><th>kind</th><th>tokens</th><th>seen</th><th>restore</th></tr>{top_rows}</table>"""
@@ -866,6 +1076,8 @@ table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radiu
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
 th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 ul.warn{{margin:0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:4px 0}}
+svg .mark:hover{{filter:brightness(1.3)}}
+details{{margin:10px 0}} details summary{{cursor:pointer}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
 code{{color:#8b7bff}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -943,28 +943,38 @@ _GRID = "#1b2030"
 _INK_MUTED = "#9aa1b3"
 
 
-def _svg_hbars(rows: list[tuple[str, int]], *, color: str = _C_OVERHEAD) -> str:
-    """Horizontal bar chart (single measure, one hue): label, thin bar, value."""
+def _svg_hbars(
+    rows: list[tuple[str, int, list[tuple[str, str, str]]]],
+    *,
+    color: str = _C_OVERHEAD,
+) -> str:
+    """Horizontal bar chart (single measure, one hue): label, thin bar, value.
+
+    Each row is (label, value, tooltip_rows). The whole row — label through
+    value — is one oversized hit target for the styled tooltip.
+    """
     if not rows:
         return ""
-    top = max(v for _, v in rows) or 1
+    top = max(v for _, v, _t in rows) or 1
     rh, bar_h, label_w, val_w, width = 26, 12, 220, 64, 640
     plot_w = width - label_w - val_w
     parts = [
         f'<svg viewBox="0 0 {width} {len(rows) * rh + 6}" role="img" '
         f'style="width:100%;height:auto;font:12px Inter,ui-sans-serif,sans-serif">'
     ]
-    for i, (label, val) in enumerate(rows):
+    for i, (label, val, tip_rows) in enumerate(rows):
         y = i * rh + 4
         w = max(2, round(plot_w * val / top))
         name = label if len(label) <= 30 else label[:29] + "…"
         parts.append(
+            f"<g{_tip_attr(label, tip_rows)}>"
+            f'<rect x="0" y="{y - 2}" width="{width}" height="{rh}" fill="transparent"/>'
             f'<text x="{label_w - 8}" y="{y + bar_h - 2}" text-anchor="end" '
             f'fill="{_INK_MUTED}">{_html.escape(name)}</text>'
             f'<rect class="mark" x="{label_w}" y="{y}" width="{w}" height="{bar_h}" '
-            f'rx="2" fill="{color}"><title>{_html.escape(label)}: {val:,} tokens</title></rect>'
+            f'rx="2" fill="{color}"/>'
             f'<text x="{label_w + w + 6}" y="{y + bar_h - 2}" fill="{_INK_MUTED}">'
-            f"{_human(val)}</text>"
+            f"{_human(val)}</text></g>"
         )
     parts.append("</svg>")
     return "".join(parts)
@@ -1004,13 +1014,26 @@ def _svg_stack_timeline(requests: list[dict[str, Any]]) -> str:
         )
     for i, (overhead, sent, saved, r) in enumerate(comp):
         x = pad_l + i * step + (step - bar_w) / 2
-        tip = (
-            f"request {i + 1} · {r.get('model', '?')} · overhead {overhead:,} · "
-            f"sent {sent:,} · saved {saved:,}"
-        )
+        tip_rows = [
+            (_C_SAVED, "saved by distil", f"{saved:,}"),
+            (_C_SENT, "sent content", f"{sent:,}"),
+            (_C_OVERHEAD, "overhead", f"{overhead:,}"),
+        ]
+        billed = r.get("usage_input_tokens")
+        if billed is not None:
+            tip_rows.append(("", "billed input", f"{int(billed):,}"))
+        if r.get("duration_ms") is not None:
+            tip_rows.append(("", "duration", f"{int(r['duration_ms']) / 1000:.1f}s"))
         y = 8 + plot_h
         segs = [(_C_OVERHEAD, overhead), (_C_SENT, sent), (_C_SAVED, saved)]
         drawn = [(c, v) for c, v in segs if v > 0]
+        # The whole column is one hit target: hover anywhere over the request,
+        # not just the thin bar, and every series is listed in one tooltip.
+        parts.append(
+            f"<g{_tip_attr(f'request {i + 1} · ' + str(r.get('model', '?')), tip_rows)}>"
+            f'<rect x="{pad_l + i * step:.1f}" y="8" width="{step:.1f}" '
+            f'height="{plot_h + pad_b:.1f}" fill="transparent"/>'
+        )
         for j, (color, val) in enumerate(drawn):
             h = max(1.0, plot_h * val / top)
             y -= h
@@ -1020,9 +1043,9 @@ def _svg_stack_timeline(requests: list[dict[str, Any]]) -> str:
             gap = 0.0 if topmost else min(2.0, h - 0.5)
             parts.append(
                 f'<rect class="mark" x="{x:.1f}" y="{y + gap:.1f}" width="{bar_w}" '
-                f'height="{h - gap:.1f}" rx="{2 if topmost else 0}" fill="{color}">'
-                f"<title>{_html.escape(tip)}</title></rect>"
+                f'height="{h - gap:.1f}" rx="{2 if topmost else 0}" fill="{color}"/>'
             )
+        parts.append("</g>")
     parts.append(
         f'<text x="{pad_l}" y="{height - 4}" fill="{_INK_MUTED}">1</text>'
         f'<text x="{width - 8}" y="{height - 4}" text-anchor="end" '
@@ -1065,13 +1088,33 @@ def _timeline_table(requests: list[dict[str, Any]]) -> str:
     )
 
 
-def _tile(label: str, value: str, note: str = "", help_text: str = "") -> str:
-    """One stat card. ``help_text`` becomes a native hover (title=) in plain
-    English — every distil term on the page must be explainable without docs."""
-    note_html = f'<div class="n">{note}</div>' if note else ""
-    title = f' title="{_html.escape(help_text)}"' if help_text else ""
+def _tip_attr(title: str, rows: list[tuple[str, str, str]] | None = None, body: str = "") -> str:
+    """Build the ``data-tip`` attribute for the styled hover layer.
+
+    Payload is JSON — the page's script rebuilds it with textContent (never
+    innerHTML), so model/tool/signature names stay data, not markup. ``rows``
+    are (series_color, label, value) triples; values render strong, labels
+    secondary, keyed by a short stroke of the series color.
+    """
+    payload: dict[str, Any] = {"t": title}
+    if rows:
+        payload["rows"] = [list(r) for r in rows]
+    if body:
+        payload["body"] = body
     return (
-        f'<div class="card tile"{title}><div class="l">{label}</div>'
+        f' data-tip="{_html.escape(json.dumps(payload, ensure_ascii=False), quote=True)}"'
+        ' tabindex="0"'
+    )
+
+
+def _tile(label: str, value: str, note: str = "", help_text: str = "") -> str:
+    """One stat card. ``help_text`` feeds the styled hover/focus tooltip in
+    plain English — every distil term on the page must be explainable without
+    docs."""
+    note_html = f'<div class="n">{note}</div>' if note else ""
+    tip = _tip_attr(label, body=help_text) if help_text else ""
+    return (
+        f'<div class="card tile"{tip}><div class="l">{label}</div>'
         f'<div class="v2">{value}</div>{note_html}</div>'
     )
 
@@ -1245,7 +1288,17 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
             else ""
         )
 
-        tool_rows = [(name, per) for name, per, _tot in d.tool_costs()[:10]]
+        tool_rows = [
+            (
+                name,
+                per,
+                [
+                    (_C_OVERHEAD, "tokens per request", f"{per:,}"),
+                    ("", "session total (× every request)", f"{tot:,}"),
+                ],
+            )
+            for name, per, tot in d.tool_costs()[:10]
+        ]
         tools_chart = (
             "<h2>Tool definitions <span class='muted'>(tokens per request)</span></h2>"
             "<p class='desc'>Every enabled tool is re-described to the model on every "
@@ -1256,7 +1309,18 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
             else ""
         )
         kind_chart = _svg_hbars(
-            [(sig, toks) for sig, _u, toks in d.blocks_by_kind()[:10]], color=_C_SAVED
+            [
+                (
+                    sig,
+                    toks,
+                    [
+                        (_C_SAVED, "tokens folded", f"{toks:,}"),
+                        ("", "distinct blocks", str(uniq)),
+                    ],
+                )
+                for sig, uniq, toks in d.blocks_by_kind()[:10]
+            ],
+            color=_C_SAVED,
         )
         detail_body = f"""<h2>Request detail</h2>
 <p class="desc">Every API request this session made, and where its tokens went — hover any
@@ -1318,8 +1382,19 @@ h2{{font-size:17px;font-weight:700;margin:34px 0 12px}}
 .card .l{{color:#9aa1b3;font-size:12px}} .card .v{{font-size:30px;font-weight:800;margin-top:4px}}
 .card .v2{{font-size:22px;font-weight:700;margin-top:4px}}
 .card .n{{color:#5b6177;font-size:12px;margin-top:6px;line-height:1.45}}
-.tile{{cursor:help}} .card[title] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
+.tile{{cursor:help}} .card[data-tip] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
  padding-bottom:1px}}
+[data-tip]{{outline:none}}
+g[data-tip]:hover .mark,g[data-tip]:focus .mark{{filter:brightness(1.35)}}
+#tip{{position:fixed;display:none;background:#161a26;border:1px solid #2c3550;
+ border-radius:10px;padding:10px 13px;font-size:12.5px;line-height:1.5;
+ pointer-events:none;z-index:9;max-width:340px;box-shadow:0 8px 24px rgba(0,0,0,.55)}}
+#tip .tt{{color:#f2f3f7;font-weight:600;margin-bottom:2px}}
+#tip .tb{{color:#9aa1b3}}
+#tip .trow{{display:flex;align-items:center;gap:8px;margin:3px 0}}
+#tip .tkey{{width:10px;height:3px;border-radius:1.5px;flex:none}}
+#tip .trow b{{font-variant-numeric:tabular-nums}}
+#tip .tlab{{color:#9aa1b3}}
 .desc{{color:#5b6177;font-size:13px;line-height:1.55;margin:-4px 0 14px}}
 .story{{background:linear-gradient(180deg,#12151f,#0b0d15);border:1px solid #252c3e;
  border-radius:14px;padding:16px 20px;margin:0 0 10px}}
@@ -1336,7 +1411,6 @@ code{{color:#8b7bff}}
 .callout b{{color:#e8b34b}}
 ul.warn{{margin:8px 0 0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:6px 0}}
 ul.notes{{margin:14px 0 0;padding-left:20px}} ul.notes li{{color:#9aa1b3;margin:8px 0}}
-svg .mark:hover{{filter:brightness(1.3)}}
 details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:26px}}
 </style></head><body><div class="wrap">
@@ -1365,4 +1439,44 @@ verdicts near this session (time-joined): {d.shadow_window_agree}/{d.shadow_wind
 {exit_line}
 <p class="foot">Local-first: assembled from savings.jsonl, sessions/&lt;sid&gt;*, restore/ and
 shadow.jsonl on this machine. Content-free — handles and kind:size signatures only.</p>
-</div></body></html>"""
+</div><div id="tip" role="tooltip"></div><script>
+(function () {{
+  var tip = document.getElementById("tip");
+  function fill(el) {{
+    var d; try {{ d = JSON.parse(el.dataset.tip); }} catch (e) {{ return false; }}
+    tip.replaceChildren();
+    var t = document.createElement("div"); t.className = "tt";
+    t.textContent = d.t || ""; tip.append(t);
+    if (d.body) {{ var b = document.createElement("div"); b.className = "tb";
+      b.textContent = d.body; tip.append(b); }}
+    (d.rows || []).forEach(function (r) {{
+      var row = document.createElement("div"); row.className = "trow";
+      var key = document.createElement("span"); key.className = "tkey";
+      if (r[0]) key.style.background = r[0]; else key.style.visibility = "hidden";
+      var val = document.createElement("b"); val.textContent = r[2];
+      var lab = document.createElement("span"); lab.className = "tlab";
+      lab.textContent = r[1];
+      row.append(key, val, lab); tip.append(row);
+    }});
+    tip.style.display = "block";
+    return true;
+  }}
+  function place(x, y) {{
+    var r = tip.getBoundingClientRect(), pad = 14;
+    var px = x + pad, py = y + pad;
+    if (px + r.width > innerWidth - 8) px = x - r.width - pad;
+    if (py + r.height > innerHeight - 8) py = y - r.height - pad;
+    tip.style.left = Math.max(8, px) + "px"; tip.style.top = Math.max(8, py) + "px";
+  }}
+  document.addEventListener("mousemove", function (e) {{
+    var el = e.target.closest && e.target.closest("[data-tip]");
+    if (el && fill(el)) place(e.clientX, e.clientY);
+    else tip.style.display = "none";
+  }});
+  document.addEventListener("focusin", function (e) {{
+    var el = e.target.closest && e.target.closest("[data-tip]");
+    if (el && fill(el)) {{ var r = el.getBoundingClientRect(); place(r.right, r.top); }}
+  }});
+  document.addEventListener("focusout", function () {{ tip.style.display = "none"; }});
+}})();
+</script></body></html>"""

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -731,6 +731,10 @@ def render_text(
         out.append("  no session-scoped signal recorded for this session")
 
     out.append("")
+    out.append(c("2", "terms: fold = bulky content replaced by a summary + recovery handle · cache-delta ="))
+    out.append(c("2", "resent content replaced by a reference · verbatim = passed through untouched ·"))
+    out.append(c("2", "unbooked = upstream failed/retried, not counted as savings"))
+    out.append("")
     out.append(
         c("2", "sources: savings.jsonl, sessions/<sid>{.json,.requests.jsonl,.hb,.exit}, restore/, shadow.jsonl")
     )
@@ -950,10 +954,13 @@ def _timeline_table(requests: list[dict[str, Any]]) -> str:
     )
 
 
-def _tile(label: str, value: str, note: str = "") -> str:
+def _tile(label: str, value: str, note: str = "", help_text: str = "") -> str:
+    """One stat card. ``help_text`` becomes a native hover (title=) in plain
+    English — every distil term on the page must be explainable without docs."""
     note_html = f'<div class="n">{note}</div>' if note else ""
+    title = f' title="{_html.escape(help_text)}"' if help_text else ""
     return (
-        f'<div class="card tile"><div class="l">{label}</div>'
+        f'<div class="card tile"{title}><div class="l">{label}</div>'
         f'<div class="v2">{value}</div>{note_html}</div>'
     )
 
@@ -987,7 +994,9 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
 
     warn_html = "".join(f"<li>{e(w)}</li>" for w in d.anomalies(peers))
     warn_card = (
-        f'<div class="callout"><b>⚠ Worth your attention</b><ul class="warn">{warn_html}</ul></div>'
+        f'<div class="callout"><b>⚠ Worth your attention</b>'
+        f'<div class="n">Automatic checks on this session found things that may need '
+        f'action.</div><ul class="warn">{warn_html}</ul></div>'
         if warn_html
         else ""
     )
@@ -1000,27 +1009,42 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
                 "Requests",
                 str(len(d.requests)),
                 f"{d.unbooked_requests} unbooked · {d.verbatim_requests} verbatim",
+                "API calls the wrapped tool made through distil. Unbooked = the upstream "
+                "call failed or was retried, so it is not counted as savings. Verbatim = "
+                "the request was passed through untouched because nothing in it was worth "
+                "compressing.",
             ),
             _tile(
                 "Digest folds",
                 _human(d.digest_saved),
                 f"{100.0 * d.digest_saved / saved:.0f}% of savings",
+                "Tokens distil avoided sending by replacing bulky content (test logs, file "
+                "dumps, stack traces) with a short summary plus a recovery handle. The "
+                "original bytes stay on this machine and can be restored at any time.",
             ),
             _tile(
                 "Cache-delta",
                 _human(d.delta_tokens_saved),
                 f"{100.0 * d.delta_tokens_saved / saved:.0f}% of savings",
+                "Tokens avoided by sending a short reference to content this session "
+                "already sent earlier, instead of resending the full text every request.",
             ),
             _tile(
                 "Fixed overhead",
                 _human(d.overhead_tokens_total),
                 f"{d.overhead_share:.0f}% of sent · system {_human(d.system_tokens_avg)}/req "
                 f"· tools {_human(d.tools_tokens_avg)}/req",
+                "The system prompt and tool definitions are resent word-for-word with "
+                "every single request, and distil never alters them. If this share is "
+                "large, removing unused tools/MCP servers saves more than compression can.",
             ),
             _tile(
                 "Re-fold churn",
                 _human(d.churn_tokens),
                 f"{d.churned_blocks} block{'s' if d.churned_blocks != 1 else ''} re-folded",
+                "The same content arrived again on later requests and had to be folded "
+                "again. High churn means smarter caching (cache-delta / the learned codec) "
+                "has room to help.",
             ),
         ]
         cal = d.calibration()
@@ -1030,25 +1054,56 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
                     "Billed input",
                     _human(d.usage_input_total),
                     f"{_human(d.usage_output_total)} out · estimate ×{cal[0] / cal[1]:.2f} of billed",
+                    "Token counts reported by the API itself in its responses — the ground "
+                    "truth. The × figure is how close distil's local estimate came to it "
+                    "(×1.00 would be exact).",
                 )
             )
         else:
-            tiles.append(_tile("Billed input", "—", "usage not captured"))
+            tiles.append(
+                _tile(
+                    "Billed input",
+                    "—",
+                    "usage not captured",
+                    "The API reports exact token counts in its responses; none were "
+                    "captured for this session (recorded by newer wraps only).",
+                )
+            )
         if subscription and d.headroom_multiplier > 1:
             tiles.append(
                 _tile(
                     "Headroom",
                     f"{d.headroom_multiplier:.1f}×",
                     "flat-rate: context budget stretched",
+                    "On a flat-rate subscription there is no per-token bill — the real win "
+                    "is that the same rate/context limits go this many times further "
+                    "before you hit them.",
                 )
             )
-        tiles.append(_tile("Expand", str(d.expand_resolved), "requests resolved in-proxy"))
+        tiles.append(
+            _tile(
+                "Expand",
+                str(d.expand_resolved),
+                "requests resolved in-proxy",
+                "Times the model asked for a folded block back (it kept a recovery handle) "
+                "and distil answered from local storage, invisibly to the session.",
+            )
+        )
         shadow_note = (
             f"{d.shadow_window_agree}/{d.shadow_window_rows} verdicts equivalent"
             if d.shadow_window_rows
             else "no verdicts in window"
         )
-        tiles.append(_tile("Shadow", str(d.shadow_sampled), f"sampled · {shadow_note}"))
+        tiles.append(
+            _tile(
+                "Shadow",
+                str(d.shadow_sampled),
+                f"sampled · {shadow_note}",
+                "A sample of requests is re-run uncompressed in the background and the "
+                "two answers compared — a live check that compression is not changing "
+                "the model's decisions.",
+            )
+        )
 
         notes: list[str] = []
         growth = d.system_growth()
@@ -1081,8 +1136,11 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
 
         tool_rows = [(name, per) for name, per, _tot in d.tool_costs()[:10]]
         tools_chart = (
-            "<h2>Tool definitions <span class='muted'>(tokens per request — resent every "
-            f"time)</span></h2>{_svg_hbars(tool_rows)}"
+            "<h2>Tool definitions <span class='muted'>(tokens per request)</span></h2>"
+            "<p class='desc'>Every enabled tool is re-described to the model on every "
+            "request, so each bar is a standing cost you pay per call. Long bars from "
+            "tools you rarely use are the cheapest tokens to reclaim — disable them.</p>"
+            f"{_svg_hbars(tool_rows)}"
             if tool_rows
             else ""
         )
@@ -1090,18 +1148,29 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
             [(sig, toks) for sig, _u, toks in d.blocks_by_kind()[:10]], color=_C_SAVED
         )
         detail_body = f"""<h2>Request detail</h2>
+<p class="desc">Every API request this session made, and where its tokens went — hover any
+card for what the term means.</p>
 <div class="grid">{"".join(tiles)}</div>
 {notes_html}
 <h2>Request composition <span class="muted">(tokens per request)</span></h2>
+<p class="desc">One bar per request, in order. Blue is the fixed overhead every request must
+carry, green is conversation content that was actually sent, yellow is what distil kept off
+the wire. Hover a bar for exact numbers.</p>
 {_legend()}
 {_svg_stack_timeline(d.requests)}
 {_timeline_table(d.requests)}
 {tools_chart}
-<h2>Digested blocks <span class="muted">(content-free: kind:size)</span></h2>
+<h2>Digested blocks <span class="muted">(what got folded)</span></h2>
+<p class="desc">Content distil summarized, grouped by what it looked like. The label is
+kind:size — e.g. <code>log:l</code> is a large log, <code>prose:m</code> a medium block of
+text. Only these labels are stored, never the content.</p>
 {kind_chart}
 <table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
 <h2>Largest folds</h2>
-<table><tr><th>handle</th><th>kind</th><th>tokens</th><th>seen</th><th>restore</th></tr>{top_rows}</table>"""
+<p class="desc">The biggest single blocks distil summarized. The handle is the short ID the
+model can use to ask for the original back; “recoverable” means those original bytes are
+still on this machine.</p>
+<table><tr><th>handle</th><th>kind</th><th>tokens</th><th title="how many requests carried this block">seen</th><th title="is the original still on disk (restore/)?">restore</th></tr>{top_rows}</table>"""
     else:
         detail_body = (
             "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
@@ -1127,6 +1196,9 @@ h2{{font-size:17px;font-weight:700;margin:34px 0 12px}}
 .card .l{{color:#9aa1b3;font-size:12px}} .card .v{{font-size:30px;font-weight:800;margin-top:4px}}
 .card .v2{{font-size:22px;font-weight:700;margin-top:4px}}
 .card .n{{color:#5b6177;font-size:12px;margin-top:6px;line-height:1.45}}
+.tile{{cursor:help}} .card[title] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
+ padding-bottom:1px}}
+.desc{{color:#5b6177;font-size:13px;line-height:1.55;margin:-4px 0 14px}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
@@ -1148,16 +1220,21 @@ details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 · billing: {e(d.billing)}</p>
 {warn_card}
 <div class="tot">
-<div class="card"><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div></div>
-<div class="card"><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div></div>
-<div class="card"><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div></div>
+<div class="card" title="Input tokens are everything sent TO the model (your conversation so far, tool outputs, prompts) — the part that grows every turn and that distil compresses."><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div><div class="n">would have been sent → actually sent</div></div>
+<div class="card" title="Share of input tokens distil kept off the wire across the whole session."><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div><div class="n">of input tokens never sent</div></div>
+<div class="card" title="What those saved tokens are worth at API prices. On a flat-rate subscription nothing is billed per token, so this is notional — the real win is headroom."><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div><div class="n">at API prices for this model mix</div></div>
 </div>
 <h2>Per model</h2>
+<p class="desc">Who talked and what it cost: baseline is what each model <em>would</em> have
+received unwrapped; distil is what was actually sent after compression.</p>
 <table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
 {detail_body}
 <h2>Quality loops</h2>
+<p class="desc">distil's own safety nets: <b>expand</b> lets the model pull any folded block
+back when it needs the detail; <b>shadow</b> re-runs a sample of requests uncompressed to
+verify the answers don't change.</p>
 <p class="muted">expand: {d.expand_resolved} resolved in-proxy · shadow: {d.shadow_sampled} sampled ·
-window verdicts (time-joined): {d.shadow_window_agree}/{d.shadow_window_rows} equivalent</p>
+verdicts near this session (time-joined): {d.shadow_window_agree}/{d.shadow_window_rows} equivalent</p>
 {exit_line}
 <p class="foot">Local-first: assembled from savings.jsonl, sessions/&lt;sid&gt;*, restore/ and
 shadow.jsonl on this machine. Content-free — handles and kind:size signatures only.</p>

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1646,9 +1646,15 @@ JSON at /json/&lt;session&gt;.</p>
 </div></body></html>"""
 
 
-def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
+def make_server(
+    host: str = "127.0.0.1", port: int = 8790, transcript: str | None = None
+) -> Any:
     """Build (don't start) the dissect portal server — stdlib only, like the
     gateway. Routes: ``/`` index, ``/session/<sid>`` report, ``/json/<sid>``.
+
+    ``transcript`` makes correlation the default for every report page
+    ("auto" or a transcript path — the ``--transcript`` flag passed through);
+    ``?t=0`` opts a page out, ``?t=1`` opts in when no default is set.
 
     Every request re-reads state from disk, so a refresh shows the live
     session as it grows. Binds localhost by default; the data is one user's
@@ -1684,7 +1690,11 @@ def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
                     d = dissect(sid)
                     peers = list_sessions()
                     corr = None
-                    if "t=1" in query.split("&"):
+                    params = query.split("&")
+                    want_corr = (
+                        "t=1" in params or (transcript is not None and "t=0" not in params)
+                    )
+                    if want_corr:
                         try:
                             from .correlate import correlate
                             from .transcripts import find_transcript
@@ -1694,6 +1704,7 @@ def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
                                 str(man.get("tool") or ""),
                                 (d.started, d.ended or d.started),
                                 cwd=man.get("cwd"),
+                                path=None if transcript in (None, "auto") else transcript,
                             )
                             if tr is not None:
                                 corr = correlate(d, tr)
@@ -1707,7 +1718,7 @@ def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
                         )
                     else:
                         toggle = (
-                            f'<a href="/session/{_html.escape(sid)}" style="color:#8b7bff">hide correlation</a>'
+                            f'<a href="/session/{_html.escape(sid)}?t=0" style="color:#8b7bff">hide correlation</a>'
                             if corr is not None
                             else f'<a href="/session/{_html.escape(sid)}?t=1" style="color:#8b7bff">+ correlate with transcript</a>'
                         )

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -28,12 +28,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from typing import TYPE_CHECKING
+
 from .ledger import (
     default_path,
     session_manifest_path,
     session_marker_path,
     session_requests_path,
 )
+
+if TYPE_CHECKING:  # pragma: no cover — render-time only
+    from .correlate import Correlation
 
 
 def _state_dir() -> Path:
@@ -681,7 +686,11 @@ def _flags_line(man: dict[str, Any]) -> str:
 
 
 def render_text(
-    d: Dissection, *, color: bool = True, peers: list[SessionOverview] | None = None
+    d: Dissection,
+    *,
+    color: bool = True,
+    peers: list[SessionOverview] | None = None,
+    corr: "Correlation | None" = None,
 ) -> str:
     """Terminal report. Sections degrade gracefully when a source is missing."""
 
@@ -840,6 +849,39 @@ def render_text(
     elif not d.detail_available:
         out.append("  no session-scoped signal recorded for this session")
 
+    if corr is not None:
+        out.append("")
+        out.append(c("1", f"conversation correlation ({corr.agent} transcript: {corr.label or 'untitled'})"))
+        if corr.fold_sources:
+            out.append("  largest folds, named:")
+            for s in corr.fold_sources[:5]:
+                who = s.tool or "unknown tool"
+                turn = f' (turn {s.turn}: "{s.turn_text[:40]}…")' if s.turn_text else ""
+                out.append(f"    {_human(s.tokens):>8} ×{s.folds}  {who} output{turn}")
+        if corr.unnamed_blocks:
+            out.append(f"  {corr.unnamed_blocks} blocks unattributed (restore blob expired or content transformed)")
+        if corr.unused_tools:
+            out.append(
+                f"  unused tools ({len(corr.unused_tools)}/{corr.tools_defined} defined, "
+                f"{_human(corr.unused_tokens_per_request)} tokens/request paid for nothing): "
+                + ", ".join(n for n, _t in corr.unused_tools[:8])
+                + (" …" if len(corr.unused_tools) > 8 else "")
+            )
+        for s in corr.refetched[:3]:
+            out.append(
+                c("33", f"  ⚠ re-fetched after fold: {s.tool or '?'} output ({_human(s.tokens)} tokens) "
+                        f"appeared in {s.refetches} separate results — the digest may have dropped "
+                        "something the agent needed")
+            )
+        if corr.turns:
+            out.append("  costliest turns:")
+            for t in corr.turns[:3]:
+                label = t.text[:46] + ("…" if len(t.text) > 46 else "") if t.text else "(session start)"
+                out.append(
+                    f'    turn {t.index}: "{label}" — {t.requests} req, '
+                    f"{_human(t.baseline_tokens)} baseline, {_human(t.saved_tokens)} saved"
+                )
+
     out.append("")
     out.append(c("2", "terms: fold = bulky content replaced by a summary + recovery handle · cache-delta ="))
     out.append(c("2", "resent content replaced by a reference · verbatim = passed through untouched ·"))
@@ -852,10 +894,42 @@ def render_text(
     return "\n".join(out)
 
 
-def to_json(d: Dissection, peers: list[SessionOverview] | None = None) -> dict[str, Any]:
+def to_json(
+    d: Dissection,
+    peers: list[SessionOverview] | None = None,
+    corr: "Correlation | None" = None,
+) -> dict[str, Any]:
     """Machine-readable dissection (same numbers the text/html reports show)."""
     cal = d.calibration()
+    correlation = None
+    if corr is not None:
+        correlation = {
+            "agent": corr.agent,
+            "label": corr.label,
+            "transcript": corr.path,
+            "fold_sources": [
+                {"handle": s.handle, "sig": s.sig, "tokens": s.tokens, "folds": s.folds,
+                 "tool": s.tool, "turn": s.turn, "refetches": s.refetches}
+                for s in corr.fold_sources
+            ],
+            "unnamed_blocks": corr.unnamed_blocks,
+            "tools": {
+                "defined": corr.tools_defined,
+                "invoked": corr.tools_invoked,
+                "unused": [{"name": n, "tokens_per_request": t} for n, t in corr.unused_tools],
+            },
+            "refetched_after_fold": [
+                {"tool": s.tool, "tokens": s.tokens, "refetches": s.refetches}
+                for s in corr.refetched
+            ],
+            "turns": [
+                {"index": t.index, "text": t.text, "requests": t.requests,
+                 "baseline_tokens": t.baseline_tokens, "saved_tokens": t.saved_tokens}
+                for t in corr.turns
+            ],
+        }
     return {
+        "correlation": correlation,
         "headlines": [{"headline": h, "detail": b} for h, b in d.headlines()],
         "insights": {
             "mechanism": {
@@ -1119,7 +1193,11 @@ def _tile(label: str, value: str, note: str = "", help_text: str = "") -> str:
     )
 
 
-def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> str:
+def render_html(
+    d: Dissection,
+    peers: list[SessionOverview] | None = None,
+    corr: "Correlation | None" = None,
+) -> str:
     """Self-contained dark page in the ledger `render_html` style.
 
     Layout follows the stat-tile pattern: one number per card with a short
@@ -1352,6 +1430,51 @@ still on this machine.</p>
             "wrap from this distil version or newer.</p>"
         )
     exit_line = f"<p class='muted'>exit: {e(d.exit_note)}</p>" if d.exit_note else ""
+    corr_html = ""
+    if corr is not None:
+        fold_rows = "".join(
+            f"<tr><td>{e(s.tool or 'unknown')}</td>"
+            f"<td class='muted'>{e((s.turn_text or '')[:48])}</td>"
+            f"<td class='r'>{_human(s.tokens)}</td><td class='r'>×{s.folds}</td>"
+            f"<td class='r'>{s.refetches}</td></tr>"
+            for s in corr.fold_sources[:10]
+        )
+        unused = (
+            f"<p><b>{len(corr.unused_tools)}</b> of {corr.tools_defined} defined tools were "
+            f"never invoked, costing <b>{_human(corr.unused_tokens_per_request)}</b> tokens on "
+            f"every request: <span class='muted'>"
+            + e(", ".join(n for n, _t in corr.unused_tools[:10]))
+            + ("…" if len(corr.unused_tools) > 10 else "")
+            + "</span></p>"
+            if corr.unused_tools
+            else f"<p>All {corr.tools_defined} defined tools were invoked at least once.</p>"
+        )
+        refetch = "".join(
+            f"<li>{e(s.tool or '?')} output ({_human(s.tokens)} tokens) reappeared in "
+            f"{s.refetches} separate tool results — the digest may have dropped something "
+            "the agent needed</li>"
+            for s in corr.refetched[:3]
+        )
+        refetch_html = f"<ul class='warn'>{refetch}</ul>" if refetch else ""
+        turn_rows = "".join(
+            f"<tr><td>{t.index or '—'}</td><td class='muted'>{e(t.text[:56]) or '(session start)'}</td>"
+            f"<td class='r'>{t.requests}</td><td class='r'>{_human(t.baseline_tokens)}</td>"
+            f"<td class='r'>{_human(t.saved_tokens)}</td></tr>"
+            for t in corr.turns[:8]
+        )
+        corr_html = f"""<h2>Conversation correlation <span class="muted">({e(corr.agent)}:
+{e(corr.label or "untitled")})</span></h2>
+<p class="desc">Opt-in join with the agent's own transcript (read locally, stored nowhere):
+folds named by the tool call that produced them, tools you pay for but never used, and what
+each of your prompts cost.</p>
+{unused}
+{refetch_html}
+<h3>Largest folds, named</h3>
+<table><tr><th>source</th><th>under turn</th><th>tokens</th><th>folds</th><th>results seen in</th></tr>
+{fold_rows or "<tr><td class='muted' colspan='5'>no blocks could be attributed</td></tr>"}</table>
+<h3>Costliest turns</h3>
+<table><tr><th>#</th><th>your prompt</th><th>req</th><th>baseline</th><th>saved</th></tr>
+{turn_rows or "<tr><td class='muted' colspan='5'>no turns matched</td></tr>"}</table>"""
     heads = d.headlines()
     story = (
         "<h2>What happened</h2>"
@@ -1373,6 +1496,7 @@ body{{margin:0;background:#06070b;color:#f2f3f7;font:15px/1.6 Inter,ui-sans-seri
 .wrap{{max-width:820px;margin:0 auto;padding:48px 24px}}
 h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
 h2{{font-size:17px;font-weight:700;margin:34px 0 12px}}
+h3{{font-size:14px;font-weight:700;margin:20px 0 8px}}
 .sub{{color:#9aa1b3;margin:0 0 28px}}
 .tot{{display:flex;gap:14px;margin:0 0 14px;flex-wrap:wrap}}
 .grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px}}
@@ -1430,6 +1554,7 @@ details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 received unwrapped; distil is what was actually sent after compression.</p>
 <table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
 {detail_body}
+{corr_html}
 <h2>Quality loops</h2>
 <p class="desc">distil's own safety nets: <b>expand</b> lets the model pull any folded block
 back when it needs the detail; <b>shadow</b> re-runs a sample of requests uncompressed to
@@ -1549,6 +1674,7 @@ def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
             if path in ("/", "/index.html"):
                 self._send(200, render_sessions_html(list_sessions()))
                 return
+            query = self.path.partition("?")[2]
             for prefix, as_json in (("/session/", False), ("/json/", True)):
                 if path.startswith(prefix):
                     sid = resolve_sid(path[len(prefix):])
@@ -1557,15 +1683,38 @@ def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
                         return
                     d = dissect(sid)
                     peers = list_sessions()
+                    corr = None
+                    if "t=1" in query.split("&"):
+                        try:
+                            from .correlate import correlate
+                            from .transcripts import find_transcript
+
+                            man = d.manifest or {}
+                            tr = find_transcript(
+                                str(man.get("tool") or ""),
+                                (d.started, d.ended or d.started),
+                                cwd=man.get("cwd"),
+                            )
+                            if tr is not None:
+                                corr = correlate(d, tr)
+                        except Exception:  # noqa: BLE001 — correlation is best-effort
+                            corr = None
                     if as_json:
                         self._send(
                             200,
-                            json.dumps(to_json(d, peers), indent=2),
+                            json.dumps(to_json(d, peers, corr), indent=2),
                             ctype="application/json",
                         )
                     else:
-                        page = render_html(d, peers).replace(
-                            "<h1>", '<p><a href="/" style="color:#8b7bff">← sessions</a></p><h1>', 1
+                        toggle = (
+                            f'<a href="/session/{_html.escape(sid)}" style="color:#8b7bff">hide correlation</a>'
+                            if corr is not None
+                            else f'<a href="/session/{_html.escape(sid)}?t=1" style="color:#8b7bff">+ correlate with transcript</a>'
+                        )
+                        page = render_html(d, peers, corr).replace(
+                            "<h1>",
+                            f'<p><a href="/" style="color:#8b7bff">← sessions</a> · {toggle}</p><h1>',
+                            1,
                         )
                         self._send(200, page)
                     return

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1480,3 +1480,98 @@ shadow.jsonl on this machine. Content-free — handles and kind:size signatures 
   document.addEventListener("focusout", function () {{ tip.style.display = "none"; }});
 }})();
 </script></body></html>"""
+
+
+# ------------------------------------------------------------------- portal
+def render_sessions_html(sessions: list[SessionOverview]) -> str:
+    """The portal index: the session picker as a clickable page."""
+    e = _html.escape
+    rows = "".join(
+        f'<tr onclick="location=\'/session/{e(o.sid)}\'">'
+        f"<td><code>{e(o.sid)}</code></td><td>{e(o.tool or '?')}</td>"
+        f"<td>{e(_when(o.started))}</td><td>{e(_when(o.last_ts))}</td>"
+        f"<td class='r'>{o.requests}</td>"
+        f"<td class='r'>{100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens if o.baseline_tokens else 0.0:.1f}%</td>"
+        f"<td>{e(o.status)}</td></tr>"
+        for o in sessions
+    ) or "<tr><td class='muted' colspan='7'>no sessions recorded yet — run a wrap first</td></tr>"
+    return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta http-equiv="refresh" content="15"/>
+<title>Distil — sessions</title><style>
+body{{margin:0;background:#06070b;color:#f2f3f7;font:15px/1.6 Inter,ui-sans-serif,sans-serif}}
+.wrap{{max-width:820px;margin:0 auto;padding:48px 24px}}
+h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
+.sub{{color:#9aa1b3;margin:0 0 28px}}
+.g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
+table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
+th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
+th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}}
+tbody tr{{cursor:pointer}} tbody tr:hover td{{background:#10131d}}
+code{{color:#8b7bff}} .muted{{color:#5b6177}}
+.foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+</style></head><body><div class="wrap">
+<h1>Distil <span class="g">sessions</span></h1>
+<p class="sub">Pick a session to dissect — newest activity first. This page refreshes itself.</p>
+<table><thead><tr><th>session</th><th>tool</th><th>started</th><th>last</th><th>reqs</th>
+<th>saved</th><th>status</th></tr></thead><tbody>{rows}</tbody></table>
+<p class="foot">Local-first: served from this machine's ~/.distil only. Reports are per-session;
+JSON at /json/&lt;session&gt;.</p>
+</div></body></html>"""
+
+
+def make_server(host: str = "127.0.0.1", port: int = 8790) -> Any:
+    """Build (don't start) the dissect portal server — stdlib only, like the
+    gateway. Routes: ``/`` index, ``/session/<sid>`` report, ``/json/<sid>``.
+
+    Every request re-reads state from disk, so a refresh shows the live
+    session as it grows. Binds localhost by default; the data is one user's
+    own telemetry, so there is no auth layer — don't bind it wider unless
+    that is understood.
+    """
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class _Portal(BaseHTTPRequestHandler):
+        server_version = "distil-dissect"
+
+        def _send(self, status: int, body: str, ctype: str = "text/html; charset=utf-8") -> None:
+            data = body.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self) -> None:  # noqa: N802 — http.server API
+            path = self.path.split("?", 1)[0]
+            if path in ("/", "/index.html"):
+                self._send(200, render_sessions_html(list_sessions()))
+                return
+            for prefix, as_json in (("/session/", False), ("/json/", True)):
+                if path.startswith(prefix):
+                    sid = resolve_sid(path[len(prefix):])
+                    if sid is None:
+                        self._send(404, "<h1>unknown session</h1>")
+                        return
+                    d = dissect(sid)
+                    peers = list_sessions()
+                    if as_json:
+                        self._send(
+                            200,
+                            json.dumps(to_json(d, peers), indent=2),
+                            ctype="application/json",
+                        )
+                    else:
+                        page = render_html(d, peers).replace(
+                            "<h1>", '<p><a href="/" style="color:#8b7bff">← sessions</a></p><h1>', 1
+                        )
+                        self._send(200, page)
+                    return
+            self._send(404, "<h1>not found</h1><p><a href='/'>sessions</a></p>")
+
+        def log_message(self, *args: Any) -> None:  # quiet by design, like the proxy
+            pass
+
+    return ThreadingHTTPServer((host, port), _Portal)

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -440,6 +440,108 @@ class Dissection:
             ((name, v[0], v[0] * v[1]) for name, v in per.items()), key=lambda t: -t[2]
         )
 
+    def headlines(self) -> list[tuple[str, str]]:
+        """The layman's story of the session: [(headline, detail)] in plain
+        language, data-driven, biggest thing first. This is what a reader who
+        will never hover a tile should still walk away knowing."""
+        out: list[tuple[str, str]] = []
+        kind_words = {
+            "log": "large logs",
+            "prose": "long text output",
+            "code": "code listings",
+            "error": "error output",
+            "traceback": "stack traces",
+            "diff": "diffs",
+            "columnar": "tabular data",
+        }
+        if self.baseline_tokens:
+            kinds = self.blocks_by_kind()
+            mostly = ""
+            if kinds:
+                word = kind_words.get(kinds[0][0].split(":")[0], "bulky content")
+                mostly = f", mostly by summarizing {word}"
+            kept = self.baseline_tokens - self.distil_tokens
+            out.append(
+                (
+                    f"distil kept {_human(kept)} of {_human(self.baseline_tokens)} input "
+                    f"tokens off the wire ({self.pct_saved:.0f}%)",
+                    f"Your session's conversation and tool results would have cost "
+                    f"{_human(self.baseline_tokens)} tokens to resend across its requests; "
+                    f"{_human(self.distil_tokens)} actually went out{mostly}. Everything "
+                    "summarized stays recoverable on this machine.",
+                )
+            )
+        if self.detail_available and self.overhead_share >= 30:
+            n_tools = len(self.tool_costs())
+            out.append(
+                (
+                    f"Your agent's fixed setup is {self.overhead_share:.0f}% of everything sent",
+                    f"The system prompt plus {n_tools} tool definitions are resent "
+                    "word-for-word on every request, and no compression applies to them. "
+                    "Disabling tools/MCP servers you don't use is the single cheapest "
+                    "saving available.",
+                )
+            )
+        if self.usage_output_total:
+            total_usage = self.usage_input_total + self.usage_output_total
+            pct = 100.0 * self.usage_output_total / total_usage if total_usage else 0.0
+            shaping = (self.manifest or {}).get("flags", {}).get("shape_output", "off")
+            if self.billing == "subscription":
+                shaping_note = (
+                    "Live replies are never shortened on a subscription — output shaping "
+                    "is gated to metered billing, where its effect is measured before "
+                    "being trusted."
+                )
+            elif shaping and shaping != "off":
+                shaping_note = f"Output shaping is on ({shaping}) for live replies."
+            else:
+                shaping_note = (
+                    "Live replies can additionally be shortened with --shape-output "
+                    "(off for this session)."
+                )
+            out.append(
+                (
+                    f"The model wrote {_human(self.usage_output_total)} output tokens "
+                    f"({pct:.0f}% of billed traffic)",
+                    "Output tokens are the model's own replies. distil trims verbose past "
+                    "replies when they re-enter later requests as context (that saving is "
+                    f"counted above). {shaping_note}",
+                )
+            )
+        if self.churn_tokens and self.tokens_saved_total and (
+            self.churn_tokens >= 0.25 * self.tokens_saved_total
+        ):
+            out.append(
+                (
+                    f"{_human(self.churn_tokens)} tokens were resent and re-summarized",
+                    "The client kept resending the same content, so distil had to fold it "
+                    "again each time. The session-delta cache absorbs exactly this; if it "
+                    "is already on, these blocks are candidates for the learned codec.",
+                )
+            )
+        if self.shadow_window_rows:
+            out.append(
+                (
+                    f"Compression was spot-checked {self.shadow_window_rows} time"
+                    f"{'s' if self.shadow_window_rows != 1 else ''} — "
+                    f"{self.shadow_window_agree} matched",
+                    "Shadow mode re-ran a sample of requests uncompressed in the "
+                    "background and compared the answers, so you don't have to take the "
+                    "savings on faith.",
+                )
+            )
+        if self.detail_available and self.expand_resolved:
+            out.append(
+                (
+                    f"The model asked for folded detail back {self.expand_resolved} time"
+                    f"{'s' if self.expand_resolved != 1 else ''}",
+                    "When a summary wasn't enough, the model used its recovery handle and "
+                    "distil restored the original content mid-request — nothing was lost, "
+                    "it just cost one extra round-trip.",
+                )
+            )
+        return out
+
     def blocks_by_kind(self) -> list[tuple[str, int, int]]:
         """[(signature, unique_blocks, tokens)] biggest-token first."""
         agg: dict[str, list[int]] = {}
@@ -616,6 +718,14 @@ def render_text(
         for w in warnings:
             out.append(c("33", f"  ⚠ {w}"))
 
+    heads = d.headlines()
+    if heads:
+        out.append("")
+        out.append(c("1", "what happened"))
+        for title, body in heads:
+            out.append(f"  • {title}")
+            out.append(c("2", f"    {body}"))
+
     # Savings (ledger)
     out.append("")
     out.append(c("1", "savings (input tokens, booked 2xx only)"))
@@ -746,6 +856,7 @@ def to_json(d: Dissection, peers: list[SessionOverview] | None = None) -> dict[s
     """Machine-readable dissection (same numbers the text/html reports show)."""
     cal = d.calibration()
     return {
+        "headlines": [{"headline": h, "detail": b} for h, b in d.headlines()],
         "insights": {
             "mechanism": {
                 "digest_tokens_saved": d.digest_saved,
@@ -1177,6 +1288,17 @@ still on this machine.</p>
             "wrap from this distil version or newer.</p>"
         )
     exit_line = f"<p class='muted'>exit: {e(d.exit_note)}</p>" if d.exit_note else ""
+    heads = d.headlines()
+    story = (
+        "<h2>What happened</h2>"
+        "<p class='desc'>The session in plain language — details and charts below.</p>"
+        + "".join(
+            f'<div class="story"><b>{e(h)}</b><div class="n">{e(body)}</div></div>'
+            for h, body in heads
+        )
+        if heads
+        else ""
+    )
 
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -1199,6 +1321,10 @@ h2{{font-size:17px;font-weight:700;margin:34px 0 12px}}
 .tile{{cursor:help}} .card[title] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
  padding-bottom:1px}}
 .desc{{color:#5b6177;font-size:13px;line-height:1.55;margin:-4px 0 14px}}
+.story{{background:linear-gradient(180deg,#12151f,#0b0d15);border:1px solid #252c3e;
+ border-radius:14px;padding:16px 20px;margin:0 0 10px}}
+.story b{{font-size:15px}}
+.story .n{{color:#9aa1b3;font-size:13px;line-height:1.55;margin-top:4px}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
@@ -1224,6 +1350,7 @@ details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 <div class="card" title="Share of input tokens distil kept off the wire across the whole session."><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div><div class="n">of input tokens never sent</div></div>
 <div class="card" title="What those saved tokens are worth at API prices. On a flat-rate subscription nothing is billed per token, so this is notional — the real win is headroom."><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div><div class="n">at API prices for this model mix</div></div>
 </div>
+{story}
 <h2>Per model</h2>
 <p class="desc">Who talked and what it cost: baseline is what each model <em>would</em> have
 received unwrapped; distil is what was actually sent after compression.</p>

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -950,8 +950,21 @@ def _timeline_table(requests: list[dict[str, Any]]) -> str:
     )
 
 
+def _tile(label: str, value: str, note: str = "") -> str:
+    note_html = f'<div class="n">{note}</div>' if note else ""
+    return (
+        f'<div class="card tile"><div class="l">{label}</div>'
+        f'<div class="v2">{value}</div>{note_html}</div>'
+    )
+
+
 def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> str:
-    """Self-contained dark page in the ledger `render_html` style."""
+    """Self-contained dark page in the ledger `render_html` style.
+
+    Layout follows the stat-tile pattern: one number per card with a short
+    sub-note, anomalies in a bordered callout, and one observation per line —
+    never a paragraph of run-together figures.
+    """
     man = d.manifest or {}
     subscription = d.billing == "subscription"
     e = _html.escape
@@ -962,7 +975,6 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
         f"<td class='r'>{_human(t)}</td><td class='r'>{100.0 * (b - t) / b if b else 0.0:.1f}%</td></tr>"
         for m, r, b, t in d.per_model()
     ) or "<tr><td class='muted' colspan='5'>no booked requests</td></tr>"
-
     kind_rows = "".join(
         f"<tr><td>{e(s)}</td><td class='r'>{u}</td><td class='r'>{_human(t)}</td></tr>"
         for s, u, t in d.blocks_by_kind()
@@ -972,69 +984,114 @@ def render_html(d: Dissection, peers: list[SessionOverview] | None = None) -> st
         f"<td class='r'>×{f}</td><td>{'recoverable' if r else '<span class=muted>expired</span>'}</td></tr>"
         for h, s, t, f, r in d.top_blocks()
     )
+
     warn_html = "".join(f"<li>{e(w)}</li>" for w in d.anomalies(peers))
     warn_card = (
-        f"<h2>Worth your attention</h2><ul class='warn'>{warn_html}</ul>" if warn_html else ""
-    )
-    cal = d.calibration()
-    cal_line = (
-        f"Billed usage: <b>{_human(d.usage_input_total)}</b> in / "
-        f"<b>{_human(d.usage_output_total)}</b> out over {d.usage_requests} requests; heuristic "
-        f"estimate x{cal[0] / cal[1]:.2f} of billed."
-        if cal is not None and cal[1]
-        else "Billed usage: not captured for this session."
-    )
-    saved = d.tokens_saved_total
-    mech_line = (
-        f"Mechanism: digest folds <b>{_human(d.digest_saved)}</b> "
-        f"({100.0 * d.digest_saved / saved:.0f}%), cache-delta "
-        f"<b>{_human(d.delta_tokens_saved)}</b>."
-        if saved
+        f'<div class="callout"><b>⚠ Worth your attention</b><ul class="warn">{warn_html}</ul></div>'
+        if warn_html
         else ""
     )
-    lat_line = " · ".join(f"{k}: {n} req @ {ms / 1000:.1f}s" for k, n, ms in d.latency_by_path())
-    headroom_line = (
-        f"Flat-rate headroom: context budget stretched ~<b>{d.headroom_multiplier:.1f}x</b>."
-        if d.billing == "subscription" and d.headroom_multiplier > 1
-        else ""
-    )
-    regret_line = (
-        "Expansion regret: "
-        + "; ".join(f"{e(s)} pulled back {x}/{t}" for s, x, t in d.expansion_regret())
-        + "."
-        if d.expansion_regret()
-        else ""
-    )
-    tool_rows = [(name, per) for name, per, _tot in d.tool_costs()[:10]]
-    tools_chart = (
-        "<h2>Tool definitions <span class='muted'>(tokens per request — resent every "
-        f"time)</span></h2>{_svg_hbars(tool_rows)}"
-        if tool_rows
-        else ""
-    )
-    growth = d.system_growth()
-    prompt_line = (
-        f"System prompt grew {_human(growth[0])} → {_human(growth[1])} tokens over the "
-        "session (memory/context injections accumulate there)."
-        if growth and growth[1] != growth[0]
-        else ""
-    )
-    kind_chart = _svg_hbars(
-        [(sig, toks) for sig, _u, toks in d.blocks_by_kind()[:10]], color=_C_SAVED
-    )
-    detail_card = (
-        f"""<h2>Request detail</h2>
-<p>{len(d.requests)} proxied requests — {d.unbooked_requests} not booked (non-2xx/retry),
-{d.verbatim_requests} verbatim (nothing worth compressing).
-{mech_line}
-Fixed overhead: system prompt ({_human(d.system_tokens_avg)}/req) + tool definitions
-({_human(d.tools_tokens_avg)}/req) = <b>{_human(d.overhead_tokens_total)}</b> tokens
-({d.overhead_share:.0f}% of everything sent). {prompt_line}
-Re-fold churn: <b>{_human(d.churn_tokens)}</b> tokens across {d.churned_blocks} re-folded
-block{'s' if d.churned_blocks != 1 else ''}. {cal_line} {headroom_line}</p>
-<p class="muted">Latency — {lat_line or "not recorded"}.
-{f"{d.forced_buffered} streamed requests buffered for the expand loop (TTFT tax)." if d.forced_buffered else ""}
-{regret_line}</p>
+
+    detail_body = ""
+    if d.detail_available:
+        saved = d.tokens_saved_total or 1
+        tiles = [
+            _tile(
+                "Requests",
+                str(len(d.requests)),
+                f"{d.unbooked_requests} unbooked · {d.verbatim_requests} verbatim",
+            ),
+            _tile(
+                "Digest folds",
+                _human(d.digest_saved),
+                f"{100.0 * d.digest_saved / saved:.0f}% of savings",
+            ),
+            _tile(
+                "Cache-delta",
+                _human(d.delta_tokens_saved),
+                f"{100.0 * d.delta_tokens_saved / saved:.0f}% of savings",
+            ),
+            _tile(
+                "Fixed overhead",
+                _human(d.overhead_tokens_total),
+                f"{d.overhead_share:.0f}% of sent · system {_human(d.system_tokens_avg)}/req "
+                f"· tools {_human(d.tools_tokens_avg)}/req",
+            ),
+            _tile(
+                "Re-fold churn",
+                _human(d.churn_tokens),
+                f"{d.churned_blocks} block{'s' if d.churned_blocks != 1 else ''} re-folded",
+            ),
+        ]
+        cal = d.calibration()
+        if cal is not None and cal[1]:
+            tiles.append(
+                _tile(
+                    "Billed input",
+                    _human(d.usage_input_total),
+                    f"{_human(d.usage_output_total)} out · estimate ×{cal[0] / cal[1]:.2f} of billed",
+                )
+            )
+        else:
+            tiles.append(_tile("Billed input", "—", "usage not captured"))
+        if subscription and d.headroom_multiplier > 1:
+            tiles.append(
+                _tile(
+                    "Headroom",
+                    f"{d.headroom_multiplier:.1f}×",
+                    "flat-rate: context budget stretched",
+                )
+            )
+        tiles.append(_tile("Expand", str(d.expand_resolved), "requests resolved in-proxy"))
+        shadow_note = (
+            f"{d.shadow_window_agree}/{d.shadow_window_rows} verdicts equivalent"
+            if d.shadow_window_rows
+            else "no verdicts in window"
+        )
+        tiles.append(_tile("Shadow", str(d.shadow_sampled), f"sampled · {shadow_note}"))
+
+        notes: list[str] = []
+        growth = d.system_growth()
+        if growth and growth[1] != growth[0]:
+            notes.append(
+                f"System prompt grew {_human(growth[0])} → {_human(growth[1])} tokens over the "
+                "session — memory/context injections accumulate there."
+            )
+        lat = d.latency_by_path()
+        if lat:
+            notes.append(
+                "Latency: " + " · ".join(f"{k} {n} req @ {ms / 1000:.1f}s" for k, n, ms in lat)
+            )
+        if d.forced_buffered:
+            notes.append(
+                f"{d.forced_buffered} streamed request"
+                f"{'s' if d.forced_buffered != 1 else ''} buffered for the expand loop — "
+                "the --expand time-to-first-token tax."
+            )
+        for s, x, t in d.expansion_regret():
+            notes.append(
+                f"Expansion regret: {e(s)} blocks pulled back {x}/{t} — folding this kind "
+                "costs a round-trip more than it saves."
+            )
+        notes_html = (
+            "<ul class='notes'>" + "".join(f"<li>{n}</li>" for n in notes) + "</ul>"
+            if notes
+            else ""
+        )
+
+        tool_rows = [(name, per) for name, per, _tot in d.tool_costs()[:10]]
+        tools_chart = (
+            "<h2>Tool definitions <span class='muted'>(tokens per request — resent every "
+            f"time)</span></h2>{_svg_hbars(tool_rows)}"
+            if tool_rows
+            else ""
+        )
+        kind_chart = _svg_hbars(
+            [(sig, toks) for sig, _u, toks in d.blocks_by_kind()[:10]], color=_C_SAVED
+        )
+        detail_body = f"""<h2>Request detail</h2>
+<div class="grid">{"".join(tiles)}</div>
+{notes_html}
 <h2>Request composition <span class="muted">(tokens per request)</span></h2>
 {_legend()}
 {_svg_stack_timeline(d.requests)}
@@ -1045,16 +1102,11 @@ block{'s' if d.churned_blocks != 1 else ''}. {cal_line} {headroom_line}</p>
 <table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
 <h2>Largest folds</h2>
 <table><tr><th>handle</th><th>kind</th><th>tokens</th><th>seen</th><th>restore</th></tr>{top_rows}</table>"""
-        if d.detail_available
-        else "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
-        "wrap from this distil version or newer.</p>"
-    )
-    quality = (
-        f"<p>expand: {d.expand_resolved} requests resolved in-proxy · shadow: {d.shadow_sampled} "
-        f"sampled · window verdicts (time-joined): {d.shadow_window_agree}/{d.shadow_window_rows} equivalent</p>"
-        if (d.detail_available or d.shadow_window_rows)
-        else "<p class='muted'>no session-scoped quality signal recorded</p>"
-    )
+    else:
+        detail_body = (
+            "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
+            "wrap from this distil version or newer.</p>"
+        )
     exit_line = f"<p class='muted'>exit: {e(d.exit_note)}</p>" if d.exit_note else ""
 
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"/>
@@ -1063,40 +1115,49 @@ block{'s' if d.churned_blocks != 1 else ''}. {cal_line} {headroom_line}</p>
 <title>Distil — dissect {e(d.sid)}</title><style>
 body{{margin:0;background:#06070b;color:#f2f3f7;font:15px/1.6 Inter,ui-sans-serif,sans-serif;
  -webkit-font-smoothing:antialiased}}
-.wrap{{max-width:760px;margin:0 auto;padding:48px 24px}}
+.wrap{{max-width:820px;margin:0 auto;padding:48px 24px}}
 h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
-h2{{font-size:17px;font-weight:700;margin:26px 0 10px}}
+h2{{font-size:17px;font-weight:700;margin:34px 0 12px}}
 .sub{{color:#9aa1b3;margin:0 0 28px}}
-.tot{{display:flex;gap:14px;margin:0 0 28px;flex-wrap:wrap}}
-.card{{flex:1;min-width:150px;background:linear-gradient(180deg,#12151f,#0b0d15);
+.tot{{display:flex;gap:14px;margin:0 0 14px;flex-wrap:wrap}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px}}
+.card{{background:linear-gradient(180deg,#12151f,#0b0d15);
  border:1px solid #252c3e;border-radius:14px;padding:20px}}
+.tot .card{{flex:1;min-width:150px}}
 .card .l{{color:#9aa1b3;font-size:12px}} .card .v{{font-size:30px;font-weight:800;margin-top:4px}}
+.card .v2{{font-size:22px;font-weight:700;margin-top:4px}}
+.card .n{{color:#5b6177;font-size:12px;margin-top:6px;line-height:1.45}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
 th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
-ul.warn{{margin:0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:4px 0}}
-svg .mark:hover{{filter:brightness(1.3)}}
-details{{margin:10px 0}} details summary{{cursor:pointer}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
 code{{color:#8b7bff}}
-.foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+.callout{{border:1px solid #6b5416;background:#14100a;border-radius:12px;
+ padding:14px 18px;margin:24px 0}}
+.callout b{{color:#e8b34b}}
+ul.warn{{margin:8px 0 0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:6px 0}}
+ul.notes{{margin:14px 0 0;padding-left:20px}} ul.notes li{{color:#9aa1b3;margin:8px 0}}
+svg .mark:hover{{filter:brightness(1.3)}}
+details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
+.foot{{color:#5b6177;font-size:12.5px;margin-top:26px}}
 </style></head><body><div class="wrap">
 <h1>Session <span class="g">dissected</span></h1>
 <p class="sub">{e(d.sid)} — {e(man.get("tool") or "unknown tool")},
 {e(_when(d.started))} → {e(_when(d.ended))} · wrap flags: {e(_flags_line(man)) if man else "unknown"}
 · billing: {e(d.billing)}</p>
+{warn_card}
 <div class="tot">
 <div class="card"><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div></div>
 <div class="card"><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div></div>
 <div class="card"><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div></div>
 </div>
-{warn_card}
 <h2>Per model</h2>
 <table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
-{detail_card}
+{detail_body}
 <h2>Quality loops</h2>
-{quality}
+<p class="muted">expand: {d.expand_resolved} resolved in-proxy · shadow: {d.shadow_sampled} sampled ·
+window verdicts (time-joined): {d.shadow_window_agree}/{d.shadow_window_rows} equivalent</p>
 {exit_line}
 <p class="foot">Local-first: assembled from savings.jsonl, sessions/&lt;sid&gt;*, restore/ and
 shadow.jsonl on this machine. Content-free — handles and kind:size signatures only.</p>

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -18,6 +18,7 @@ import shutil
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 try:
     import fcntl  # POSIX advisory locking; absent on Windows
@@ -54,6 +55,49 @@ def session_marker_path(sid: str | None = None) -> Path | None:
     if not sid or "/" in sid or "\\" in sid or ".." in sid:
         return None  # session ids are wrap-minted; refuse anything path-like
     return default_path().parent / "sessions" / sid
+
+
+def session_manifest_path(sid: str | None = None) -> Path | None:
+    """``sessions/<sid>.json`` — what a wrap session *was*: wrapped tool, argv,
+    flags, start time, billing mode. Written once by ``distil wrap`` at startup;
+    read by ``distil dissect``. Same TTL sweep as the liveness markers."""
+    base = session_marker_path(sid)
+    return None if base is None else base.with_suffix(".json")
+
+
+def session_requests_path(sid: str | None = None) -> Path | None:
+    """``sessions/<sid>.requests.jsonl`` — one content-free record per proxied
+    request (token accounting, per-block digest signatures, shadow/expand flags).
+    Appended by the proxy; read by ``distil dissect``."""
+    base = session_marker_path(sid)
+    return None if base is None else base.with_name(base.name + ".requests.jsonl")
+
+
+def write_session_manifest(manifest: dict[str, Any], sid: str | None = None) -> None:
+    """Best-effort write of the session manifest — never raises (the wrap must
+    start even when the state dir is unwritable)."""
+    path = session_manifest_path(sid)
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def append_session_request(rec: dict[str, Any], sid: str | None = None) -> None:
+    """Best-effort append of one per-request detail record — never raises
+    (bookkeeping must never break a request)."""
+    path = session_requests_path(sid)
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, sort_keys=True) + "\n")
+    except OSError:
+        pass
 
 
 @dataclass

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -1204,6 +1204,7 @@ def wrap_run(
                 "sid": os.environ["DISTIL_SESSION"],
                 "tool": os.path.basename(command[0]) if command else "",
                 "argv": command,
+                "cwd": os.getcwd(),
                 "started_ts": time.time(),
                 "distil_version": _ver,
                 "billing": _billing,

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -809,14 +809,24 @@ def build_handler(
                         )
                     except Exception:  # noqa: BLE001 — one bad handle must not drop the record
                         continue
-                overhead = 0
+                system_tok = tools_tok = 0
+                tool_costs: list[dict[str, Any]] = []
                 if isinstance(body, dict):
-                    for key in ("system", "tools"):
-                        val = body.get(key)
-                        if val:
-                            overhead += _tokenizer.count(
-                                val if isinstance(val, str) else json.dumps(val)
-                            )
+                    sys_val = body.get("system")
+                    if sys_val:
+                        system_tok = _tokenizer.count(
+                            sys_val if isinstance(sys_val, str) else json.dumps(sys_val)
+                        )
+                    for tool in body.get("tools") or []:
+                        try:
+                            n = _tokenizer.count(json.dumps(tool))
+                            tools_tok += n
+                            name = tool.get("name") if isinstance(tool, dict) else None
+                            tool_costs.append({"name": str(name or "?"), "tokens": n})
+                        except Exception:  # noqa: BLE001 — one odd tool must not drop the rest
+                            continue
+                    tool_costs.sort(key=lambda t: -t["tokens"])
+                overhead = system_tok + tools_tok
                 rec = {
                     "ts": time.time(),
                     "model": model,
@@ -832,6 +842,9 @@ def build_handler(
                     "compressible_tokens": int(extras.get("x-distil-compressible-tokens", 0) or 0),
                     "tokens_saved": int(extras.get("x-distil-tokens-saved", 0) or 0),
                     "overhead_tokens": overhead,
+                    "system_tokens": system_tok,
+                    "tools_tokens": tools_tok,
+                    "tools": tool_costs[:24],  # names + token counts only; content-free
                     "delta_refs": int(extras.get("x-distil-cache-refs", 0) or 0),
                     "delta_tokens_saved": int(extras.get("x-distil-cache-tokens-saved", 0) or 0),
                     "prefix_msgs": int(extras.get("x-distil-cache-prefix-msgs", 0) or 0),

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -672,6 +672,19 @@ def build_handler(
                     _bt, _at, _m = _pending_savings
                     savings.record(_bt, _at, model=_m)
                     savings.maybe_flush(every=flush_every)
+                self._emit_detail(
+                    extras=extras,
+                    store=store,
+                    body=body if isinstance(body, dict) else None,
+                    model=_span_model,
+                    stream=True,
+                    status=status_s,
+                    booked=(
+                        savings is not None
+                        and _pending_savings is not None
+                        and 200 <= status_s < 300
+                    ),
+                )
                 if shadow_sampled:
                     self._spawn_shadow(raw, headers, new_raw)
                 return
@@ -722,6 +735,17 @@ def build_handler(
             # signal on real traffic. Never blocks the client's response.
             if shadow_sampled:
                 self._spawn_shadow(raw, headers, new_raw)
+            self._emit_detail(
+                extras=extras,
+                store=store,
+                body=body if isinstance(body, dict) else None,
+                model=_span_model,
+                stream=False,
+                status=status,
+                booked=(
+                    savings is not None and _pending_savings is not None and 200 <= status < 300
+                ),
+            )
             # Book savings only after a confirmed 2xx (P0-1): failed or SDK-retried
             # upstream calls must not be counted as savings.
             if savings is not None and _pending_savings is not None and 200 <= status < 300:
@@ -729,6 +753,68 @@ def build_handler(
                 savings.record(_bt, _at, model=_m)
                 savings.maybe_flush(every=flush_every)
             self._relay(status, rhdrs, rbody, extras=extras)
+
+        def _emit_detail(
+            self,
+            *,
+            extras: dict[str, str],
+            store: Any,
+            body: dict[str, Any] | None,
+            model: str,
+            stream: bool,
+            status: int,
+            booked: bool,
+        ) -> None:
+            """Append one content-free per-request record to the wrap session's
+            ``sessions/<sid>.requests.jsonl`` (read by ``distil dissect``).
+            Records token accounting, per-block digest signatures (handle + kind
+            + size only — never content), and shadow/expand flags. Best-effort:
+            any failure is a debug log — bookkeeping must never break a request."""
+            try:
+                from . import ledger
+
+                if ledger.session_requests_path() is None:
+                    return  # not a wrap session; nothing to attribute the request to
+                from .learn import signature
+
+                blocks: list[dict[str, Any]] = []
+                for h in sorted(getattr(store, "handles", None) or ()):
+                    try:
+                        text = store.expand(h)
+                        blocks.append(
+                            {"h": h, "sig": signature(text), "tokens": _tokenizer.count(text)}
+                        )
+                    except Exception:  # noqa: BLE001 — one bad handle must not drop the record
+                        continue
+                overhead = 0
+                if isinstance(body, dict):
+                    for key in ("system", "tools"):
+                        val = body.get(key)
+                        if val:
+                            overhead += _tokenizer.count(
+                                val if isinstance(val, str) else json.dumps(val)
+                            )
+                rec = {
+                    "ts": time.time(),
+                    "model": model,
+                    "stream": stream,
+                    "status": status,
+                    "booked": booked,
+                    "mode": extras.get("x-distil-mode", "verbatim"),
+                    "compressible_tokens": int(extras.get("x-distil-compressible-tokens", 0) or 0),
+                    "tokens_saved": int(extras.get("x-distil-tokens-saved", 0) or 0),
+                    "overhead_tokens": overhead,
+                    "delta_refs": int(extras.get("x-distil-cache-refs", 0) or 0),
+                    "delta_tokens_saved": int(extras.get("x-distil-cache-tokens-saved", 0) or 0),
+                    "prefix_msgs": int(extras.get("x-distil-cache-prefix-msgs", 0) or 0),
+                    "shadow_sampled": extras.get("x-distil-shadow") == "sampled",
+                    "expanded": extras.get("x-distil-expanded") == "1",
+                    "output_shaping": extras.get("x-distil-output-shaping", ""),
+                    "blocks": blocks,
+                }
+                ledger.append_session_request(rec)
+            except Exception:  # noqa: BLE001 — bookkeeping must never break a request
+                log.debug("request-detail record failed", exc_info=True)
 
         def _spawn_shadow(
             self,
@@ -1059,6 +1145,41 @@ def wrap_run(
             marker.with_name(marker.name + ".exit").unlink(missing_ok=True)
         except OSError:
             pass  # marker is best-effort; never block the wrap over it
+
+    # Session manifest: what this wrap *is* (tool, argv, flags, billing) — the
+    # header `distil dissect` reads. Best-effort, like the marker above.
+    try:
+        from . import __version__ as _ver
+        from . import ledger as _ledger
+
+        try:
+            from .doctor import subscription_mode
+
+            _billing = "subscription" if subscription_mode() else "metered"
+        except Exception:  # noqa: BLE001 — billing detection is cosmetic
+            _billing = "unknown"
+        _ledger.write_session_manifest(
+            {
+                "sid": os.environ["DISTIL_SESSION"],
+                "tool": os.path.basename(command[0]) if command else "",
+                "argv": command,
+                "started_ts": time.time(),
+                "distil_version": _ver,
+                "billing": _billing,
+                "flags": {
+                    "upstream": upstream,
+                    "env_var": env_var,
+                    "lossless_only": lossless_only,
+                    "verbatim": verbatim,
+                    "shape_output": shape_output,
+                    "expand": expand,
+                    "session_delta": session_delta,
+                    "shadow_rate": shadow_rate,
+                },
+            }
+        )
+    except Exception:  # noqa: BLE001 — manifest is best-effort; never block the wrap
+        log.debug("session manifest write failed", exc_info=True)
 
     # Hot-swap (POSIX default): the proxy runs as a supervised subprocess on a
     # listener FD the wrap owns, so a `pipx upgrade` mid-session swaps in a

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -641,9 +641,11 @@ def build_handler(
             # re-query before answering), so expand-eligible requests stay on
             # the buffered path.
             want_stream = bool(body.get("stream")) or ":streamGenerateContent" in self.path
+            t_req = time.monotonic()  # upstream + relay latency (compression excluded)
             if want_stream and not _expand_should_intercept(expand, store, body):
                 from .streamrelay import stream_upstream
 
+                _usage_s: dict[str, int] = {}
                 with request_span(_span_model, self.path) as _span:
                     status_s, _rbody_opt = stream_upstream(
                         self,
@@ -654,6 +656,7 @@ def build_handler(
                         hop_by_hop=_HOP_BY_HOP,
                         extras=extras,
                         want_body=False,  # v3 shadow re-issues its own temp-0 calls; no need to buffer
+                        usage_sink=_usage_s,
                     )
                     set_result_attrs(
                         _span,
@@ -678,12 +681,15 @@ def build_handler(
                     body=body if isinstance(body, dict) else None,
                     model=_span_model,
                     stream=True,
+                    client_stream=want_stream,
                     status=status_s,
                     booked=(
                         savings is not None
                         and _pending_savings is not None
                         and 200 <= status_s < 300
                     ),
+                    duration_ms=int((time.monotonic() - t_req) * 1000),
+                    usage=_usage_s,
                 )
                 if shadow_sampled:
                     self._spawn_shadow(raw, headers, new_raw)
@@ -704,6 +710,7 @@ def build_handler(
 
             # Transparent expand loop: resolve any distil_expand tool calls against
             # the local store and re-query, invisibly, before returning to the agent.
+            _expanded_handles: list[str] = []
             if _expand_should_intercept(expand, store, body):
                 try:
                     resp_json = json.loads(rbody)
@@ -717,6 +724,7 @@ def build_handler(
                         return json.loads(rb)
 
                     def _on_signal(handle: str, original: str) -> None:
+                        _expanded_handles.append(handle)
                         record_signal(handle, original)  # content-free expand log
                         if _learn_stats is not None:  # learn the expanded signature
                             from .learn import signature
@@ -735,16 +743,27 @@ def build_handler(
             # signal on real traffic. Never blocks the client's response.
             if shadow_sampled:
                 self._spawn_shadow(raw, headers, new_raw)
+            _usage_b: dict[str, int] = {}
+            try:
+                from .streamrelay import scan_usage
+
+                _usage_b = scan_usage(rbody[:16384] + b"\n" + rbody[-16384:])
+            except Exception:  # noqa: BLE001 — usage capture is bookkeeping only
+                pass
             self._emit_detail(
                 extras=extras,
                 store=store,
                 body=body if isinstance(body, dict) else None,
                 model=_span_model,
                 stream=False,
+                client_stream=want_stream,
                 status=status,
                 booked=(
                     savings is not None and _pending_savings is not None and 200 <= status < 300
                 ),
+                duration_ms=int((time.monotonic() - t_req) * 1000),
+                usage=_usage_b,
+                expanded_handles=_expanded_handles,
             )
             # Book savings only after a confirmed 2xx (P0-1): failed or SDK-retried
             # upstream calls must not be counted as savings.
@@ -762,8 +781,12 @@ def build_handler(
             body: dict[str, Any] | None,
             model: str,
             stream: bool,
+            client_stream: bool,
             status: int,
             booked: bool,
+            duration_ms: int | None = None,
+            usage: dict[str, int] | None = None,
+            expanded_handles: list[str] | None = None,
         ) -> None:
             """Append one content-free per-request record to the wrap session's
             ``sessions/<sid>.requests.jsonl`` (read by ``distil dissect``).
@@ -798,8 +821,13 @@ def build_handler(
                     "ts": time.time(),
                     "model": model,
                     "stream": stream,
+                    "client_stream": client_stream,
                     "status": status,
                     "booked": booked,
+                    "duration_ms": duration_ms,
+                    "usage_input_tokens": (usage or {}).get("input_tokens"),
+                    "usage_output_tokens": (usage or {}).get("output_tokens"),
+                    "expanded_handles": expanded_handles or [],
                     "mode": extras.get("x-distil-mode", "verbatim"),
                     "compressible_tokens": int(extras.get("x-distil-compressible-tokens", 0) or 0),
                     "tokens_saved": int(extras.get("x-distil-tokens-saved", 0) or 0),

--- a/distil/streamrelay.py
+++ b/distil/streamrelay.py
@@ -12,11 +12,37 @@ Content-Length (the SSE case); requires the handler to speak HTTP/1.1.
 from __future__ import annotations
 
 import json
+import re
 import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler
 
 _CHUNK = 8192
+
+# Billed-usage capture. Works on a plain JSON response and on SSE bytes alike:
+# input_tokens appears once near the start (message_start), output_tokens is
+# cumulative so the LAST occurrence (final message_delta) is the total.
+_USAGE_IN = re.compile(rb'"input_tokens"\s*:\s*(\d+)')
+_USAGE_OUT = re.compile(rb'"output_tokens"\s*:\s*(\d+)')
+_USAGE_SCAN_CAP = 16384  # head/tail window — usage lives at the edges of a stream
+
+
+def scan_usage(blob: bytes) -> dict[str, int]:
+    """Best-effort billed-token extraction from a response body (JSON or SSE).
+
+    Returns any of ``{"input_tokens": n, "output_tokens": m}`` found — empty
+    dict when the body carries no usage (error payloads, non-messages routes).
+    """
+    out: dict[str, int] = {}
+    m = _USAGE_IN.search(blob)
+    if m:
+        out["input_tokens"] = int(m.group(1))
+    last = None
+    for last in _USAGE_OUT.finditer(blob):  # noqa: B007 — want the final (cumulative) one
+        pass
+    if last is not None:
+        out["output_tokens"] = int(last.group(1))
+    return out
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -48,8 +74,13 @@ def stream_upstream(
     hop_by_hop: frozenset[str],
     extras: dict[str, str] | None = None,
     want_body: bool = False,
+    usage_sink: dict[str, int] | None = None,
 ) -> tuple[int, bytes | None]:
     """Send the request and relay the response to *handler* incrementally.
+
+    When ``usage_sink`` is given, the first/last ``_USAGE_SCAN_CAP`` bytes of
+    the relayed stream are scanned for billed usage after relay completes and
+    the result is merged into the dict — without buffering the full body.
 
     When ``want_body`` is set, returns the complete response body (buffered as
     it streamed) so callers can run post-hoc accounting (shadow sampling); when
@@ -116,6 +147,8 @@ def stream_upstream(
         handler.end_headers()
 
         buf = bytearray()
+        head = bytearray()
+        tail = bytearray()
         try:
             while True:
                 # read1: return as soon as ANY bytes arrive (at most one socket
@@ -126,6 +159,12 @@ def stream_upstream(
                     break
                 if want_body:
                     buf += chunk
+                if usage_sink is not None:
+                    if len(head) < _USAGE_SCAN_CAP:
+                        head += chunk
+                    tail += chunk
+                    if len(tail) > _USAGE_SCAN_CAP:
+                        del tail[: len(tail) - _USAGE_SCAN_CAP]
                 if chunked:
                     handler.wfile.write(f"{len(chunk):X}\r\n".encode() + chunk + b"\r\n")
                 else:
@@ -139,4 +178,9 @@ def stream_upstream(
             # can be appended once bytes have flowed — drop the connection but
             # keep what streamed for accounting.
             handler.close_connection = True
+        if usage_sink is not None:
+            try:
+                usage_sink.update(scan_usage(bytes(head) + b"\n" + bytes(tail)))
+            except Exception:  # noqa: BLE001 — usage capture must never break the relay
+                pass
         return resp.status, (bytes(buf) if want_body else None)

--- a/distil/transcripts/__init__.py
+++ b/distil/transcripts/__init__.py
@@ -1,0 +1,58 @@
+"""Agent transcript adapters — see ``base.py`` for the contract.
+
+The registry key is the executable basename the wrap manifest records as
+``tool``. Adding an agent is: write one adapter module, add one line here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import ToolCall, ToolResult, Transcript, TranscriptAdapter, UserTurn
+from .claude_code import ClaudeCodeAdapter
+
+ADAPTERS: dict[str, TranscriptAdapter] = {
+    "claude": ClaudeCodeAdapter(),
+}
+
+__all__ = [
+    "ADAPTERS",
+    "ToolCall",
+    "ToolResult",
+    "Transcript",
+    "TranscriptAdapter",
+    "UserTurn",
+    "find_transcript",
+]
+
+
+def find_transcript(
+    tool: str,
+    window: tuple[float, float],
+    cwd: str | None = None,
+    path: str | Path | None = None,
+) -> Transcript | None:
+    """Locate and load the agent transcript matching a wrap session.
+
+    ``path`` short-circuits discovery (the user pointed at a file); otherwise
+    the adapter registered for *tool* searches, falling back to every adapter
+    when the tool is unknown (old sessions without a manifest).
+    """
+    if path is not None:
+        p = Path(path).expanduser()
+        adapter = ADAPTERS.get(tool)
+        candidates = [adapter] if adapter is not None else list(ADAPTERS.values())
+        for a in candidates:
+            tr = a.load(p)
+            if tr.turns or tr.tool_results:
+                return tr
+        return None
+    adapters = (
+        [ADAPTERS[tool]] if tool in ADAPTERS else list(ADAPTERS.values())
+    )
+    for a in adapters:
+        for candidate in a.discover(window, cwd)[:3]:
+            tr = a.load(candidate)
+            if tr.turns or tr.tool_results:
+                return tr
+    return None

--- a/distil/transcripts/base.py
+++ b/distil/transcripts/base.py
@@ -1,0 +1,89 @@
+"""Agent-transcript adapter contract.
+
+distil is agent-generic: the wrap proxies any base-url-honoring tool, and the
+dissect report must stay useful for all of them. Correlating a wrap session
+with the *agent's own conversation log* is therefore an adapter concern — one
+small module per agent, all normalizing into the model below.
+
+To add support for a new agent (codex, gemini, aider, ...):
+
+1. Create ``distil/transcripts/<agent>.py`` with a class implementing
+   :class:`TranscriptAdapter` — two methods, no base class required.
+2. Normalize into :class:`Transcript`: human turns, tool calls, tool results.
+   Timestamps are epoch seconds; ``text`` fields carry the agent's original
+   content (read at render time only — distil never copies it anywhere).
+3. Register it in ``distil/transcripts/__init__.py`` under the executable
+   name the wrap manifest records (``tool``), e.g. ``"codex"``.
+
+That's the whole surface: discovery (find candidate log files for a time
+window) and load (parse one). Everything downstream — fold naming, unused-tool
+detection, re-fetch analysis, per-turn cost — is adapter-independent and comes
+for free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+@dataclass
+class UserTurn:
+    """One real human prompt (not tool feedback, not a subagent's input)."""
+
+    index: int
+    ts: float
+    text: str  # trimmed to a label-sized excerpt by the adapter
+
+
+@dataclass
+class ToolCall:
+    """The agent invoking a tool."""
+
+    ts: float
+    name: str
+    call_id: str = ""
+    turn: int = 0  # index of the human turn this happened under
+
+
+@dataclass
+class ToolResult:
+    """A tool's output entering the conversation (what distil may later fold)."""
+
+    ts: float
+    text: str
+    tool: str = ""  # resolved tool name ("" when the agent's log doesn't say)
+    turn: int = 0
+
+
+@dataclass
+class Transcript:
+    """A wrap-session-shaped view of one agent conversation log."""
+
+    agent: str  # adapter name, e.g. "claude"
+    path: Path
+    label: str = ""  # human title if the agent records one
+    cwd: str = ""
+    started: float = 0.0
+    ended: float = 0.0
+    turns: list[UserTurn] = field(default_factory=list)
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_results: list[ToolResult] = field(default_factory=list)
+
+
+class TranscriptAdapter(Protocol):
+    """What an agent integration must provide. Keep both methods tolerant:
+    a malformed line is skipped, never raised — correlation is best-effort."""
+
+    name: str  # must equal the wrap manifest's "tool" (executable basename)
+
+    def discover(self, window: tuple[float, float], cwd: str | None) -> list[Path]:
+        """Candidate transcript files whose activity overlaps *window*,
+        best match first. ``cwd`` is the wrap session's working directory
+        when known — use it to narrow the search."""
+        ...
+
+    def load(self, path: Path) -> Transcript:
+        """Parse one transcript file into the normalized model."""
+        ...

--- a/distil/transcripts/claude_code.py
+++ b/distil/transcripts/claude_code.py
@@ -1,0 +1,170 @@
+"""Claude Code transcript adapter.
+
+Claude Code writes one JSONL file per session under
+``~/.claude/projects/<cwd-slug>/<session-uuid>.jsonl``. Lines carry a ``type``
+("user", "assistant", "ai-title", ...); user/assistant lines hold an
+Anthropic-shaped ``message`` plus ISO ``timestamp``, ``cwd`` and
+``isSidechain``. Human prompts are user lines whose ``origin.kind`` is
+"human" (tool results also arrive as user lines — they are not turns).
+Subagent (sidechain) traffic lives in the same file and is kept: the wrap
+proxied those requests too.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .base import ToolCall, ToolResult, Transcript, UserTurn
+
+_EXCERPT = 80  # turn-label length
+
+
+def _epoch(iso: str | None) -> float:
+    if not iso:
+        return 0.0
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _blocks(content: Any) -> list[dict[str, Any]]:
+    return [b for b in content if isinstance(b, dict)] if isinstance(content, list) else []
+
+
+def _block_text(content: Any) -> str:
+    """Flatten a message/tool_result content field to text."""
+    if isinstance(content, str):
+        return content
+    return "\n".join(
+        str(b.get("text", "")) for b in _blocks(content) if b.get("type") == "text"
+    )
+
+
+class ClaudeCodeAdapter:
+    name = "claude"
+
+    def _root(self) -> Path:
+        return Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))) / "projects"
+
+    def discover(self, window: tuple[float, float], cwd: str | None) -> list[Path]:
+        root = self._root()
+        dirs: list[Path] = []
+        if cwd:
+            slug = cwd.replace("/", "-").replace("\\", "-").replace("_", "-").replace(".", "-")
+            cand = root / slug
+            if cand.is_dir():
+                dirs.append(cand)
+        if not dirs:
+            try:
+                dirs = [p for p in root.iterdir() if p.is_dir()]
+            except OSError:
+                return []
+        lo, hi = window
+        scored: list[tuple[float, Path]] = []
+        for d in dirs:
+            try:
+                files = list(d.glob("*.jsonl"))
+            except OSError:
+                continue
+            for f in files:
+                try:
+                    mtime = f.stat().st_mtime
+                except OSError:
+                    continue
+                # Cheap overlap filter: the file must have been written into
+                # after the session started and begun before it ended.
+                if mtime < lo - 60:
+                    continue
+                first_ts = self._first_ts(f)
+                if first_ts and first_ts > hi + 60:
+                    continue
+                overlap = min(hi, mtime) - max(lo, first_ts or lo)
+                scored.append((overlap, f))
+        return [f for _o, f in sorted(scored, key=lambda t: -t[0])]
+
+    @staticmethod
+    def _first_ts(path: Path) -> float:
+        try:
+            with path.open(encoding="utf-8") as fh:
+                for _ in range(50):
+                    line = fh.readline()
+                    if not line:
+                        break
+                    try:
+                        ts = _epoch(json.loads(line).get("timestamp"))
+                    except json.JSONDecodeError:
+                        continue
+                    if ts:
+                        return ts
+        except OSError:
+            pass
+        return 0.0
+
+    def load(self, path: Path) -> Transcript:
+        tr = Transcript(agent=self.name, path=path)
+        call_names: dict[str, str] = {}  # tool_use_id -> tool name
+        turn = 0
+        try:
+            fh = path.open(encoding="utf-8")
+        except OSError:
+            return tr
+        with fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                kind = rec.get("type")
+                if kind == "ai-title":
+                    tr.label = str(rec.get("aiTitle") or tr.label)
+                    continue
+                if kind not in ("user", "assistant"):
+                    continue
+                ts = _epoch(rec.get("timestamp"))
+                if ts:
+                    tr.started = min(tr.started or ts, ts)
+                    tr.ended = max(tr.ended, ts)
+                if not tr.cwd and rec.get("cwd"):
+                    tr.cwd = str(rec["cwd"])
+                msg = rec.get("message") or {}
+                content = msg.get("content")
+                if kind == "assistant":
+                    for b in _blocks(content):
+                        if b.get("type") == "tool_use":
+                            name = str(b.get("name") or "")
+                            call_id = str(b.get("id") or "")
+                            call_names[call_id] = name
+                            tr.tool_calls.append(
+                                ToolCall(ts=ts, name=name, call_id=call_id, turn=turn)
+                            )
+                    continue
+                # user line: a human turn, tool results, or subagent input.
+                origin = rec.get("origin")
+                is_human = isinstance(origin, dict) and origin.get("kind") == "human"
+                if is_human and not rec.get("isSidechain"):
+                    text = _block_text(content).strip()
+                    if text:
+                        turn += 1
+                        tr.turns.append(
+                            UserTurn(index=turn, ts=ts, text=text[:_EXCERPT])
+                        )
+                for b in _blocks(content):
+                    if b.get("type") == "tool_result":
+                        text = _block_text(b.get("content")).strip()
+                        if text:
+                            tr.tool_results.append(
+                                ToolResult(
+                                    ts=ts,
+                                    text=text,
+                                    tool=call_names.get(str(b.get("tool_use_id") or ""), ""),
+                                    turn=turn,
+                                )
+                            )
+        return tr

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -33,14 +34,37 @@ _LOG_LINES = "\n".join(
 )
 
 
+_UPSTREAM_JSON = json.dumps(
+    {
+        "id": "msg_test",
+        "content": [{"type": "text", "text": "ok"}],
+        "usage": {"input_tokens": 4321, "output_tokens": 87},
+    }
+).encode()
+
+_UPSTREAM_SSE = (
+    b'event: message_start\ndata: {"type":"message_start","message":'
+    b'{"usage":{"input_tokens":1234,"output_tokens":1}}}\n\n'
+    b'event: message_delta\ndata: {"type":"message_delta","usage":{"output_tokens":55}}\n\n'
+    b"event: message_stop\ndata: {}\n\n"
+)
+
+
 class _EchoHandler(BaseHTTPRequestHandler):
+    """Stub upstream: SSE when the request asked to stream, JSON otherwise —
+    both carrying known usage figures so capture can be asserted exactly."""
+
     def do_POST(self) -> None:  # noqa: N802 — http.server API
         body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        streaming = b'"stream": true' in body or b'"stream":true' in body
+        payload = _UPSTREAM_SSE if streaming else _UPSTREAM_JSON
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
+        self.send_header(
+            "Content-Type", "text/event-stream" if streaming else "application/json"
+        )
+        self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
-        self.wfile.write(body)
+        self.wfile.write(payload)
 
     def log_message(self, *args: Any) -> None:  # quiet
         pass
@@ -114,6 +138,34 @@ class TestRequestDetailLogging:
         assert set(blk) == {"h", "sig", "tokens"} and len(blk["h"]) == 8
         assert ":" in blk["sig"] and blk["tokens"] > 0
         assert "handle=" not in json.dumps(rec), "detail records must stay content-free"
+        assert rec["client_stream"] is False
+        assert rec["duration_ms"] is not None and rec["duration_ms"] >= 0
+        assert rec["usage_input_tokens"] == 4321  # billed usage from the JSON response
+        assert rec["usage_output_tokens"] == 87
+        assert rec["expanded_handles"] == []
+
+    def test_streamed_request_captures_sse_usage(
+        self, servers: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.setenv("DISTIL_SESSION", "s101-1")
+        payload = _compressible_payload() | {"stream": True}
+        with _post(servers, payload) as resp:
+            assert resp.status == 200
+            resp.read()
+        path = session_requests_path("s101-1")
+        assert path is not None
+        # The detail record lands after the last relayed byte — poll briefly.
+        for _ in range(100):
+            if path.exists():
+                break
+            time.sleep(0.02)
+        assert path.exists()
+        rec = json.loads(path.read_text().splitlines()[0])
+        assert rec["stream"] is True and rec["client_stream"] is True
+        assert rec["usage_input_tokens"] == 1234  # from SSE message_start
+        assert rec["usage_output_tokens"] == 55  # last (cumulative) message_delta
+        assert rec["duration_ms"] is not None
 
     def test_no_session_no_record(
         self, servers: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -184,20 +236,27 @@ def _seed_state(home: Path) -> None:
                   "upstream": "https://api.anthropic.com", "env_var": "ANTHROPIC_BASE_URL"},
     }))
     details = [
-        {"ts": 1000.0, "model": "m-big", "stream": True, "status": 200, "booked": True,
+        {"ts": 1000.0, "model": "m-big", "stream": True, "client_stream": True,
+         "status": 200, "booked": True, "duration_ms": 4000,
+         "usage_input_tokens": 2100, "usage_output_tokens": 300, "expanded_handles": [],
          "mode": "digest", "compressible_tokens": 5000, "tokens_saved": 3500,
          "overhead_tokens": 700, "delta_refs": 0, "delta_tokens_saved": 0,
          "prefix_msgs": 0, "shadow_sampled": True, "expanded": False,
          "output_shaping": "",
          "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000},
                     {"h": "bbbb2222", "sig": "prose:m", "tokens": 900}]},
-        {"ts": 1600.0, "model": "m-small", "stream": True, "status": 200, "booked": True,
+        {"ts": 1600.0, "model": "m-small", "stream": False, "client_stream": True,
+         "status": 200, "booked": True, "duration_ms": 9000,
+         "usage_input_tokens": 1200, "usage_output_tokens": 150,
+         "expanded_handles": ["aaaa1111"],
          "mode": "digest", "compressible_tokens": 2000, "tokens_saved": 1200,
          "overhead_tokens": 500, "delta_refs": 3, "delta_tokens_saved": 800,
          "prefix_msgs": 4, "shadow_sampled": False, "expanded": True,
          "output_shaping": "",
          "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000}]},
-        {"ts": 1700.0, "model": "m-small", "stream": False, "status": 529, "booked": False,
+        {"ts": 1700.0, "model": "m-small", "stream": False, "client_stream": False,
+         "status": 529, "booked": False, "duration_ms": 500,
+         "usage_input_tokens": None, "usage_output_tokens": None, "expanded_handles": [],
          "mode": "verbatim", "compressible_tokens": 0, "tokens_saved": 0,
          "overhead_tokens": 500, "delta_refs": 0, "delta_tokens_saved": 0,
          "prefix_msgs": 0, "shadow_sampled": False, "expanded": False,
@@ -327,6 +386,165 @@ class TestCli:
     def test_unknown_session_exits_2(self, capsys: pytest.CaptureFixture[str]) -> None:
         assert main(["dissect", "zzz"]) == 2
         assert "no session matches" in capsys.readouterr().out
+
+
+class TestInsights:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    def test_mechanism_decomposition(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.tokens_saved_total == 4700
+        assert d.delta_tokens_saved == 800 and d.digest_saved == 3900
+
+    def test_overhead_tax(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.overhead_tokens_total == 1700
+        # 1700 overhead vs 7000 compressible -> 1700/8700
+        assert d.overhead_share == pytest.approx(19.54, abs=0.01)
+
+    def test_churn(self) -> None:
+        d = dz.dissect("s200-1")
+        # aaaa1111 folded twice -> 2000 tokens re-digested; no block hit 3+ folds
+        assert d.churn_tokens == 2000 and d.churned_blocks == 0
+
+    def test_usage_and_calibration(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.usage_input_total == 3300 and d.usage_output_total == 450
+        assert d.usage_requests == 2
+        est, billed = d.calibration()
+        # r1: 700 + (5000-3500) = 2200; r2: 500 + (2000-1200) = 1300
+        assert est == 3500 and billed == 3300
+
+    def test_headroom_multiplier(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.headroom_multiplier == pytest.approx(10000 / 3900)
+
+    def test_latency_by_path_and_forced_buffering(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.forced_buffered == 1
+        lat = dict((k, (n, ms)) for k, n, ms in d.latency_by_path())
+        assert lat["streamed"] == (1, 4000)
+        assert lat["buffered (forced by expand)"] == (1, 9000)
+        assert lat["buffered"] == (1, 500)
+
+    def test_expansion_regret(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.expansion_regret() == [("log:l", 1, 1)]
+
+    def test_no_anomalies_on_healthy_session(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.anomalies(dz.list_sessions()) == []
+
+    def test_report_renders_insights(self) -> None:
+        d = dz.dissect("s200-1")
+        text = dz.render_text(d, color=False, peers=dz.list_sessions())
+        assert "digest folds 3.90k (83%)" in text
+        assert "20% of everything sent" in text
+        assert "2.00k tokens re-digested" in text
+        assert "heuristic estimate 3.50k vs billed 3.30k" in text
+        assert "~2.6x" in text  # flat-rate headroom
+        assert "buffered (forced by expand) 1 req @ 9.0s" in text
+        assert "regret: log:l blocks pulled back 1/1" in text
+        page = dz.render_html(d, peers=dz.list_sessions())
+        assert "Mechanism" in page and "stretched ~<b>2.6x</b>" in page
+        payload = dz.to_json(d, dz.list_sessions())
+        assert payload["insights"]["churn"]["tokens"] == 2000
+        assert payload["insights"]["usage"]["calibration"] == {
+            "estimated": 3500,
+            "billed": 3300,
+        }
+        assert payload["insights"]["anomalies"] == []
+
+
+class TestAnomalies:
+    def _session(self, home: Path, requests: list[dict[str, Any]], **manifest: Any) -> None:
+        sess = home / "sessions"
+        sess.mkdir(exist_ok=True)
+        man = {
+            "sid": "s900-1", "tool": "claude", "argv": ["claude"], "started_ts": 1.0,
+            "distil_version": "1.15.0", "billing": "subscription",
+            "flags": {"expand": False, "session_delta": False, "shadow_rate": 0.0,
+                      "lossless_only": False},
+        }
+        man["flags"].update(manifest.pop("flags", {}))
+        man.update(manifest)
+        (sess / "s900-1.json").write_text(json.dumps(man))
+        (sess / "s900-1.requests.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in requests) + "\n"
+        )
+
+    @staticmethod
+    def _req(**over: Any) -> dict[str, Any]:
+        base = {
+            "ts": 10.0, "model": "m", "stream": True, "client_stream": True,
+            "status": 200, "booked": True, "duration_ms": 100,
+            "usage_input_tokens": None, "usage_output_tokens": None,
+            "expanded_handles": [], "mode": "digest", "compressible_tokens": 100,
+            "tokens_saved": 50, "overhead_tokens": 10, "delta_refs": 0,
+            "delta_tokens_saved": 0, "prefix_msgs": 0, "shadow_sampled": False,
+            "expanded": False, "output_shaping": "",
+            "blocks": [{"h": "cccc3333", "sig": "log:m", "tokens": 40}],
+        }
+        base.update(over)
+        return base
+
+    def test_silent_shadow_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        self._session(tmp_path, [self._req() for _ in range(12)], flags={"shadow_rate": 0.5})
+        warnings = dz.dissect("s900-1").anomalies()
+        assert any("shadow may be silently failing" in w for w in warnings)
+
+    def test_expand_never_intercepted_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        # expand on, folds happening, yet every request streamed straight through.
+        self._session(tmp_path, [self._req() for _ in range(12)], flags={"expand": True})
+        warnings = dz.dissect("s900-1").anomalies()
+        assert any("could never be intercepted" in w for w in warnings)
+
+    def test_unbooked_spike_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        reqs = [self._req() for _ in range(6)] + [
+            self._req(booked=False, status=529) for _ in range(4)
+        ]
+        self._session(tmp_path, reqs)
+        warnings = dz.dissect("s900-1").anomalies()
+        assert any("not booked" in w for w in warnings)
+
+    def test_calibration_drift_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        # estimate 10+ (100-50) = 60 vs billed 20 -> ratio 3.0
+        self._session(tmp_path, [self._req(usage_input_tokens=20)])
+        warnings = dz.dissect("s900-1").anomalies()
+        assert any("off by >50% vs billed" in w for w in warnings)
+
+
+class TestScanUsage:
+    def test_json_body(self) -> None:
+        from distil.streamrelay import scan_usage
+
+        assert scan_usage(_UPSTREAM_JSON) == {"input_tokens": 4321, "output_tokens": 87}
+
+    def test_sse_body_takes_last_output(self) -> None:
+        from distil.streamrelay import scan_usage
+
+        assert scan_usage(_UPSTREAM_SSE) == {"input_tokens": 1234, "output_tokens": 55}
+
+    def test_no_usage(self) -> None:
+        from distil.streamrelay import scan_usage
+
+        assert scan_usage(b'{"error": "overloaded"}') == {}
 
 
 class TestTolerantReader:

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -497,6 +497,11 @@ class TestToolsAndCharts:
         assert "request 2 · m-small · overhead 500 · sent 800 · saved 1,200" in page
         assert "data table" in page  # accessible table view of the timeline
         assert "Request composition" in page
+        # Plain-English help layer: section descriptions + hover titles on tiles.
+        assert "for what the term means" in page
+        assert 'title="Tokens distil avoided sending by replacing bulky content' in page
+        assert "class=\"desc\"" in page
+        assert "re-described to the model on every request" in page
 
     def test_json_has_tool_breakdown(self) -> None:
         payload = dz.to_json(dz.dissect("s200-1"))

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -636,6 +636,39 @@ class TestAnomalies:
         assert any("off by >50% vs billed" in w for w in warnings)
 
 
+class TestHeadlines:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    def test_layman_story(self) -> None:
+        heads = dict(dz.dissect("s200-1").headlines())
+        assert "distil kept 6.10k of 10.00k input tokens off the wire (61%)" in heads
+        assert "mostly by summarizing large logs" in heads[
+            "distil kept 6.10k of 10.00k input tokens off the wire (61%)"
+        ]
+        out_head = "The model wrote 450 output tokens (12% of billed traffic)"
+        assert out_head in heads
+        # Subscription session -> the output-shaping gate is explained.
+        assert "never shortened on a subscription" in heads[out_head]
+        assert any("resent and re-summarized" in h for h in heads)
+        assert any("spot-checked" in h for h in heads)
+
+    def test_story_leads_the_renderers(self) -> None:
+        d = dz.dissect("s200-1")
+        text = dz.render_text(d, color=False)
+        assert text.index("what happened") < text.index("savings (input tokens")
+        page = dz.render_html(d)
+        assert page.index("What happened") < page.index("Per model")
+        payload = dz.to_json(d)
+        assert payload["headlines"][0]["headline"].startswith("distil kept 6.10k")
+
+    def test_no_story_without_data(self, tmp_path: Path) -> None:
+        assert dz.dissect("s999-0").headlines() == []
+
+
 class TestScanUsage:
     def test_json_body(self) -> None:
         from distil.streamrelay import scan_usage

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -673,6 +674,54 @@ class TestHeadlines:
 
     def test_no_story_without_data(self, tmp_path: Path) -> None:
         assert dz.dissect("s999-0").headlines() == []
+
+
+class TestServePortal:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    @pytest.fixture()
+    def portal(self) -> Any:
+        server = dz.make_server("127.0.0.1", 0)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+        server.shutdown()
+
+    def _get(self, url: str) -> tuple[int, str]:
+        try:
+            with urllib.request.urlopen(url) as resp:
+                return resp.status, resp.read().decode()
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read().decode()
+
+    def test_index_lists_sessions_as_links(self, portal: str) -> None:
+        status, body = self._get(portal + "/")
+        assert status == 200
+        assert "s200-1" in body and "s300-9" in body and "codex" in body
+        assert "/session/s200-1" in body  # clickable rows
+
+    def test_session_report_served_live(self, portal: str) -> None:
+        status, body = self._get(portal + "/session/s200-1")
+        assert status == 200
+        assert "What happened" in body and "61.0%" in body
+        assert "← sessions" in body  # back link injected before the title
+
+    def test_prefix_and_latest_resolve(self, portal: str) -> None:
+        assert self._get(portal + "/session/s200")[0] == 200
+        status, body = self._get(portal + "/json/latest")
+        assert status == 200
+        assert json.loads(body)["session"] == "s300-9"
+
+    def test_unknown_session_404(self, portal: str) -> None:
+        assert self._get(portal + "/session/zzz")[0] == 404
+        assert self._get(portal + "/nope")[0] == 404
+
+    def test_traversal_is_not_a_session(self, portal: str) -> None:
+        status, _ = self._get(portal + "/session/..%2F..%2Fetc%2Fpasswd")
+        assert status == 404
 
 
 class TestScanUsage:

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -35,6 +35,52 @@ _LOG_LINES = "\n".join(
 )
 
 
+_BLOB = "\n".join(f"[worker-{i}] heartbeat ok, queue depth {i * 7}, no errors" for i in range(8))
+
+
+def _iso(ts: float) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _write_transcript(claude_dir: Path, cwd_slug: str = "-tmp-proj") -> Path:
+    """A minimal Claude-Code-shaped transcript matching the seeded session
+    (s200-1: requests at ts 1000/1600/1700, restore blob _BLOB)."""
+    proj = claude_dir / "projects" / cwd_slug
+    proj.mkdir(parents=True, exist_ok=True)
+    lines = [
+        {"type": "ai-title", "aiTitle": "fix the flaky tests"},
+        {"type": "user", "timestamp": _iso(900), "cwd": "/tmp/proj",
+         "origin": {"kind": "human"},
+         "message": {"role": "user", "content": "please run the tests"}},
+        {"type": "assistant", "timestamp": _iso(950),
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu1", "name": "bash", "input": {}}]}},
+        {"type": "user", "timestamp": _iso(990),
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu1",
+              "content": [{"type": "text", "text": "$ make test\n" + _BLOB}]}]}},
+        # a sidechain human line must NOT count as a turn
+        {"type": "user", "timestamp": _iso(1200), "isSidechain": True,
+         "origin": {"kind": "human"},
+         "message": {"role": "user", "content": "subagent task prompt"}},
+        {"type": "user", "timestamp": _iso(1500), "origin": {"kind": "human"},
+         "message": {"role": "user", "content": [{"type": "text", "text": "now fix the bug"}]}},
+        {"type": "assistant", "timestamp": _iso(1550),
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu2", "name": "Read", "input": {}}]}},
+        # the agent re-fetched the same content after it had been folded
+        {"type": "user", "timestamp": _iso(1560),
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu2", "content": _BLOB}]}},
+        {"type": "not json line skipped below"},
+    ]
+    path = proj / "abc-session.jsonl"
+    path.write_text("\n".join(json.dumps(rec) for rec in lines) + "\nnot json\n")
+    return path
+
+
 _UPSTREAM_JSON = json.dumps(
     {
         "id": "msg_test",
@@ -231,6 +277,7 @@ def _seed_state(home: Path) -> None:
     sess.mkdir()
     (sess / "s200-1.json").write_text(json.dumps({
         "sid": "s200-1", "tool": "codex", "argv": ["codex", "--full-auto"],
+        "cwd": "/tmp/proj",
         "started_ts": 990.0, "distil_version": "1.15.0", "billing": "subscription",
         "flags": {"expand": True, "session_delta": True, "shadow_rate": 0.1,
                   "lossless_only": False, "verbatim": False, "shape_output": "off",
@@ -277,7 +324,7 @@ def _seed_state(home: Path) -> None:
     (sess / "s300-9.exit").write_text("rc=0")
     restore = home / "restore"
     restore.mkdir()
-    (restore / "aaaa1111").write_text("original log content")
+    (restore / "aaaa1111").write_text(_BLOB)
     (home / "shadow.jsonl").write_text(
         json.dumps({"ts": 1500.0, "equivalent": True}) + "\n"
         + json.dumps({"ts": 999999.0, "equivalent": False}) + "\n"
@@ -722,6 +769,133 @@ class TestServePortal:
     def test_traversal_is_not_a_session(self, portal: str) -> None:
         status, _ = self._get(portal + "/session/..%2F..%2Fetc%2Fpasswd")
         assert status == 404
+
+
+class TestTranscriptCorrelation:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path / "distil"))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        (tmp_path / "distil").mkdir()
+        _seed_state(tmp_path / "distil")
+        self.transcript = _write_transcript(tmp_path / "claude")
+
+    def test_adapter_parses_the_shape(self) -> None:
+        from distil.transcripts.claude_code import ClaudeCodeAdapter
+
+        tr = ClaudeCodeAdapter().load(self.transcript)
+        assert tr.label == "fix the flaky tests"
+        assert [t.text for t in tr.turns] == ["please run the tests", "now fix the bug"]
+        assert [c.name for c in tr.tool_calls] == ["bash", "Read"]
+        assert len(tr.tool_results) == 2
+        assert tr.tool_results[0].tool == "bash"  # resolved via tool_use_id
+        assert tr.tool_results[1].turn == 2  # attributed to the second turn
+
+    def test_discovery_by_window_and_cwd(self) -> None:
+        from distil.transcripts import find_transcript
+
+        tr = find_transcript("claude", (900.0, 1800.0), cwd="/tmp/proj")
+        assert tr is not None and tr.path == self.transcript
+        # A window that ends before the transcript's first event can't match.
+        assert find_transcript("claude", (100.0, 200.0), cwd="/tmp/proj") is None
+
+    def test_registry_is_the_extension_point(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Proof of the contract: a new agent = one adapter + one registry entry."""
+        from distil import transcripts
+        from distil.transcripts.base import ToolResult, Transcript, UserTurn
+
+        class ToyAdapter:
+            name = "toyagent"
+
+            def discover(self, window: Any, cwd: Any) -> list[Path]:
+                return [Path("/toy.log")]
+
+            def load(self, path: Path) -> Transcript:
+                return Transcript(
+                    agent=self.name, path=path, label="toy session",
+                    turns=[UserTurn(index=1, ts=1.0, text="hi")],
+                    tool_results=[ToolResult(ts=2.0, text="x" * 50, tool="toytool", turn=1)],
+                )
+
+        monkeypatch.setitem(transcripts.ADAPTERS, "toyagent", ToyAdapter())
+        tr = transcripts.find_transcript("toyagent", (0.0, 10.0))
+        assert tr is not None and tr.agent == "toyagent" and tr.label == "toy session"
+
+    def _corr(self) -> Any:
+        from distil.correlate import correlate
+        from distil.transcripts import find_transcript
+
+        d = dz.dissect("s200-1")
+        tr = find_transcript("claude", (d.started, d.ended), cwd="/tmp/proj")
+        assert tr is not None
+        return d, correlate(d, tr)
+
+    def test_fold_sources_named_by_content(self) -> None:
+        _d, corr = self._corr()
+        assert len(corr.fold_sources) == 1  # bbbb2222's blob is expired -> unnamed
+        src = corr.fold_sources[0]
+        assert src.handle == "aaaa1111" and src.tool == "bash" and src.turn == 1
+        assert src.refetches == 2  # seen again at turn 2 -> re-fetch after fold
+        assert corr.refetched and corr.refetched[0].handle == "aaaa1111"
+        assert corr.unnamed_blocks == 1
+
+    def test_unused_tools_defined_minus_invoked(self) -> None:
+        _d, corr = self._corr()
+        assert corr.tools_defined == 2 and corr.tools_invoked == 1
+        assert corr.unused_tools == [("mcp__gmail__search", 300)]
+        assert corr.unused_tokens_per_request == 300
+
+    def test_turn_cost_attribution(self) -> None:
+        _d, corr = self._corr()
+        by_index = {t.index: t for t in corr.turns}
+        assert by_index[1].requests == 1 and by_index[1].baseline_tokens == 5700
+        assert by_index[2].requests == 2 and by_index[2].baseline_tokens == 3000
+        assert corr.turns[0].index == 1  # costliest first
+
+    def test_renderers_carry_the_correlation(self) -> None:
+        d, corr = self._corr()
+        text = dz.render_text(d, color=False, corr=corr)
+        assert "conversation correlation (claude transcript: fix the flaky tests)" in text
+        assert "bash output" in text and "unused tools (1/2 defined" in text
+        assert "re-fetched after fold" in text
+        assert 'turn 1: "please run the tests"' in text
+        page = dz.render_html(d, corr=corr)
+        assert "Conversation correlation" in page and "never invoked" in page
+        assert "mcp__gmail__search" in page and "reappeared in 2 separate tool results" in page
+        payload = dz.to_json(d, corr=corr)
+        assert payload["correlation"]["tools"]["unused"] == [
+            {"name": "mcp__gmail__search", "tokens_per_request": 300}
+        ]
+        assert payload["correlation"]["fold_sources"][0]["tool"] == "bash"
+
+    def test_cli_transcript_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect", "s200", "--no-color", "--transcript"]) == 0
+        out = capsys.readouterr().out
+        assert "conversation correlation" in out
+
+    def test_cli_no_transcript_found_is_a_note(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/nonexistent")
+        assert main(["dissect", "s200", "--no-color", "--transcript"]) == 0
+        out = capsys.readouterr().out
+        assert "no matching agent transcript found" in out
+
+    def test_portal_correlation_toggle(self) -> None:
+        server = dz.make_server("127.0.0.1", 0)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        try:
+            with urllib.request.urlopen(base + "/session/s200-1") as resp:
+                plain = resp.read().decode()
+            assert "+ correlate with transcript" in plain
+            assert "Conversation correlation" not in plain
+            with urllib.request.urlopen(base + "/session/s200-1?t=1") as resp:
+                correlated = resp.read().decode()
+            assert "Conversation correlation" in correlated and "hide correlation" in correlated
+        finally:
+            server.shutdown()
 
 
 class TestScanUsage:

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -1,0 +1,339 @@
+"""Tests for `distil dissect` — session picker, report math, renderers, and the
+proxy/wrap logging it reads (session manifest + per-request detail records).
+
+The proxy round-trip test mirrors tests/test_proxy.py: a stub upstream echoes
+the forwarded body, the real handler runs in a thread, and the assertion is on
+the *artifact* — sessions/<sid>.requests.jsonl — not on internals.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from distil import dissect as dz
+from distil.cli import main
+from distil.ledger import (
+    append_session_request,
+    session_manifest_path,
+    session_requests_path,
+    write_session_manifest,
+)
+from distil.proxy import build_handler, wrap_run
+
+_LOG_LINES = "\n".join(
+    f"[2026-07-11 12:00:{i:02d}] INFO worker-{i}: heartbeat ok, queue depth {i * 3}"
+    for i in range(60)
+)
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802 — http.server API
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:  # quiet
+        pass
+
+
+@pytest.fixture()
+def servers() -> Any:
+    upstream = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    handler_cls = build_handler(f"http://127.0.0.1:{upstream.server_address[1]}")
+    proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    threading.Thread(target=proxy.serve_forever, daemon=True).start()
+    yield proxy.server_address[1]
+    proxy.shutdown()
+    upstream.shutdown()
+
+
+def _post(port: int, payload: dict[str, Any]) -> Any:
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/messages",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(req)
+
+
+def _compressible_payload() -> dict[str, Any]:
+    return {
+        "model": "claude-test-1",
+        "max_tokens": 128,
+        "system": "You are a test agent." * 20,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": _LOG_LINES}
+                ],
+            },
+            {"role": "user", "content": "next"},
+            {"role": "user", "content": "next again"},
+        ],
+    }
+
+
+# --------------------------------------------------------------- proxy logging
+class TestRequestDetailLogging:
+    def test_detail_record_written_per_request(
+        self, servers: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.setenv("DISTIL_SESSION", "s100-1")
+        with _post(servers, _compressible_payload()) as resp:
+            assert resp.status == 200
+        path = session_requests_path("s100-1")
+        assert path is not None and path.exists()
+        recs = [json.loads(line) for line in path.read_text().splitlines()]
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec["model"] == "claude-test-1"
+        assert rec["mode"] == "digest"
+        assert rec["stream"] is False
+        assert rec["status"] == 200
+        assert rec["booked"] is False  # no SavingsTracker wired in this harness
+        assert rec["compressible_tokens"] > 0
+        assert rec["tokens_saved"] > 0
+        assert rec["overhead_tokens"] > 0  # the system prompt is counted, not compressed
+        assert rec["blocks"], "digested blocks should be inventoried"
+        blk = rec["blocks"][0]
+        assert set(blk) == {"h", "sig", "tokens"} and len(blk["h"]) == 8
+        assert ":" in blk["sig"] and blk["tokens"] > 0
+        assert "handle=" not in json.dumps(rec), "detail records must stay content-free"
+
+    def test_no_session_no_record(
+        self, servers: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        with _post(servers, _compressible_payload()) as resp:
+            assert resp.status == 200
+        assert not list((tmp_path / "sessions").glob("*.requests.jsonl"))
+
+
+class TestWrapManifest:
+    def test_manifest_written_at_wrap_start(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        assert wrap_run(["true"], expand=True, session_delta=True, shadow_rate=0.25) == 0
+        manifests = list((tmp_path / "sessions").glob("s*.json"))
+        assert len(manifests) == 1
+        man = json.loads(manifests[0].read_text())
+        assert man["tool"] == "true" and man["argv"] == ["true"]
+        assert man["flags"]["expand"] is True
+        assert man["flags"]["session_delta"] is True
+        assert man["flags"]["shadow_rate"] == 0.25
+        assert man["billing"] in ("subscription", "metered", "unknown")
+        assert man["started_ts"] > 0 and man["sid"] == manifests[0].stem
+
+    def test_writers_are_fail_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        # No session -> no path -> both writers are silent no-ops.
+        assert session_manifest_path() is None
+        write_session_manifest({"sid": "x"})
+        append_session_request({"ts": 1})
+
+
+# ----------------------------------------------------------------- report math
+def _seed_state(home: Path) -> None:
+    """Two sessions: sA (manifest + detail + restore blobs), sB (ledger only)."""
+    row = {
+        "trajectory_id": "live-proxy",
+        "tokenizer": "heuristic",
+        "mode": "digest",
+        "acct": 2,
+    }
+    ledger = [
+        {**row, "session": "s200-1", "model": "m-big", "turns": 2, "ts": 1000.0,
+         "baseline_input_tokens": 9000, "distil_input_tokens": 3000,
+         "baseline_dollars": 0.9, "distil_dollars": 0.3},
+        {**row, "session": "s200-1", "model": "m-small", "turns": 1, "ts": 1600.0,
+         "baseline_input_tokens": 1000, "distil_input_tokens": 900,
+         "baseline_dollars": 0.1, "distil_dollars": 0.09},
+        {**row, "session": "s300-9", "model": "m-big", "turns": 1, "ts": 2000.0,
+         "baseline_input_tokens": 500, "distil_input_tokens": 400,
+         "baseline_dollars": 0.05, "distil_dollars": 0.04},
+        {"corrupt": "row missing session"},
+    ]
+    (home / "savings.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in ledger) + "\nnot json\n"
+    )
+    sess = home / "sessions"
+    sess.mkdir()
+    (sess / "s200-1.json").write_text(json.dumps({
+        "sid": "s200-1", "tool": "codex", "argv": ["codex", "--full-auto"],
+        "started_ts": 990.0, "distil_version": "1.15.0", "billing": "subscription",
+        "flags": {"expand": True, "session_delta": True, "shadow_rate": 0.1,
+                  "lossless_only": False, "verbatim": False, "shape_output": "off",
+                  "upstream": "https://api.anthropic.com", "env_var": "ANTHROPIC_BASE_URL"},
+    }))
+    details = [
+        {"ts": 1000.0, "model": "m-big", "stream": True, "status": 200, "booked": True,
+         "mode": "digest", "compressible_tokens": 5000, "tokens_saved": 3500,
+         "overhead_tokens": 700, "delta_refs": 0, "delta_tokens_saved": 0,
+         "prefix_msgs": 0, "shadow_sampled": True, "expanded": False,
+         "output_shaping": "",
+         "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000},
+                    {"h": "bbbb2222", "sig": "prose:m", "tokens": 900}]},
+        {"ts": 1600.0, "model": "m-small", "stream": True, "status": 200, "booked": True,
+         "mode": "digest", "compressible_tokens": 2000, "tokens_saved": 1200,
+         "overhead_tokens": 500, "delta_refs": 3, "delta_tokens_saved": 800,
+         "prefix_msgs": 4, "shadow_sampled": False, "expanded": True,
+         "output_shaping": "",
+         "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000}]},
+        {"ts": 1700.0, "model": "m-small", "stream": False, "status": 529, "booked": False,
+         "mode": "verbatim", "compressible_tokens": 0, "tokens_saved": 0,
+         "overhead_tokens": 500, "delta_refs": 0, "delta_tokens_saved": 0,
+         "prefix_msgs": 0, "shadow_sampled": False, "expanded": False,
+         "output_shaping": "", "blocks": []},
+    ]
+    (sess / "s200-1.requests.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in details) + "\n"
+    )
+    (sess / "s200-1").write_text("1")
+    (sess / "s300-9.exit").write_text("rc=0")
+    restore = home / "restore"
+    restore.mkdir()
+    (restore / "aaaa1111").write_text("original log content")
+    (home / "shadow.jsonl").write_text(
+        json.dumps({"ts": 1500.0, "equivalent": True}) + "\n"
+        + json.dumps({"ts": 999999.0, "equivalent": False}) + "\n"
+    )
+
+
+class TestDissection:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    def test_list_sessions_newest_first_with_status(self) -> None:
+        sessions = dz.list_sessions()
+        assert [o.sid for o in sessions] == ["s300-9", "s200-1"]
+        s200 = sessions[1]
+        assert s200.tool == "codex" and s200.requests == 3
+        assert s200.baseline_tokens == 10000 and s200.distil_tokens == 3900
+        assert s200.status == "live"
+        assert sessions[0].status == "exited"
+
+    def test_resolve_sid(self) -> None:
+        assert dz.resolve_sid("latest") == "s300-9"
+        assert dz.resolve_sid("s200") == "s200-1"
+        assert dz.resolve_sid("s200-1") == "s200-1"
+        assert dz.resolve_sid("s") is None  # ambiguous
+        assert dz.resolve_sid("nope") is None
+
+    def test_dissection_math(self) -> None:
+        d = dz.dissect("s200-1")
+        assert d.baseline_tokens == 10000 and d.distil_tokens == 3900
+        assert d.pct_saved == pytest.approx(61.0)
+        assert d.dollars_saved == pytest.approx(0.61)
+        assert d.per_model()[0] == ("m-big", 2, 9000, 3000)
+        assert d.detail_available
+        assert d.delta_tokens_saved == 800
+        assert d.overhead_tokens_avg == 566
+        assert d.verbatim_requests == 1 and d.unbooked_requests == 1
+        assert d.shadow_sampled == 1 and d.expand_resolved == 1
+        assert d.billing == "subscription"
+        # Blocks dedup by handle across requests; folds counted per sighting.
+        assert set(d.blocks) == {"aaaa1111", "bbbb2222"}
+        assert d.blocks["aaaa1111"]["folds"] == 2
+        assert d.blocks["aaaa1111"]["recoverable"] is True
+        assert d.blocks["bbbb2222"]["recoverable"] is False
+        assert d.blocks_by_kind()[0] == ("log:l", 1, 2000)
+        # Shadow join is by time window: only the ts=1500 row is inside.
+        assert d.shadow_window_rows == 1 and d.shadow_window_agree == 1
+
+    def test_render_text_full(self) -> None:
+        d = dz.dissect("s200-1")
+        text = dz.render_text(d, color=False)
+        assert "s200-1" in text and "codex" in text
+        assert "61.0% saved" in text and "notional" in text
+        assert "log:l" in text and "aaaa1111" in text
+        assert "1/2 blocks still in restore/" in text
+        assert "expand: 1 requests" in text and "shadow: 1 requests" in text
+        assert "1 verbatim" in text
+
+    def test_render_text_degrades_without_detail(self) -> None:
+        d = dz.dissect("s300-9")
+        text = dz.render_text(d, color=False)
+        assert "manifest not recorded" in text
+        assert "not recorded — per-request detail" in text
+        assert "rc=0" in text
+
+    def test_to_json_schema(self) -> None:
+        payload = dz.to_json(dz.dissect("s200-1"))
+        assert payload["session"] == "s200-1"
+        assert payload["savings"]["pct_saved"] == 61.0
+        assert payload["savings"]["dollars_notional"] is True
+        assert payload["requests"]["total"] == 3
+        assert payload["blocks"]["unique"] == 2 and payload["blocks"]["recoverable"] == 1
+        assert payload["quality"]["shadow_sampled_requests"] == 1
+
+    def test_render_html_self_contained(self) -> None:
+        page = dz.render_html(dz.dissect("s200-1"))
+        assert page.startswith("<!doctype html>")
+        assert "s200-1" in page and "61.0%" in page and "notional" in page
+        assert "aaaa1111" in page and "log:l" in page
+
+
+class TestCli:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    def test_picker_lists_sessions(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect"]) == 0
+        out = capsys.readouterr().out
+        assert "s200-1" in out and "s300-9" in out and "codex" in out
+
+    def test_picker_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect", "--json"]) == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert {r["session"] for r in rows} == {"s200-1", "s300-9"}
+
+    def test_report_and_prefix_resolution(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect", "s200", "--no-color"]) == 0
+        assert "61.0% saved" in capsys.readouterr().out
+
+    def test_json_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect", "latest", "--json"]) == 0
+        assert json.loads(capsys.readouterr().out)["session"] == "s300-9"
+
+    def test_html_export(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        out_file = tmp_path / "dissect.html"
+        assert main(["dissect", "s200-1", "--html", str(out_file)]) == 0
+        assert out_file.read_text().startswith("<!doctype html>")
+
+    def test_unknown_session_exits_2(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["dissect", "zzz"]) == 2
+        assert "no session matches" in capsys.readouterr().out
+
+
+class TestTolerantReader:
+    def test_read_jsonl_skips_garbage(self, tmp_path: Path) -> None:
+        p = tmp_path / "x.jsonl"
+        p.write_text('{"a": 1}\nnot json\n[1,2]\n\n{"b": 2}\n')
+        assert dz._read_jsonl(p) == [{"a": 1}, {"b": 2}]
+
+    def test_read_jsonl_missing_file(self, tmp_path: Path) -> None:
+        assert dz._read_jsonl(tmp_path / "absent.jsonl") == []

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -494,12 +494,18 @@ class TestToolsAndCharts:
         assert "#3987e5" in page and "#199e70" in page and "#c98500" in page
         assert "overhead (system + tools)" in page  # legend, not color-alone
         assert "Tool definitions" in page and "bash" in page
-        assert "request 2 · m-small · overhead 500 · sent 800 · saved 1,200" in page
         assert "data table" in page  # accessible table view of the timeline
         assert "Request composition" in page
-        # Plain-English help layer: section descriptions + hover titles on tiles.
+        # Styled hover layer: JSON data-tip payloads rebuilt with textContent,
+        # full-column/row hit targets, and the tooltip container + script.
+        assert "request 2 · m-small" in page  # timeline column tip title
+        assert "saved by distil" in page and "billed input" in page  # series rows
+        assert page.count("data-tip=") >= 15  # tiles + columns + bar rows
+        assert '<div id="tip" role="tooltip">' in page and "dataset.tip" in page
+        assert "textContent" in page and "innerHTML" not in page  # names stay data
+        # Plain-English help layer: section descriptions + tile explanations.
         assert "for what the term means" in page
-        assert 'title="Tokens distil avoided sending by replacing bulky content' in page
+        assert "Tokens distil avoided sending by replacing bulky content" in page
         assert "class=\"desc\"" in page
         assert "re-described to the model on every request" in page
 

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -882,6 +882,20 @@ class TestTranscriptCorrelation:
         out = capsys.readouterr().out
         assert "no matching agent transcript found" in out
 
+    def test_serve_with_transcript_flag_correlates_by_default(self) -> None:
+        server = dz.make_server("127.0.0.1", 0, transcript="auto")
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        try:
+            with urllib.request.urlopen(base + "/session/s200-1") as resp:
+                page = resp.read().decode()
+            assert "Conversation correlation" in page  # default on
+            assert 'href="/session/s200-1?t=0"' in page  # opt-out link
+            with urllib.request.urlopen(base + "/session/s200-1?t=0") as resp:
+                assert "Conversation correlation" not in resp.read().decode()
+        finally:
+            server.shutdown()
+
     def test_portal_correlation_toggle(self) -> None:
         server = dz.make_server("127.0.0.1", 0)
         threading.Thread(target=server.serve_forever, daemon=True).start()

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -457,7 +457,8 @@ class TestInsights:
         assert "buffered (forced by expand) 1 req @ 9.0s" in text
         assert "regret: log:l blocks pulled back 1/1" in text
         page = dz.render_html(d, peers=dz.list_sessions())
-        assert "Mechanism" in page and "stretched ~<b>2.6x</b>" in page
+        assert "Digest folds" in page and "83% of savings" in page
+        assert ">2.6\u00d7<" in page  # headroom tile
         payload = dz.to_json(d, dz.list_sessions())
         assert payload["insights"]["churn"]["tokens"] == 2000
         assert payload["insights"]["usage"]["calibration"] == {

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -240,7 +240,10 @@ def _seed_state(home: Path) -> None:
          "status": 200, "booked": True, "duration_ms": 4000,
          "usage_input_tokens": 2100, "usage_output_tokens": 300, "expanded_handles": [],
          "mode": "digest", "compressible_tokens": 5000, "tokens_saved": 3500,
-         "overhead_tokens": 700, "delta_refs": 0, "delta_tokens_saved": 0,
+         "overhead_tokens": 700, "system_tokens": 100, "tools_tokens": 600,
+         "tools": [{"name": "bash", "tokens": 300},
+                   {"name": "mcp__gmail__search", "tokens": 300}],
+         "delta_refs": 0, "delta_tokens_saved": 0,
          "prefix_msgs": 0, "shadow_sampled": True, "expanded": False,
          "output_shaping": "",
          "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000},
@@ -250,7 +253,9 @@ def _seed_state(home: Path) -> None:
          "usage_input_tokens": 1200, "usage_output_tokens": 150,
          "expanded_handles": ["aaaa1111"],
          "mode": "digest", "compressible_tokens": 2000, "tokens_saved": 1200,
-         "overhead_tokens": 500, "delta_refs": 3, "delta_tokens_saved": 800,
+         "overhead_tokens": 500, "system_tokens": 200, "tools_tokens": 300,
+         "tools": [{"name": "bash", "tokens": 300}],
+         "delta_refs": 3, "delta_tokens_saved": 800,
          "prefix_msgs": 4, "shadow_sampled": False, "expanded": True,
          "output_shaping": "",
          "blocks": [{"h": "aaaa1111", "sig": "log:l", "tokens": 2000}]},
@@ -258,7 +263,9 @@ def _seed_state(home: Path) -> None:
          "status": 529, "booked": False, "duration_ms": 500,
          "usage_input_tokens": None, "usage_output_tokens": None, "expanded_handles": [],
          "mode": "verbatim", "compressible_tokens": 0, "tokens_saved": 0,
-         "overhead_tokens": 500, "delta_refs": 0, "delta_tokens_saved": 0,
+         "overhead_tokens": 500, "system_tokens": 250, "tools_tokens": 250,
+         "tools": [{"name": "bash", "tokens": 250}],
+         "delta_refs": 0, "delta_tokens_saved": 0,
          "prefix_msgs": 0, "shadow_sampled": False, "expanded": False,
          "output_shaping": "", "blocks": []},
     ]
@@ -408,8 +415,8 @@ class TestInsights:
 
     def test_churn(self) -> None:
         d = dz.dissect("s200-1")
-        # aaaa1111 folded twice -> 2000 tokens re-digested; no block hit 3+ folds
-        assert d.churn_tokens == 2000 and d.churned_blocks == 0
+        # aaaa1111 folded twice -> 2000 tokens re-digested across 1 re-folded block
+        assert d.churn_tokens == 2000 and d.churned_blocks == 1
 
     def test_usage_and_calibration(self) -> None:
         d = dz.dissect("s200-1")
@@ -458,6 +465,99 @@ class TestInsights:
             "billed": 3300,
         }
         assert payload["insights"]["anomalies"] == []
+
+
+class TestToolsAndCharts:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        _seed_state(tmp_path)
+
+    def test_tool_costs_aggregation(self) -> None:
+        d = dz.dissect("s200-1")
+        # bash: max 300/req, seen on 3 requests -> 900; gmail: 300 on 1 -> 300.
+        assert d.tool_costs() == [("bash", 300, 900), ("mcp__gmail__search", 300, 300)]
+        assert d.system_tokens_avg == 183 and d.tools_tokens_avg == 383
+        assert d.system_growth() == (100, 250)
+
+    def test_text_report_shows_tools_and_prompt_growth(self) -> None:
+        text = dz.render_text(dz.dissect("s200-1"), color=False)
+        assert "tool definitions (2): bash 300/req, mcp__gmail__search 300/req" in text
+        assert "system prompt: 100 → 250 tokens over the session" in text
+
+    def test_html_has_charts(self) -> None:
+        page = dz.render_html(dz.dissect("s200-1"))
+        assert page.count("<svg") == 3  # timeline, tools, block kinds
+        # Validated categorical series, fixed order: overhead / sent / saved.
+        assert "#3987e5" in page and "#199e70" in page and "#c98500" in page
+        assert "overhead (system + tools)" in page  # legend, not color-alone
+        assert "Tool definitions" in page and "bash" in page
+        assert "request 2 · m-small · overhead 500 · sent 800 · saved 1,200" in page
+        assert "data table" in page  # accessible table view of the timeline
+        assert "Request composition" in page
+
+    def test_json_has_tool_breakdown(self) -> None:
+        payload = dz.to_json(dz.dissect("s200-1"))
+        overhead = payload["insights"]["overhead"]
+        assert overhead["tools"][0] == {
+            "name": "bash",
+            "tokens_per_request": 300,
+            "session_tokens": 900,
+        }
+        assert overhead["system_growth"] == (100, 250)
+
+    def test_charts_absent_without_detail(self) -> None:
+        page = dz.render_html(dz.dissect("s300-9"))
+        assert "<svg" not in page
+
+
+class TestInteractivePicker:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        _seed_state(tmp_path)
+
+    def _tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import sys
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+
+    def test_numbered_pick_renders_report(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._tty(monkeypatch)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "2")
+        assert main(["dissect"]) == 0
+        out = capsys.readouterr().out
+        assert "#" in out and "s200-1" in out  # numbered list first
+        assert "savings (input tokens, booked 2xx only)" in out  # then the report
+        assert "codex" in out
+
+    def test_enter_quits(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._tty(monkeypatch)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        assert main(["dissect"]) == 0
+        assert "savings (input tokens" not in capsys.readouterr().out
+
+    def test_bad_pick_exits_2(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._tty(monkeypatch)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "zzz")
+        assert main(["dissect"]) == 2
+
+    def test_non_tty_keeps_list_only(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # capsys stdout is not a tty -> no prompt, list only (the old behavior).
+        assert main(["dissect"]) == 0
+        out = capsys.readouterr().out
+        assert "pick one to dissect" in out
+        assert "savings (input tokens" not in out
 
 
 class TestAnomalies:


### PR DESCRIPTION
Implements #26 — `distil dissect`: a per-session deep-dive report of what distil actually did, for any wrapped tool.

## What this adds

```
distil dissect                     # session picker (interactive on a TTY)
distil dissect latest              # one session: narrative + drill-down (--json / --html)
distil dissect --serve             # localhost portal: / picker, /session/<sid> live reports
distil dissect latest --transcript # opt-in: correlate with the agent's own conversation log
```

**The report** leads with a plain-language "What happened" narrative, then drills down: savings per model (dollars marked *notional* on flat-rate billing, with a headroom multiplier instead), savings by mechanism (digest vs cache-delta), what was *not* optimized and why (system-prompt/tool-definition overhead, verbatim and unbooked requests), the digest inventory (blocks by kind, largest folds, re-fold churn, restore-blob recoverability), billed usage captured from API responses with a heuristic-calibration figure, latency by path (the `--expand` buffering tax is now a measured number), quality loops, and a "worth your attention" anomaly list — which detects the #25 signatures automatically, so that class of silent failure can't hide again.

The HTML report is self-contained (inline SVG, no CDN, no new dependencies) with cursor-following tooltips that explain every distil term in plain English. A demo rendered from synthetic data is attached to #26.

**Transcript correlation** (strictly opt-in — it names tools/files/prompts, everything else stays content-free): joins the session with the agent's own log via the restore store's original bytes matched into transcript tool results. Yields folds named by producing tool + prompt, tools defined-but-never-invoked (on a real session: 20/24 tools ≈ 40k tokens/request paid for nothing), re-fetched-after-fold warnings (a multi-turn quality signal shadow sampling can't see), and cost per human turn.

Agent support is a pluggable adapter layer: `distil/transcripts/base.py` documents the contract (two methods — `discover`, `load` — normalizing into turns/tool-calls/tool-results); the registry keys on the wrap manifest's tool name. Claude Code is the first adapter; codex/gemini/aider are one module + one registry line each. Extensibility is proven by an in-test toy adapter.

## Proxy-side changes (small, fail-open, content-free)

Two logs, both under the existing `sessions/` TTL sweep, both wrapped so bookkeeping can never break a request:

- `sessions/<sid>.json` — wrap manifest (tool, argv, cwd, flags, billing, version), written once at startup.
- `sessions/<sid>.requests.jsonl` — one record per proxied request: token accounting from the extras the proxy already computes, per-block digest signatures (handle + kind:size + tokens, never content), billed `usage.*` (JSON parsed; SSE scanned from a bounded head/tail window in `streamrelay` via a new `usage_sink` param — nothing new is buffered), duration + stream-vs-buffered path, shadow/expand flags, per-tool definition sizes.

Pre-existing sessions degrade to a ledger-only view with an explicit note. The expand loop's `on_signal` seam additionally reports which handles were resolved (content-free).

## Conventions honored

- stdlib only, no new dependencies; full type hints; ruff/mypy clean.
- `make gate` + `distil verify` PASS on every commit (the branch is rebased onto v1.15.0, composing cleanly with the #25 fix — the report's forced-buffering metric now measures the TTFT trade your fix docstring mentions).
- No CHANGELOG entry, per RELEASING.md.
- 64 new tests in `tests/test_dissect.py` (proxy round-trips against a stub upstream incl. SSE usage capture, report math, renderers, portal routes, adapter parsing/discovery, correlation math, toy-adapter extensibility). Full suite: 1356 passed.

## Trying it

```
pipx install --force <this branch>   # or: uv run distil ...
distil wrap --expand --session-delta -- claude   # any base-url-honoring agent
distil dissect --transcript --serve              # then open http://127.0.0.1:8790/
```

## Review notes

The 10 commits are individually coherent if you prefer to review in stages (core+logging → insights → charts/UX → portal → transcript adapters). Equally happy to split this into that PR sequence instead — whatever reviews best. Naming and flag conventions are all up for adjustment.

Filed by Claude (Fable 5) assisting @pliablepixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
