### PR TITLE
Adoption telemetry: passive registry pipeline + opt-in content-free census, live badges & site strip

### DIFF
--- a/.github/workflows/adoption-stats.yml
+++ b/.github/workflows/adoption-stats.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: metrics-branch-writes
+  cancel-in-progress: false
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
@@ -35,9 +39,11 @@ jobs:
           mkdir -p ../metrics/data
           python3 scripts/adoption_snapshot.py >> ../metrics/data/adoption.jsonl
           tail -1 ../metrics/data/adoption.jsonl
+      - name: Roll up aggregates + badges
+        run: python3 scripts/census_rollup.py ../metrics
       - name: Push
         run: |
           cd ../metrics
-          git add data/adoption.jsonl
-          git commit -m "adoption snapshot $(date -u +%F)"
-          git push origin HEAD:metrics
+          git add data
+          git commit -m "adoption snapshot + rollup $(date -u +%F)"
+          git push origin HEAD:metrics || { git pull --rebase origin metrics && git push origin HEAD:metrics; }

--- a/.github/workflows/adoption-stats.yml
+++ b/.github/workflows/adoption-stats.yml
@@ -1,0 +1,43 @@
+# Passive adoption snapshot — registry-side numbers, zero user telemetry.
+#
+# Nightly append of scripts/adoption_snapshot.py output to data/adoption.jsonl
+# on the `metrics` branch (kept off main so history stays clean). GitHub's
+# traffic API only retains a rolling 14-day window — this cron is what turns
+# it into history. See specs/adoption-telemetry.md phase 0.
+name: adoption-stats
+
+on:
+  schedule:
+    - cron: "43 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch or create metrics branch
+        run: |
+          git config user.name "adoption-stats[bot]"
+          git config user.email "actions@users.noreply.github.com"
+          if git fetch origin metrics 2>/dev/null; then
+            git worktree add ../metrics origin/metrics
+          else
+            git worktree add --orphan -b metrics ../metrics
+          fi
+      - name: Append snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ../metrics/data
+          python3 scripts/adoption_snapshot.py >> ../metrics/data/adoption.jsonl
+          tail -1 ../metrics/data/adoption.jsonl
+      - name: Push
+        run: |
+          cd ../metrics
+          git add data/adoption.jsonl
+          git commit -m "adoption snapshot $(date -u +%F)"
+          git push origin HEAD:metrics

--- a/.github/workflows/census-ingest.yml
+++ b/.github/workflows/census-ingest.yml
@@ -1,0 +1,47 @@
+# Census ingest — repository_dispatch("census") → metrics branch.
+#
+# The census worker (packaging/census-worker/) forwards each opted-in ping as
+# a dispatch event; this workflow RE-VALIDATES it (defense in depth — the
+# dispatch payload is untrusted input even though our worker validated once)
+# and appends it to data/census.jsonl on the `metrics` branch. Serialized via
+# a concurrency group so concurrent pings can't race the push.
+name: census-ingest
+
+on:
+  repository_dispatch:
+    types: [census]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: metrics-branch-writes
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate payload (defense in depth)
+        env:
+          CENSUS: ${{ toJSON(github.event.client_payload.census) }}
+        run: |
+          printf '%s' "$CENSUS" | python3 scripts/census_validate.py > /tmp/census-row.json
+      - name: Append to metrics branch
+        run: |
+          git config user.name "census-ingest[bot]"
+          git config user.email "actions@users.noreply.github.com"
+          if git fetch origin metrics 2>/dev/null; then
+            git worktree add ../metrics origin/metrics
+          else
+            git worktree add --orphan -b metrics ../metrics
+          fi
+          mkdir -p ../metrics/data
+          cat /tmp/census-row.json >> ../metrics/data/census.jsonl
+          cd ../metrics
+          git add data/census.jsonl
+          git commit -m "census ping"
+          # One retry on push race — the concurrency group serializes runs, but
+          # adoption-stats can still land in between.
+          git push origin HEAD:metrics || { git pull --rebase origin metrics && git push origin HEAD:metrics; }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="LICENSE"><img src="https://img.shields.io/pypi/l/distil-llm?color=8b7bff" alt="license"/></a>
   <a href="#-what-we-wont-pretend"><img src="https://img.shields.io/badge/runtime%20deps-0-5ad19a" alt="zero runtime deps"/></a>
   <a href="https://dshakes.github.io/distil/architecture.html"><img src="https://img.shields.io/badge/typed-py.typed%20%C2%B7%20mypy%20clean-8b7bff" alt="typed"/></a>
+  <a href="https://pypi.org/project/distil-llm/"><img src="https://img.shields.io/pypi/dm/distil-llm?color=5ad19a&label=downloads" alt="PyPI downloads/month"/></a>
+  <a href="TELEMETRY.md"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdshakes%2Fdistil%2Fmetrics%2Fdata%2Fbadges%2Fsavings-tokens.json" alt="community tokens saved (opt-in census)"/></a>
+  <a href="TELEMETRY.md"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdshakes%2Fdistil%2Fmetrics%2Fdata%2Fbadges%2Factive-installs.json" alt="active installs, 30d (opt-in census)"/></a>
 </p>
 
 <h2 align="center">Compress your agent's context.<br/>Prove its decisions don't change.</h2>

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Measured on **your** traffic, never estimated, nothing leaves your machine:
 - **Per machine:** `distil leaderboard` (`--html` for a page).
 - **Shadow mode:** `distil proxy --shadow 0.05` reports the live decision-change rate — streaming-aware.
 - **Org-wide:** `distil proxy` sidecar + set `ANTHROPIC_BASE_URL` once; every client routes through it.
+- **Community:** an **opt-in** census (`distil census on`) shares your numbers-only totals — preview the exact payload with `distil census show` before consenting; [`TELEMETRY.md`](TELEMETRY.md) has the frozen schema. Default remains: nothing is sent.
 
 Dashboard, status-line plugin, federated leaderboard: [Deploy & observability](https://dshakes.github.io/distil/deploy-security.html).
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -55,10 +55,31 @@ in [THREAT_MODEL.md](THREAT_MODEL.md).
 - `DISTIL_CENSUS_ENDPOINT=<url>` — point the census at your own collector
   (useful for org-internal fleets)
 
-## Where the aggregate goes
+## Where the aggregate goes — a fully auditable pipeline
 
-Opted-in censuses aggregate into public totals — installs by version, active
-instances, community tokens/$ saved — published on the
-[distil site](https://dshakes.github.io/distil/). The ingest service is in
-this repo (reviewable), stores no IP addresses, and keeps only the latest
-census per install id.
+Every stage of the pipeline is public code in this repo:
+
+1. **Ingest** ([`packaging/census-worker/`](packaging/census-worker/)): a
+   stateless function that validates the schema (1 KB cap, strict allowlist,
+   hard numeric ceilings) and forwards to a GitHub `repository_dispatch`. It
+   stores nothing — no database, no IP addresses.
+2. **Append** ([`.github/workflows/census-ingest.yml`](.github/workflows/census-ingest.yml)):
+   CI **re-validates** the payload (defense in depth) and appends it to
+   `data/census.jsonl` on the public
+   [`metrics` branch](https://github.com/dshakes/distil/tree/metrics) — the
+   datastore is a git branch anyone can read.
+3. **Rollup** ([`scripts/census_rollup.py`](scripts/census_rollup.py), nightly):
+   dedupes to the latest census per install id, drops out-of-ceiling rows, and
+   publishes `data/aggregates.json` + shields.io badge JSONs — the numbers
+   behind the README badges and the site's live adoption strip.
+
+Passive registry stats (PyPI downloads, GitHub traffic, Docker pulls) join the
+same rollup via [`scripts/adoption_snapshot.py`](scripts/adoption_snapshot.py)
+— those never involve your machine at all.
+
+## The update check (not telemetry, disclosed anyway)
+
+`distil wrap` and `distil proxy` check **pypi.org** for a newer version at
+most once per 24h, in a background thread, and print one line if you're
+behind. Nothing about you is sent — it is the same public PyPI metadata
+lookup `distil onboard` performs. Opt out: `DISTIL_NO_UPDATE_CHECK=1`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,64 @@
+# Telemetry
+
+**Default: distil sends nothing.** No usage analytics, no crash reporting, no
+phone-home. The only network traffic a default install ever produces is your
+own LLM API requests to the upstream you configured, plus one PyPI
+version-lookup during `distil onboard` (skippable with `--offline`).
+
+Adoption numbers (installs, versions) come from **registry-side channels** —
+PyPI download stats, GitHub traffic — that involve zero code on your machine.
+
+## The opt-in census
+
+One thing can't be measured registry-side: community-wide tokens/$ saved,
+because savings are computed locally. For that there is an **opt-in census**:
+
+```sh
+distil census show     # print the EXACT payload — nothing is sent
+distil census on       # consent (mints a random install id)
+distil census off      # revoke — deletes the install id
+distil census          # status
+```
+
+It is **off until you say yes** — either `distil census on` or answering the
+one-time question in `distil onboard` (declining is recorded; you are never
+asked again; `--yes` does *not* consent for you).
+
+### Exactly what is sent
+
+At most **one JSON object per 24 hours**, fired from the proxy/wrap shutdown
+path, fail-open (a dead endpoint costs ≤1.5s once per day, and errors are
+swallowed). The schema is frozen by a test
+(`tests/test_census.py::test_payload_schema_frozen`) — widening it requires a
+reviewed change to this file and that test:
+
+| field | example | note |
+|---|---|---|
+| `schema` | `1` | payload version |
+| `install_id` | `"3f2a…"` | random UUID — no MAC/hostname/username derivation; deleted by `census off` |
+| `version` | `"1.20.2"` | distil version |
+| `os` / `arch` / `python` | `"Darwin"` / `"arm64"` / `"3.12.13"` | platform triple |
+| `runs` | `412` | ledger run count |
+| `tokens_saved` | `183_220` | lifetime baseline − distil input tokens |
+| `dollars_saved` | `12.41` | same, in dollars (0 for unpriced models) |
+| `ts` | `1784500000` | send time |
+
+Never sent, opted in or not: prompt/response content, message digests, file
+paths, hostnames, usernames, API keys, model inputs of any kind. The census is
+built from `ledger.summary()` totals — the same numbers-only ledger described
+in [THREAT_MODEL.md](THREAT_MODEL.md).
+
+### Kill switches (beat a stored opt-in, always)
+
+- `DO_NOT_TRACK=1` — the [console DNT convention](https://consoledonottrack.com)
+- `DISTIL_NO_TELEMETRY=1`
+- `DISTIL_CENSUS_ENDPOINT=<url>` — point the census at your own collector
+  (useful for org-internal fleets)
+
+## Where the aggregate goes
+
+Opted-in censuses aggregate into public totals — installs by version, active
+instances, community tokens/$ saved — published on the
+[distil site](https://dshakes.github.io/distil/). The ingest service is in
+this repo (reviewable), stores no IP addresses, and keeps only the latest
+census per install id.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -87,6 +87,12 @@ longer expand degrade exactly like expired ones.
 ### Other persisted state
 
 - The savings ledger / shadow ledger / learn stats: numbers only, no content.
+- The adoption census (`distil/census.py`): **opt-in only, off by default** —
+  when (and only when) consented, sends a schema-frozen JSON of platform
+  strings and ledger totals, never content (see `TELEMETRY.md`; schema pinned
+  by `tests/test_census.py`). `DO_NOT_TRACK=1` / `DISTIL_NO_TELEMETRY=1`
+  override a stored opt-in. The anonymous install id is a random UUID with no
+  machine derivation, deleted on `distil census off`.
 
 ## Out of scope (explicitly not defended)
 

--- a/distil/census.py
+++ b/distil/census.py
@@ -1,0 +1,199 @@
+"""Opt-in adoption census — content-free, transparent, revocable.
+
+Answers "how many active installs, which versions, how much is the community
+saving" with the smallest defensible signal: one JSON object, at most once per
+24h, containing ONLY numbers and platform strings (schema below, frozen by
+test). It is OFF until the user explicitly opts in (`distil census on`, or
+saying yes at `distil onboard`), and two kill switches beat a stored opt-in
+unconditionally: the cross-tool `DO_NOT_TRACK=1` convention and
+`DISTIL_NO_TELEMETRY=1`.
+
+Design rules (see docs/adr/0002-adoption-telemetry-opt-in-census.md):
+- Content never appears here — the payload is built from `ledger.summary()`
+  totals (numbers) and platform metadata, nothing else.
+- `distil census show` prints the exact payload; nothing is sent.
+- Fail-open: a send gets 1.5s and swallows every failure; it must never slow
+  or break the proxy/wrap exit path it rides on.
+- Revocable: `distil census off` deletes the anonymous install id.
+
+The ingest endpoint activates in a later phase; until it is deployed, sends
+fail silently (opt-in state and UX are unaffected).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "https://census.distil.dev/v1/ping"
+SEND_TIMEOUT_S = 1.5
+MIN_INTERVAL_S = 24 * 3600
+
+# The frozen payload contract — tests/test_census.py refuses any new key, so
+# widening the census is a deliberate, reviewed act (and a TELEMETRY.md edit).
+PAYLOAD_KEYS = frozenset(
+    {
+        "schema",
+        "install_id",
+        "version",
+        "os",
+        "arch",
+        "python",
+        "runs",
+        "tokens_saved",
+        "dollars_saved",
+        "ts",
+    }
+)
+
+
+def _home() -> Path:
+    return Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil")))
+
+
+def _consent_path() -> Path:
+    return _home() / "census"
+
+
+def _id_path() -> Path:
+    return _home() / "install-id"
+
+
+def _last_path() -> Path:
+    return _home() / "census-last"
+
+
+def hard_disabled() -> bool:
+    """Kill switches that beat a stored opt-in: DO_NOT_TRACK (cross-tool
+    convention, consoledonottrack.com) and DISTIL_NO_TELEMETRY."""
+    return os.environ.get("DO_NOT_TRACK", "") not in ("", "0") or os.environ.get(
+        "DISTIL_NO_TELEMETRY", ""
+    ) not in ("", "0")
+
+
+def consent() -> str | None:
+    """Stored decision: "on", "off", or None (never asked)."""
+    try:
+        text = _consent_path().read_text(encoding="utf-8").strip()
+        return text if text in ("on", "off") else None
+    except OSError:
+        return None
+
+
+def enabled() -> bool:
+    return not hard_disabled() and consent() == "on"
+
+
+def opt_in() -> str:
+    """Record consent and mint the anonymous install id. Returns the id."""
+    home = _home()
+    home.mkdir(parents=True, exist_ok=True)
+    _consent_path().write_text("on", encoding="utf-8")
+    return install_id()
+
+
+def opt_out() -> None:
+    """Record refusal and delete the identifier — revocation, not just a stop."""
+    home = _home()
+    home.mkdir(parents=True, exist_ok=True)
+    _consent_path().write_text("off", encoding="utf-8")
+    for p in (_id_path(), _last_path()):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
+def install_id() -> str:
+    """The anonymous id: a random UUID with no derivation from the machine
+    (no MAC, no hostname, no username) — deleting the file IS revocation."""
+    p = _id_path()
+    try:
+        existing = p.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    except OSError:
+        pass
+    fresh = uuid.uuid4().hex
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(fresh, encoding="utf-8")
+    return fresh
+
+
+def build_payload() -> dict:
+    """The census, exactly as it would be sent. Numbers and platform strings
+    only — never content, paths, hashes-of-content, or key material."""
+    from . import __version__, ledger
+
+    s = ledger.summary()
+    payload = {
+        "schema": 1,
+        "install_id": install_id(),
+        "version": __version__,
+        "os": platform.system(),
+        "arch": platform.machine(),
+        "python": platform.python_version(),
+        "runs": s.runs,
+        "tokens_saved": max(0, s.total_baseline_tokens - s.total_distil_tokens),
+        "dollars_saved": round(max(0.0, s.total_baseline_dollars - s.total_distil_dollars), 4),
+        "ts": int(time.time()),
+    }
+    assert set(payload) == PAYLOAD_KEYS  # contract, enforced in prod too
+    return payload
+
+
+def status() -> dict:
+    """Machine-readable state for `distil census status`."""
+    return {
+        "consent": consent(),
+        "hard_disabled": hard_disabled(),
+        "enabled": enabled(),
+        "install_id": _id_path().read_text(encoding="utf-8").strip()
+        if _id_path().exists()
+        else None,
+        "endpoint": os.environ.get("DISTIL_CENSUS_ENDPOINT", DEFAULT_ENDPOINT),
+    }
+
+
+def _send(payload: dict) -> None:
+    endpoint = os.environ.get("DISTIL_CENSUS_ENDPOINT", DEFAULT_ENDPOINT)
+    req = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=SEND_TIMEOUT_S):
+        pass
+
+
+def maybe_ping() -> bool:
+    """Send the census if (and only if) opted in and >24h since the last try.
+
+    Fail-open by contract: rides the proxy/wrap exit path, so it swallows every
+    failure and must never block beyond the socket timeout. Returns True only
+    when a send was attempted.
+    """
+    try:
+        if not enabled():
+            return False
+        now = time.time()
+        try:
+            last = float(_last_path().read_text(encoding="utf-8").strip() or 0)
+        except (OSError, ValueError):
+            last = 0.0
+        if now - last < MIN_INTERVAL_S:
+            return False
+        # Throttle on attempt, not success — a dead endpoint must not turn
+        # every session exit into a connect-timeout wait.
+        _last_path().parent.mkdir(parents=True, exist_ok=True)
+        _last_path().write_text(str(int(now)), encoding="utf-8")
+        _send(build_payload())
+        return True
+    except Exception:  # noqa: BLE001 — census must never affect the host path
+        return True

--- a/distil/census.py
+++ b/distil/census.py
@@ -30,7 +30,7 @@ import urllib.request
 import uuid
 from pathlib import Path
 
-DEFAULT_ENDPOINT = "https://census.distil.dev/v1/ping"
+DEFAULT_ENDPOINT = "https://distil-census.vercel.app/v1/ping"
 SEND_TIMEOUT_S = 1.5
 MIN_INTERVAL_S = 24 * 3600
 

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1129,6 +1129,34 @@ def cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_census(args: argparse.Namespace) -> int:
+    """Opt-in adoption census: on / off / status / show.
+
+    `show` prints the exact payload that WOULD be sent and sends nothing —
+    read it before you opt in. Full schema: TELEMETRY.md."""
+    import json as _json
+
+    from . import census
+
+    action = args.action
+    if action == "on":
+        iid = census.opt_in()
+        print(f"census: ON — anonymous install id {iid}")
+        print("  sends at most one content-free JSON per day (see TELEMETRY.md).")
+        print("  preview anytime: distil census show   ·   revoke: distil census off")
+        if census.hard_disabled():
+            print("  note: DO_NOT_TRACK/DISTIL_NO_TELEMETRY is set — nothing will send.")
+    elif action == "off":
+        census.opt_out()
+        print("census: OFF — install id deleted (nothing identifies this machine anymore).")
+    elif action == "show":
+        print(_json.dumps(census.build_payload(), indent=2))
+        print("(preview only — nothing was sent)", file=sys.stderr)
+    else:
+        print(_json.dumps(census.status(), indent=2))
+    return 0
+
+
 def _warn_running_proxies() -> None:
     """Warn if a distil proxy/wrap/gateway is running before an in-place upgrade.
 
@@ -1405,6 +1433,28 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             )
         )
         print()
+
+    # Adoption census — asked once, opt-in only, never assumed: an explicit yes
+    # HERE is the only consent path (`--yes` deliberately does not consent, and
+    # declining is recorded so we never ask again).
+    from . import census as _census
+
+    if interactive and _census.consent() is None and not _census.hard_disabled():
+        print(c("90", "Optional: a content-free adoption census — numbers only (version, OS,"))
+        print(c("90", "tokens/$ saved), max one JSON/day. Preview: distil census show"))
+        try:
+            census_yes = input(
+                c("1", "Share the anonymous census?") + c("90", " [y/N] ")
+            ).strip().lower() in ("y", "yes")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            census_yes = False
+        if census_yes:
+            _census.opt_in()
+            print(c("90", "  census on — TELEMETRY.md documents exactly what's sent") + "\n")
+        else:
+            _census.opt_out()
+            print(c("90", "  census off — re-enable anytime: distil census on") + "\n")
 
     # Or just route the agent once, right now.
     if env.agents:
@@ -2282,6 +2332,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     vs = sub.add_parser("version", help="print the installed version")
     vs.set_defaults(func=cmd_version)
+
+    ce = sub.add_parser("census", help="opt-in adoption census (content-free; see TELEMETRY.md)")
+    ce.add_argument(
+        "action",
+        nargs="?",
+        default="status",
+        choices=["on", "off", "status", "show"],
+        help="on/off = consent; show = print the exact payload, send nothing",
+    )
+    ce.set_defaults(func=cmd_census)
 
     up = sub.add_parser("upgrade", help="upgrade distil (auto-detects brew/pipx/uv/pip)")
     up.add_argument("--dry-run", action="store_true", help="print the command, don't run it")

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -630,6 +630,9 @@ def cmd_proxy(args: argparse.Namespace) -> int:
     """Drop-in provider proxy: point any base_url-honoring client at it."""
     import sys as _sys
 
+    from .updatecheck import maybe_notify as _update_notify
+
+    _update_notify()  # ≤1/day, background thread, DISTIL_NO_UPDATE_CHECK opts out
     _apply_subscription_safe_default(args)
     if args.use_async:
         from .aproxy import serve as aserve  # high-concurrency (needs distil-llm[async])
@@ -1742,6 +1745,9 @@ def cmd_wrap(args: argparse.Namespace) -> int:
     """Transparently wrap a command: spawn the proxy, point its env at it, run it."""
     import os as _os
 
+    from .updatecheck import maybe_notify as _update_notify
+
+    _update_notify()  # ≤1/day, background thread, DISTIL_NO_UPDATE_CHECK opts out
     command = list(args.command)
     if command and command[0] == "--":  # argparse REMAINDER keeps the separator
         command = command[1:]

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -1598,6 +1598,14 @@ def wrap_run(
         _print_proof_ledger(os.environ.get("DISTIL_SESSION", ""), _start_ts)
     except Exception:  # noqa: BLE001 — ledger print must never affect exit code
         pass
+    # Adoption census — opt-in only, ≤1/day, content-free; fail-open like the
+    # ledger print (see distil/census.py and TELEMETRY.md).
+    try:
+        from . import census as _census
+
+        _census.maybe_ping()
+    except Exception:  # noqa: BLE001 — census must never affect exit code
+        pass
     return code
 
 

--- a/distil/updatecheck.py
+++ b/distil/updatecheck.py
@@ -1,0 +1,58 @@
+"""Once-a-day update notice on long-lived commands (wrap/proxy).
+
+The gh/Homebrew pattern: check PyPI for a newer version at most every 24h and
+print one stderr line if you're behind. This talks ONLY to pypi.org (the same
+lookup `distil onboard` already does) — it is not telemetry, sends nothing
+about you, and is disclosed in TELEMETRY.md. Opt out: DISTIL_NO_UPDATE_CHECK=1.
+
+Runs in a daemon thread so a slow PyPI can never delay proxy/wrap startup.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+MIN_INTERVAL_S = 24 * 3600
+
+
+def _last_path() -> Path:
+    return Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil"))) / "update-last"
+
+
+def _due() -> bool:
+    if os.environ.get("DISTIL_NO_UPDATE_CHECK", "") not in ("", "0"):
+        return False
+    try:
+        last = float(_last_path().read_text(encoding="utf-8").strip() or 0)
+    except (OSError, ValueError):
+        last = 0.0
+    return time.time() - last >= MIN_INTERVAL_S
+
+
+def _check() -> None:
+    try:
+        _last_path().parent.mkdir(parents=True, exist_ok=True)
+        _last_path().write_text(str(int(time.time())), encoding="utf-8")
+        from . import __version__
+        from .onboard import is_outdated, latest_pypi_version
+
+        latest = latest_pypi_version()
+        if latest and is_outdated(__version__, latest):
+            print(
+                f"  distil {latest} is available (you run {__version__}) — `distil upgrade`",
+                file=sys.stderr,
+            )
+    except Exception:  # noqa: BLE001 — a version notice must never break the host command
+        pass
+
+
+def maybe_notify() -> bool:
+    """Kick off the throttled background check. Returns True if one started."""
+    if not _due():
+        return False
+    threading.Thread(target=_check, daemon=True, name="distil-updatecheck").start()
+    return True

--- a/docs/adr/0002-adoption-telemetry-opt-in-census.md
+++ b/docs/adr/0002-adoption-telemetry-opt-in-census.md
@@ -1,0 +1,76 @@
+# ADR 0002 — Adoption measurement: passive channels + opt-in content-free census
+
+- Status: Accepted
+- Date: 2026-07-19
+- Deciders: distil maintainers
+
+## Context
+
+We need an adoption picture: how many installs (by version), whether they are
+active, and community-wide tokens/$ saved. Today distil has **zero egress to a
+distil-controlled host** — the only non-LLM outbound request in the codebase is
+the PyPI version check inside `distil onboard` (skippable with `--offline`).
+The "federated leaderboard" (`distil/telemetry.py`) signs content-free
+aggregates but writes them to a **local file**; nothing is ever sent.
+
+Two public claims are load-bearing and must survive this feature:
+
+- `README.md`: "Measured on **your** traffic, never estimated, **nothing leaves
+  your machine**"
+- `distil/ledger.py`: community aggregation "is a deliberate **OPT-IN** … this
+  module never sends anything"
+
+Industry survey (2026-07): opt-out phone-home is the market norm (Next.js,
+Homebrew, gh, Continue, VS Code, .NET) but every one of them has drawn
+privacy backlash, and Continue shipped a bug where opt-out still sent. aider
+(opt-in + publishes its own event log) and LiteLLM (no telemetry at all) are
+the privacy-respecting poles. Headroom — our closest competitor — publishes
+fleet-wide savings ("1.4B tokens saved across 249 instances") from an
+opt-out-documented beacon. Passive registry channels (pypistats, pepy,
+Homebrew analytics, Docker Hub, GitHub traffic) count installs with **zero
+client code**.
+
+## Decision
+
+Three layers, in order of preference:
+
+1. **Passive first.** Install/version/geo adoption comes from registry-side
+   channels (PyPI stats, pepy per-version, GitHub traffic, Docker pulls),
+   snapshotted nightly by CI into a `metrics` branch — no byte of telemetry
+   code runs on a user's machine. This is a differentiator, not a compromise:
+   *we don't need to phone home to know we're used.*
+
+2. **Census is OPT-IN, content-free by construction, and transparent.** The one
+   thing passive channels cannot see — active usage and community savings — is
+   a periodic ping (`distil/census.py`) that sends ONLY: anonymous install id
+   (random UUID, revocable by deleting a file), distil version, OS/arch/python,
+   and the same numeric `SavingsAggregate` shape the federated leaderboard
+   already signs (tokens/dollars saved, runs — numbers, never content). It is
+   **off until the user says yes** (`distil census on`, or accepting the
+   onboard prompt). `DO_NOT_TRACK=1` and `DISTIL_NO_TELEMETRY=1` win over a
+   stored opt-in, unconditionally. `distil census show` prints the exact
+   payload that would be sent; TELEMETRY.md publishes the full schema.
+   Transport is fail-open (1.5s budget, never blocks, never changes exit
+   codes) and fires at most once per 24h, from the wrap/proxy exit flush.
+
+3. **Community savings board rides the same consent.** Opted-in censuses
+   aggregate server-side into a public JSON the docs site renders — the
+   Headroom-style fleet number, earned the opt-in way.
+
+The market-norm alternative (opt-out) was rejected: for a tool whose brand is
+"content never leaves your machine," a single opt-out incident is existential,
+and the README claim would become false the day the feature ships.
+
+## Consequences
+
+- README/THREAT_MODEL gain one honest qualifier: nothing leaves your machine
+  *except an opt-in census you can read before sending* (TELEMETRY.md).
+- A distil-controlled ingest endpoint becomes part of the surface
+  (`DISTIL_CENSUS_ENDPOINT` override; server code lives in-repo so the
+  deployment is reviewable). Until it is deployed, census stays dark —
+  consent UX exists, sends fail silently.
+- The anonymous install id is the first persisted identifier
+  (`~/.distil/install-id`); it is minted only after consent, and `distil
+  census off` deletes it.
+- Version detail beyond PyPI's own stats (e.g. per-version splits) comes from
+  pepy/BigQuery, not from users' machines.

--- a/docs/index.html
+++ b/docs/index.html
@@ -385,6 +385,55 @@
       <div class="foot">stdlib-only · 700+ tests · pip · docker · pyz</div>
     </div>
   </div>
+
+  <!-- Live adoption strip — hydrated from the metrics branch (nightly rollup of
+       registry stats + the opt-in census; see TELEMETRY.md). Hidden until the
+       fetch succeeds, so a missing/empty metrics branch costs nothing. -->
+  <div class="stats" id="adoption-live" hidden>
+    <div class="stat">
+      <div class="n" id="al-downloads">–</div>
+      <div class="l">PyPI downloads / month</div>
+      <div class="foot">registry-side — no client telemetry</div>
+    </div>
+    <div class="stat">
+      <div class="n" id="al-installs">–</div>
+      <div class="l">Active installs, 30d</div>
+      <div class="foot">opt-in census · <a href="https://github.com/dshakes/distil/blob/main/TELEMETRY.md">what's sent</a></div>
+    </div>
+    <div class="stat hl">
+      <div class="n" id="al-tokens">–</div>
+      <div class="l">Community tokens saved</div>
+      <div class="foot">Σ of opted-in ledgers · numbers only, never content</div>
+    </div>
+    <div class="stat hl">
+      <div class="n" id="al-dollars">–</div>
+      <div class="l">Community $ saved</div>
+      <div class="foot">same census · updated nightly</div>
+    </div>
+  </div>
+  <script>
+  (function () {
+    "use strict";
+    var human = function (n) {
+      if (n == null) return null;
+      var u = [[1e12, "T"], [1e9, "B"], [1e6, "M"], [1e3, "k"]];
+      for (var i = 0; i < u.length; i++) if (n >= u[i][0]) return (n / u[i][0]).toFixed(1) + u[i][1];
+      return String(Math.round(n));
+    };
+    fetch("https://raw.githubusercontent.com/dshakes/distil/metrics/data/aggregates.json")
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (a) {
+        if (!a) return;
+        var set = function (id, v) { if (v != null) document.getElementById(id).textContent = v; };
+        set("al-downloads", human(a.channels && a.channels.pypi_downloads_month));
+        set("al-installs", human(a.installs && a.installs.active_30d));
+        set("al-tokens", human(a.savings && a.savings.tokens));
+        set("al-dollars", a.savings && a.savings.dollars != null ? "$" + human(a.savings.dollars) : null);
+        document.getElementById("adoption-live").hidden = false;
+      })
+      .catch(function () { /* metrics branch absent — strip stays hidden */ });
+  })();
+  </script>
 </div></header>
 
 <section id="why"><div class="wrap">

--- a/packaging/census-worker/README.md
+++ b/packaging/census-worker/README.md
@@ -1,0 +1,48 @@
+# Census ingest worker
+
+The receiving end of the opt-in adoption census (`distil census on`,
+[TELEMETRY.md](../../TELEMETRY.md)). A single zero-dependency Vercel function:
+
+```
+POST /v1/ping  →  validate (lib/validate.js)  →  repository_dispatch "census"
+                                                  → .github/workflows/census-ingest.yml
+                                                  → metrics branch data/census.jsonl
+                                                  → nightly rollup → aggregates + badges
+```
+
+The worker **stores nothing** — no database, no IPs. GitHub's metrics branch
+is the datastore, so ingest, history, and rollup are all publicly auditable.
+
+## Deploy (one time, ~3 minutes)
+
+1. Create a **fine-grained PAT** (github.com → Settings → Developer settings)
+   scoped to the **single repo** `dshakes/distil` with **Contents: Read and
+   write** only. That is the entire blast radius of a leaked token.
+2. ```sh
+   cd packaging/census-worker
+   vercel deploy --prod
+   vercel env add GITHUB_DISPATCH_TOKEN   # paste the PAT (Production)
+   vercel deploy --prod                   # redeploy with the env var
+   ```
+3. Point the DNS name at it: CNAME `census.distil.dev` → the Vercel
+   deployment (or skip DNS and ship a release that sets
+   `DEFAULT_ENDPOINT` in `distil/census.py` to the `*.vercel.app` URL).
+4. Recommended: enable Vercel Firewall rate limiting on `/v1/ping`
+   (the in-function bucket is best-effort per instance only).
+
+Until this is deployed, opted-in clients fail open — one swallowed 1.5s
+attempt per day, nothing else.
+
+## Test
+
+```sh
+node --test packaging/census-worker/test/validate.test.mjs
+```
+
+## Verify after deploy
+
+```sh
+distil census show                                     # the payload
+distil census show | curl -sS -X POST --json @- \
+  https://census.distil.dev/v1/ping -o /dev/null -w '%{http_code}\n'   # → 202
+```

--- a/packaging/census-worker/README.md
+++ b/packaging/census-worker/README.md
@@ -24,11 +24,16 @@ is the datastore, so ingest, history, and rollup are all publicly auditable.
    vercel env add GITHUB_DISPATCH_TOKEN   # paste the PAT (Production)
    vercel deploy --prod                   # redeploy with the env var
    ```
-3. Point the DNS name at it: CNAME `census.distil.dev` → the Vercel
-   deployment (or skip DNS and ship a release that sets
-   `DEFAULT_ENDPOINT` in `distil/census.py` to the `*.vercel.app` URL).
+3. The client default (`distil/census.py`) already points at the live
+   production domain `https://distil-census.vercel.app/v1/ping`. To move to a
+   custom domain later (e.g. `census.distil.dev`), CNAME it to the deployment
+   and bump `DEFAULT_ENDPOINT` — old clients keep working via the .vercel.app
+   domain either way.
 4. Recommended: enable Vercel Firewall rate limiting on `/v1/ping`
    (the in-function bucket is best-effort per instance only).
+   Note: the team-scoped deployment aliases sit behind Vercel SSO (401);
+   only the public production domain above serves anonymous pings — that
+   asymmetry is fine and expected.
 
 Until this is deployed, opted-in clients fail open — one swallowed 1.5s
 attempt per day, nothing else.
@@ -44,5 +49,5 @@ node --test packaging/census-worker/test/validate.test.mjs
 ```sh
 distil census show                                     # the payload
 distil census show | curl -sS -X POST --json @- \
-  https://census.distil.dev/v1/ping -o /dev/null -w '%{http_code}\n'   # → 202
+  https://distil-census.vercel.app/v1/ping -o /dev/null -w '%{http_code}\n'   # → 202
 ```

--- a/packaging/census-worker/api/ping.js
+++ b/packaging/census-worker/api/ping.js
@@ -1,0 +1,80 @@
+// distil census ingest — Vercel serverless function (zero dependencies).
+//
+// POST /v1/ping  { schema:1, install_id, version, os, arch, python,
+//                  runs, tokens_saved, dollars_saved, ts }
+//
+// Validates strictly (lib/validate.js), then forwards the census to GitHub as
+// a `repository_dispatch` event on DISPATCH_REPO; .github/workflows/
+// census-ingest.yml re-validates and appends it to the metrics branch. The
+// worker itself stores NOTHING: no database, no IP addresses, no logs beyond
+// the platform's default request log.
+//
+// Security posture:
+//   - strict schema allowlist, 1 KB body cap, POST-only, JSON-only
+//   - client IP is never read, forwarded, or persisted by this code
+//   - GITHUB_DISPATCH_TOKEN is a fine-grained PAT scoped to ONE repo with
+//     Contents read/write only (see README.md) — the blast radius of a leak
+//     is "can push commits to the public metrics repo"
+//   - per-instance token-bucket rate limit (best effort on serverless; put
+//     Vercel Firewall / WAF rate limiting in front for the real guarantee)
+
+"use strict";
+
+const { validateCensus, MAX_BODY_BYTES } = require("../lib/validate.js");
+
+// ponytail: per-instance in-memory bucket — real rate limiting belongs in the
+// platform firewall; this only blunts a single hot instance.
+const bucket = { tokens: 30, last: Date.now() };
+function rateLimited() {
+  const now = Date.now();
+  bucket.tokens = Math.min(30, bucket.tokens + ((now - bucket.last) / 1000) * 0.5);
+  bucket.last = now;
+  if (bucket.tokens < 1) return true;
+  bucket.tokens -= 1;
+  return false;
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    return res.end();
+  }
+  if (rateLimited()) {
+    res.statusCode = 429;
+    return res.end();
+  }
+
+  // Vercel parses JSON bodies into req.body; enforce the size cap regardless.
+  const body = req.body;
+  if (!body || JSON.stringify(body).length > MAX_BODY_BYTES) {
+    res.statusCode = 413;
+    return res.end();
+  }
+  const verdict = validateCensus(body);
+  if (!verdict.ok) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    return res.end(JSON.stringify({ error: verdict.error }));
+  }
+
+  const repo = process.env.DISPATCH_REPO || "dshakes/distil";
+  const token = process.env.GITHUB_DISPATCH_TOKEN;
+  if (!token) {
+    res.statusCode = 503;
+    return res.end();
+  }
+
+  const resp = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "distil-census-worker",
+    },
+    body: JSON.stringify({ event_type: "census", client_payload: { census: body } }),
+  });
+
+  res.statusCode = resp.status === 204 ? 202 : 502;
+  res.end();
+};

--- a/packaging/census-worker/lib/validate.js
+++ b/packaging/census-worker/lib/validate.js
@@ -1,0 +1,67 @@
+// Census payload validation — the server-side twin of distil/census.py's
+// frozen schema. Pure function, no I/O, unit-tested with node:test.
+//
+// Contract: EXACTLY the schema-1 keys, tight types, bounded sizes. Anything
+// else is rejected — the ingest pipeline re-validates in CI (defense in
+// depth), but nothing malformed should even reach the dispatch.
+
+"use strict";
+
+const MAX_BODY_BYTES = 1024; // a census is ~250 bytes; 1 KB is generous
+const KEYS = [
+  "schema",
+  "install_id",
+  "version",
+  "os",
+  "arch",
+  "python",
+  "runs",
+  "tokens_saved",
+  "dollars_saved",
+  "ts",
+];
+
+// Hard ceilings — a hostile client must not be able to skew the community
+// aggregates with absurd numbers (rollup enforces the same caps).
+const MAX_TOKENS_SAVED = 1e13;
+const MAX_DOLLARS_SAVED = 1e8;
+const MAX_RUNS = 1e9;
+
+function isShortString(v, max) {
+  return typeof v === "string" && v.length > 0 && v.length <= max;
+}
+
+/** Validate a parsed census object. Returns {ok: true} or {ok: false, error}. */
+function validateCensus(p) {
+  if (typeof p !== "object" || p === null || Array.isArray(p)) {
+    return { ok: false, error: "not an object" };
+  }
+  const keys = Object.keys(p).sort();
+  if (keys.join(",") !== [...KEYS].sort().join(",")) {
+    return { ok: false, error: "schema keys mismatch" };
+  }
+  if (p.schema !== 1) return { ok: false, error: "unknown schema version" };
+  if (!/^[0-9a-f]{32}$/.test(String(p.install_id))) {
+    return { ok: false, error: "install_id must be 32 hex chars" };
+  }
+  if (!isShortString(p.version, 64)) return { ok: false, error: "bad version" };
+  for (const k of ["os", "arch", "python"]) {
+    if (!isShortString(p[k], 64) || p[k].includes("/") || p[k].includes("\\")) {
+      return { ok: false, error: `bad ${k}` };
+    }
+  }
+  for (const [k, max] of [
+    ["runs", MAX_RUNS],
+    ["tokens_saved", MAX_TOKENS_SAVED],
+    ["dollars_saved", MAX_DOLLARS_SAVED],
+    ["ts", 4102444800], // 2100-01-01 — clock sanity
+  ]) {
+    const v = p[k];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0 || v > max) {
+      return { ok: false, error: `bad ${k}` };
+    }
+  }
+  return { ok: true };
+}
+
+module.exports = { validateCensus, MAX_BODY_BYTES };

--- a/packaging/census-worker/test/validate.test.mjs
+++ b/packaging/census-worker/test/validate.test.mjs
@@ -1,0 +1,57 @@
+// node --test packaging/census-worker/test/
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { validateCensus } = require("../lib/validate.js");
+
+const good = () => ({
+  schema: 1,
+  install_id: "a".repeat(32),
+  version: "1.21.0",
+  os: "Darwin",
+  arch: "arm64",
+  python: "3.12.13",
+  runs: 42,
+  tokens_saved: 1000,
+  dollars_saved: 1.23,
+  ts: 1784500000,
+});
+
+test("accepts a well-formed census", () => {
+  assert.equal(validateCensus(good()).ok, true);
+});
+
+test("rejects extra keys (frozen schema)", () => {
+  const p = { ...good(), extra: "nope" };
+  assert.equal(validateCensus(p).ok, false);
+});
+
+test("rejects missing keys", () => {
+  const p = good();
+  delete p.runs;
+  assert.equal(validateCensus(p).ok, false);
+});
+
+test("rejects non-hex install ids", () => {
+  assert.equal(validateCensus({ ...good(), install_id: "Z".repeat(32) }).ok, false);
+  assert.equal(validateCensus({ ...good(), install_id: "abc" }).ok, false);
+});
+
+test("rejects absurd numbers (aggregate-skew guard)", () => {
+  assert.equal(validateCensus({ ...good(), tokens_saved: 1e14 }).ok, false);
+  assert.equal(validateCensus({ ...good(), dollars_saved: -1 }).ok, false);
+  assert.equal(validateCensus({ ...good(), runs: Infinity }).ok, false);
+  assert.equal(validateCensus({ ...good(), ts: 5e9 }).ok, false);
+});
+
+test("rejects path-ish platform strings", () => {
+  assert.equal(validateCensus({ ...good(), os: "../../etc" }).ok, false);
+});
+
+test("rejects wrong schema version and non-objects", () => {
+  assert.equal(validateCensus({ ...good(), schema: 2 }).ok, false);
+  assert.equal(validateCensus(null).ok, false);
+  assert.equal(validateCensus([1]).ok, false);
+});

--- a/packaging/census-worker/vercel.json
+++ b/packaging/census-worker/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/v1/ping", "destination": "/api/ping" }]
+}

--- a/scripts/adoption_snapshot.py
+++ b/scripts/adoption_snapshot.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Passive adoption snapshot — registry-side numbers, zero user telemetry.
+
+Pulls the adoption signals that exist WITHOUT any code running on a user's
+machine (see specs/adoption-telemetry.md, phase 0) and prints ONE JSON line:
+
+    pypistats.org  — downloads last day/week/month
+    GitHub API     — stars, forks
+    GitHub traffic — clones + unique cloners, views (14-day rolling window,
+                     which is exactly why this runs on a nightly cron: the
+                     history evaporates unless somebody snapshots it)
+    Docker Hub     — cumulative pulls (absent until an image is published)
+
+Each source degrades independently: a failure records {"error": "..."} for
+that source and never kills the row. Stdlib only; GITHUB_TOKEN (with repo
+push access, e.g. the Actions token) enables the traffic endpoints.
+
+Usage:  python scripts/adoption_snapshot.py >> adoption.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+REPO = os.environ.get("DISTIL_REPO", "dshakes/distil")
+PYPI_PACKAGE = os.environ.get("DISTIL_PYPI", "distil-llm")
+DOCKER_IMAGE = os.environ.get("DISTIL_DOCKER", "")  # e.g. "dshakes/distil"
+
+
+def _get(url: str, headers: dict | None = None) -> dict:
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.load(resp)
+
+
+def _source(fn):
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 — per-source degradation is the contract
+        return {"error": f"{type(exc).__name__}: {exc}"[:200]}
+
+
+def snapshot() -> dict:
+    gh_headers = {}
+    if os.environ.get("GITHUB_TOKEN"):
+        gh_headers["Authorization"] = f"Bearer {os.environ['GITHUB_TOKEN']}"
+
+    def pypi() -> dict:
+        data = _get(f"https://pypistats.org/api/packages/{PYPI_PACKAGE}/recent")["data"]
+        return {"day": data["last_day"], "week": data["last_week"], "month": data["last_month"]}
+
+    def github() -> dict:
+        d = _get(f"https://api.github.com/repos/{REPO}", gh_headers)
+        return {"stars": d["stargazers_count"], "forks": d["forks_count"]}
+
+    def clones() -> dict:
+        d = _get(f"https://api.github.com/repos/{REPO}/traffic/clones", gh_headers)
+        return {"count_14d": d["count"], "uniques_14d": d["uniques"]}
+
+    def views() -> dict:
+        d = _get(f"https://api.github.com/repos/{REPO}/traffic/views", gh_headers)
+        return {"count_14d": d["count"], "uniques_14d": d["uniques"]}
+
+    def docker() -> dict:
+        if not DOCKER_IMAGE:
+            return {"skipped": "no image configured"}
+        d = _get(f"https://hub.docker.com/v2/repositories/{DOCKER_IMAGE}/")
+        return {"pulls": d["pull_count"], "stars": d["star_count"]}
+
+    return {
+        "ts": int(time.time()),
+        "date": time.strftime("%Y-%m-%d"),
+        "pypi_downloads": _source(pypi),
+        "github": _source(github),
+        "clones": _source(clones),
+        "views": _source(views),
+        "docker": _source(docker),
+    }
+
+
+if __name__ == "__main__":
+    row = snapshot()
+    json.dump(row, sys.stdout, sort_keys=True)
+    print()
+    # Non-zero only when EVERY source failed — one dead API must not fail the cron.
+    sources = [v for k, v in row.items() if isinstance(v, dict)]
+    if all("error" in s for s in sources):
+        sys.exit(1)

--- a/scripts/census_rollup.py
+++ b/scripts/census_rollup.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Roll census + passive snapshots into public aggregates and badge JSONs.
+
+Reads (from the metrics branch checkout):
+    data/census.jsonl    — opted-in pings (schema validated on ingest)
+    data/adoption.jsonl  — nightly passive registry snapshots
+
+Writes:
+    data/aggregates.json — the whole adoption picture, one document:
+                           installs (census + per-channel), actives 7/30d,
+                           versions in the wild, community tokens/$ saved
+    data/badges/*.json   — shields.io "endpoint" schema, so README badges and
+                           the docs site update the night data changes
+
+Rules: latest census per install_id wins (a machine is one instance, not one
+per ping); rows failing validation or the hard ceilings are dropped, so a
+hostile ping that somehow reached the file still can't skew the totals.
+
+Usage: python3 scripts/census_rollup.py <metrics-dir>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from census_validate import validate  # noqa: E402 — CI runs this file directly
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue  # one corrupt line never kills the rollup
+    return rows
+
+
+def _humanize(n: float) -> str:
+    for cut, suffix in ((1e12, "T"), (1e9, "B"), (1e6, "M"), (1e3, "k")):
+        if n >= cut:
+            return f"{n / cut:.1f}{suffix}"
+    return str(int(n))
+
+
+def rollup(metrics_dir: Path, now: float | None = None) -> dict:
+    now = now or time.time()
+    census = [r for r in _read_jsonl(metrics_dir / "data" / "census.jsonl") if validate(r) is None]
+    adoption = _read_jsonl(metrics_dir / "data" / "adoption.jsonl")
+
+    latest: dict[str, dict] = {}
+    for row in census:
+        cur = latest.get(row["install_id"])
+        if cur is None or row["ts"] >= cur["ts"]:
+            latest[row["install_id"]] = row
+
+    def active(days: int) -> int:
+        return sum(1 for r in latest.values() if now - r["ts"] <= days * 86400)
+
+    versions = Counter(r["version"] for r in latest.values())
+    tokens = sum(int(r["tokens_saved"]) for r in latest.values())
+    dollars = round(sum(float(r["dollars_saved"]) for r in latest.values()), 2)
+
+    last_passive = adoption[-1] if adoption else {}
+    pypi = last_passive.get("pypi_downloads", {})
+    return {
+        "generated_ts": int(now),
+        "installs": {
+            "census_total": len(latest),
+            "active_7d": active(7),
+            "active_30d": active(30),
+            "by_version": dict(versions.most_common()),
+        },
+        "savings": {"tokens": tokens, "dollars": dollars, "instances": len(latest)},
+        "channels": {
+            "pypi_downloads_month": pypi.get("month"),
+            "pypi_downloads_week": pypi.get("week"),
+            "github_stars": last_passive.get("github", {}).get("stars"),
+            "clones_uniques_14d": last_passive.get("clones", {}).get("uniques_14d"),
+            "docker_pulls": last_passive.get("docker", {}).get("pulls"),
+        },
+    }
+
+
+def badges(agg: dict) -> dict[str, dict]:
+    """shields.io endpoint-schema documents, one per badge."""
+
+    def badge(label: str, message: str, color: str = "6e56cf") -> dict:
+        return {"schemaVersion": 1, "label": label, "message": message, "color": color}
+
+    pypi_month = agg["channels"]["pypi_downloads_month"]
+    return {
+        "savings-tokens": badge(
+            "community tokens saved", _humanize(agg["savings"]["tokens"]) or "0"
+        ),
+        "savings-dollars": badge("community $ saved", f"${_humanize(agg['savings']['dollars'])}"),
+        "active-installs": badge("active installs (30d)", str(agg["installs"]["active_30d"])),
+        "downloads-month": badge(
+            "pypi downloads/month", _humanize(pypi_month) if pypi_month else "n/a"
+        ),
+    }
+
+
+def main() -> int:
+    metrics_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(".")
+    agg = rollup(metrics_dir)
+    out = metrics_dir / "data"
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "aggregates.json").write_text(json.dumps(agg, indent=2) + "\n", encoding="utf-8")
+    badge_dir = out / "badges"
+    badge_dir.mkdir(exist_ok=True)
+    for name, doc in badges(agg).items():
+        (badge_dir / f"{name}.json").write_text(json.dumps(doc) + "\n", encoding="utf-8")
+    print(json.dumps(agg["savings"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/census_validate.py
+++ b/scripts/census_validate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Server-side census validation — the CI twin of the worker's validate.js.
+
+Defense in depth: the ingest workflow re-validates every repository_dispatch
+payload before it touches the metrics branch, so a compromised or bypassed
+worker still cannot append garbage. Same frozen schema as distil/census.py,
+same hard ceilings as lib/validate.js.
+
+Usage: echo '<census json>' | python3 scripts/census_validate.py
+Exits 0 and re-emits canonical JSON on stdout, exits 1 with the reason on
+stderr otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+KEYS = {
+    "schema",
+    "install_id",
+    "version",
+    "os",
+    "arch",
+    "python",
+    "runs",
+    "tokens_saved",
+    "dollars_saved",
+    "ts",
+}
+NUM_CAPS = {"runs": 1e9, "tokens_saved": 1e13, "dollars_saved": 1e8, "ts": 4102444800}
+
+
+def validate(p: object) -> str | None:
+    """Return None if valid, else the reason."""
+    if not isinstance(p, dict):
+        return "not an object"
+    if set(p) != KEYS:
+        return "schema keys mismatch"
+    if p["schema"] != 1:
+        return "unknown schema version"
+    if not re.fullmatch(r"[0-9a-f]{32}", str(p["install_id"])):
+        return "install_id must be 32 hex chars"
+    for k in ("version", "os", "arch", "python"):
+        v = p[k]
+        if not isinstance(v, str) or not 0 < len(v) <= 64:
+            return f"bad {k}"
+        if k != "version" and ("/" in v or "\\" in v):
+            return f"bad {k}"
+    for k, cap in NUM_CAPS.items():
+        v = p[k]
+        if isinstance(v, bool) or not isinstance(v, (int, float)) or not 0 <= v <= cap:
+            return f"bad {k}"
+    return None
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as exc:
+        print(f"invalid json: {exc}", file=sys.stderr)
+        return 1
+    reason = validate(payload)
+    if reason:
+        print(f"rejected: {reason}", file=sys.stderr)
+        return 1
+    json.dump(payload, sys.stdout, sort_keys=True)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/adoption-telemetry.md
+++ b/specs/adoption-telemetry.md
@@ -1,0 +1,69 @@
+# Adoption telemetry — spec & phases
+
+Goal: know (a) installs by version, (b) active usage, (c) community tokens/$
+saved — without breaking the "nothing leaves your machine" promise.
+Decision record: `docs/adr/0002-adoption-telemetry-opt-in-census.md`.
+
+## What we can already know (no code)
+
+| Signal | Source | 2026-07-19 baseline |
+|---|---|---|
+| Downloads/month | pypistats.org API | 11,943 (1,632/wk) |
+| Downloads by version | pepy.tech / PyPI BigQuery | (site/API) |
+| Unique cloners /14d | GitHub traffic API | 335 (2,610 clones) |
+| Stars/forks | GitHub API | 5 / 1 |
+| Brew installs | tap has NO public analytics (homebrew-core only) | n/a |
+| Docker pulls | Docker Hub API (if image published) | n/a |
+
+GitHub traffic is a rolling 14-day window — history is lost unless snapshotted.
+
+## Phases
+
+**Phase 0 — passive adoption pipeline (zero client code).**
+`scripts/adoption_snapshot.py` pulls pypistats recent+system, GitHub
+repo/traffic (clones, views), Docker Hub pulls; emits one JSON line.
+`.github/workflows/adoption-stats.yml` runs it nightly and appends to
+`data/adoption.jsonl` on the `metrics` branch (main stays clean).
+Acceptance: two consecutive scheduled runs append rows; script runs locally
+with `GITHUB_TOKEN` and degrades per-source (a failing source records an
+`error` field, never kills the row).
+
+**Phase 1 — opt-in census client (this branch).**
+`distil/census.py`: consent state (`~/.distil/census`), install id
+(`~/.distil/install-id`, minted on consent, deleted on `off`), payload
+builder (version, os, arch, python, days_active, tokens/dollars saved totals
+from `ledger.summary()`), sender (urllib POST, 1.5s, fail-silent), 24h
+throttle (`~/.distil/census-last`). Hard gates in one place:
+`DO_NOT_TRACK=1` / `DISTIL_NO_TELEMETRY=1` > stored consent > default OFF.
+CLI: `distil census on|off|status|show` (`show` prints the exact JSON, sends
+nothing). Onboard asks once (interactive only, default No). Ping fires from
+the wrap/proxy shutdown flush. `TELEMETRY.md` documents schema + gates;
+README/THREAT_MODEL get the honest qualifier.
+Acceptance: unit tests prove (1) no consent → no network even with endpoint
+set, (2) DNT beats stored consent, (3) payload contains only allowed keys —
+schema-frozen test, (4) `off` deletes install-id, (5) throttle honored,
+(6) send failure never raises. Full suite + gates PASS.
+
+**Phase 2 — ingest + public aggregates (needs a deploy decision).**
+Tiny ingest service (Cloudflare Worker or equivalent, code in
+`packaging/census-worker/`): validates schema, rate-limits, discards IPs,
+upserts by install id, publishes rolled-up JSON (installs by version, actives
+by week, Σ tokens/$ saved) to a public URL. Docs site "adoption" panel reads
+it. Deploy is a human step (infra creds); until then census sends fail open.
+
+**Phase 3 — community savings board.**
+Wire the existing signed `SavingsAggregate` (`distil/telemetry.py`) through
+the same endpoint (`distil federated-leaderboard --submit`), render the
+Headroom-style fleet counter ("N tokens saved across M instances") on the
+site — opt-in only.
+
+**Phase 4 — later.**
+Version-check update notifier on CLI start (24h throttle, benefit-first,
+`DISTIL_NO_UPDATE_CHECK`), doubling as census transport for opted-in users;
+OTel exporter for enterprise fleets.
+
+## Non-goals
+
+- No content, prompts, hashes-of-content, file paths, or key material — ever.
+- No opt-out phone-home. No scarf-js-style post-install ping.
+- No per-request events; the census is one small JSON per day maximum.

--- a/specs/adoption-telemetry.md
+++ b/specs/adoption-telemetry.md
@@ -44,23 +44,28 @@ set, (2) DNT beats stored consent, (3) payload contains only allowed keys —
 schema-frozen test, (4) `off` deletes install-id, (5) throttle honored,
 (6) send failure never raises. Full suite + gates PASS.
 
-**Phase 2 — ingest + public aggregates (needs a deploy decision).**
-Tiny ingest service (Cloudflare Worker or equivalent, code in
-`packaging/census-worker/`): validates schema, rate-limits, discards IPs,
-upserts by install id, publishes rolled-up JSON (installs by version, actives
-by week, Σ tokens/$ saved) to a public URL. Docs site "adoption" panel reads
-it. Deploy is a human step (infra creds); until then census sends fail open.
+**Phase 2 — ingest + public aggregates. IMPLEMENTED (deploy = human step).**
+`packaging/census-worker/` (Vercel function, zero-dep): strict validation
+(1 KB cap, key allowlist, numeric ceilings), stores nothing, forwards to
+`repository_dispatch("census")`. `census-ingest.yml` RE-validates
+(`scripts/census_validate.py`, defense in depth) and appends to
+`data/census.jsonl` on the `metrics` branch — the datastore is a public git
+branch, so the whole pipeline is auditable. `scripts/census_rollup.py`
+(nightly, inside adoption-stats.yml) dedupes latest-per-install-id, drops
+out-of-ceiling rows, emits `data/aggregates.json` + shields endpoint badges.
+Remaining human step: mint the fine-grained PAT + `vercel deploy` + DNS
+(runbook: packaging/census-worker/README.md). Until then, sends fail open.
 
-**Phase 3 — community savings board.**
-Wire the existing signed `SavingsAggregate` (`distil/telemetry.py`) through
-the same endpoint (`distil federated-leaderboard --submit`), render the
-Headroom-style fleet counter ("N tokens saved across M instances") on the
-site — opt-in only.
+**Phase 3 — community savings board. IMPLEMENTED via the census.**
+Community Σ tokens/$ ride the census rollup (latest ledger totals per
+install id) — README endpoint badges + the live adoption strip on
+docs/index.html render them. The HMAC-signed `SavingsAggregate` federation
+(`distil/telemetry.py`) remains the org-internal path (file-based, unchanged).
 
-**Phase 4 — later.**
-Version-check update notifier on CLI start (24h throttle, benefit-first,
-`DISTIL_NO_UPDATE_CHECK`), doubling as census transport for opted-in users;
-OTel exporter for enterprise fleets.
+**Phase 4 — update notifier. IMPLEMENTED.**
+`distil/updatecheck.py`: wrap/proxy check PyPI ≤1/24h in a daemon thread,
+one stderr line when behind, `DISTIL_NO_UPDATE_CHECK=1` opts out, disclosed
+in TELEMETRY.md. (OTel exporter for enterprise fleets stays future work.)
 
 ## Non-goals
 

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -1,0 +1,132 @@
+"""Census guarantees — the promises TELEMETRY.md makes, executable.
+
+Every test isolates state via DISTIL_HOME=tmp_path and replaces the socket
+layer with a tripwire: if urlopen is reached when the rules say it must not
+be, the test fails loudly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from distil import census
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("DISTIL_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("DISTIL_CENSUS_ENDPOINT", raising=False)
+
+
+def _arm_network_tripwire(monkeypatch, calls: list):
+    def fake_urlopen(req, timeout=None):
+        calls.append(json.loads(req.data.decode()))
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return _Resp()
+
+    monkeypatch.setattr(census.urllib.request, "urlopen", fake_urlopen)
+
+
+def test_default_is_silent(monkeypatch):
+    """No consent → no network, even with an endpoint configured."""
+    calls: list = []
+    _arm_network_tripwire(monkeypatch, calls)
+    monkeypatch.setenv("DISTIL_CENSUS_ENDPOINT", "http://127.0.0.1:1/ping")
+    assert census.enabled() is False
+    assert census.maybe_ping() is False
+    assert calls == []
+
+
+def test_do_not_track_beats_stored_consent(monkeypatch):
+    calls: list = []
+    _arm_network_tripwire(monkeypatch, calls)
+    census.opt_in()
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    assert census.enabled() is False
+    assert census.maybe_ping() is False
+    assert calls == []
+
+
+def test_distil_no_telemetry_beats_stored_consent(monkeypatch):
+    calls: list = []
+    _arm_network_tripwire(monkeypatch, calls)
+    census.opt_in()
+    monkeypatch.setenv("DISTIL_NO_TELEMETRY", "1")
+    assert census.maybe_ping() is False
+    assert calls == []
+
+
+def test_payload_schema_frozen():
+    """The census may contain EXACTLY these keys — widening it must edit this
+    test and TELEMETRY.md together (that's the point)."""
+    census.opt_in()
+    payload = census.build_payload()
+    assert set(payload) == {
+        "schema",
+        "install_id",
+        "version",
+        "os",
+        "arch",
+        "python",
+        "runs",
+        "tokens_saved",
+        "dollars_saved",
+        "ts",
+    }
+    # Numbers and short platform strings only — nothing that can carry content.
+    for key, value in payload.items():
+        assert isinstance(value, (int, float, str)), key
+        if isinstance(value, str):
+            assert len(value) < 128, key
+            assert "/" not in value or key == "version", key  # no paths
+
+
+def test_opt_in_sends_and_throttles(monkeypatch):
+    calls: list = []
+    _arm_network_tripwire(monkeypatch, calls)
+    census.opt_in()
+    assert census.maybe_ping() is True
+    assert len(calls) == 1
+    assert calls[0]["schema"] == 1
+    # Second call inside 24h: throttled, no second request.
+    assert census.maybe_ping() is False
+    assert len(calls) == 1
+
+
+def test_opt_out_deletes_install_id():
+    iid = census.opt_in()
+    assert census.status()["install_id"] == iid
+    census.opt_out()
+    st = census.status()
+    assert st["install_id"] is None
+    assert st["consent"] == "off"
+    assert census.enabled() is False
+
+
+def test_send_failure_never_raises(monkeypatch):
+    def boom(req, timeout=None):
+        raise OSError("endpoint down")
+
+    monkeypatch.setattr(census.urllib.request, "urlopen", boom)
+    census.opt_in()
+    assert census.maybe_ping() is True  # attempted, swallowed
+
+
+def test_install_id_is_stable_and_random():
+    a = census.opt_in()
+    b = census.install_id()
+    assert a == b and len(a) == 32
+    census.opt_out()
+    c = census.opt_in()
+    assert c != a  # re-consent mints a fresh identity

--- a/tests/test_census_pipeline.py
+++ b/tests/test_census_pipeline.py
@@ -1,0 +1,138 @@
+"""Server-side census pipeline: validator (CI twin of the worker) + rollup."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS = Path(__file__).parent.parent / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # census_rollup imports census_validate by name
+    spec.loader.exec_module(mod)
+    return mod
+
+
+census_validate = _load("census_validate")
+census_rollup = _load("census_rollup")
+
+
+def _row(**kw) -> dict:
+    base = {
+        "schema": 1,
+        "install_id": "a" * 32,
+        "version": "1.21.0",
+        "os": "Darwin",
+        "arch": "arm64",
+        "python": "3.12.13",
+        "runs": 10,
+        "tokens_saved": 1000,
+        "dollars_saved": 1.5,
+        "ts": int(time.time()),
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Validator — must agree with distil/census.py's frozen schema
+# ---------------------------------------------------------------------------
+
+
+def test_validator_accepts_real_client_payload(tmp_path, monkeypatch):
+    """The payload distil/census.py actually builds passes the CI validator —
+    the two frozen schemas cannot drift apart without failing here."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    from distil import census
+
+    census.opt_in()
+    assert census_validate.validate(census.build_payload()) is None
+
+
+def test_validator_rejects(tmp_path):
+    assert census_validate.validate(_row(extra=1)) is not None
+    assert census_validate.validate(_row(install_id="zz")) is not None
+    assert census_validate.validate(_row(tokens_saved=1e14)) is not None
+    assert census_validate.validate(_row(runs=True)) is not None  # bool is not a count
+    assert census_validate.validate(_row(os="../etc")) is not None
+    assert census_validate.validate("not a dict") is not None
+
+
+# ---------------------------------------------------------------------------
+# Rollup
+# ---------------------------------------------------------------------------
+
+
+def _write_metrics(tmp_path: Path, census_rows: list[dict], adoption_rows: list[dict]) -> Path:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "census.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in census_rows), encoding="utf-8"
+    )
+    (data / "adoption.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in adoption_rows), encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_rollup_dedupes_by_install_id_latest_wins(tmp_path):
+    now = int(time.time())
+    rows = [
+        _row(install_id="a" * 32, tokens_saved=100, ts=now - 100),
+        _row(install_id="a" * 32, tokens_saved=500, ts=now),  # same machine, later
+        _row(install_id="b" * 32, tokens_saved=50, ts=now, version="1.20.0"),
+    ]
+    agg = census_rollup.rollup(_write_metrics(tmp_path, rows, []), now=now)
+    assert agg["installs"]["census_total"] == 2
+    assert agg["savings"]["tokens"] == 550  # 500 (latest a) + 50 (b), not 650
+    assert agg["installs"]["by_version"] == {"1.21.0": 1, "1.20.0": 1}
+
+
+def test_rollup_active_windows(tmp_path):
+    now = int(time.time())
+    rows = [
+        _row(install_id="a" * 32, ts=now - 86400),  # 1 day → active in both
+        _row(install_id="b" * 32, ts=now - 86400 * 20),  # 20d → 30d only
+        _row(install_id="c" * 32, ts=now - 86400 * 90),  # stale
+    ]
+    agg = census_rollup.rollup(_write_metrics(tmp_path, rows, []), now=now)
+    assert agg["installs"]["active_7d"] == 1
+    assert agg["installs"]["active_30d"] == 2
+    assert agg["installs"]["census_total"] == 3
+
+
+def test_rollup_drops_invalid_rows_and_survives_corruption(tmp_path):
+    now = int(time.time())
+    valid = _row(install_id="a" * 32, ts=now)
+    metrics = _write_metrics(tmp_path, [valid, _row(tokens_saved=1e14, install_id="b" * 32)], [])
+    with (metrics / "data" / "census.jsonl").open("a") as f:
+        f.write("{corrupt json\n")
+    agg = census_rollup.rollup(metrics, now=now)
+    assert agg["installs"]["census_total"] == 1  # skew row + corrupt line dropped
+
+
+def test_rollup_merges_passive_channels_and_badges(tmp_path):
+    now = int(time.time())
+    adoption = [
+        {
+            "ts": now,
+            "pypi_downloads": {"month": 11943, "week": 1632, "day": 46},
+            "github": {"stars": 5, "forks": 1},
+            "clones": {"uniques_14d": 335, "count_14d": 2610},
+            "docker": {"skipped": "no image configured"},
+        }
+    ]
+    rows = [_row(install_id="a" * 32, tokens_saved=1_500_000_000, ts=now)]
+    agg = census_rollup.rollup(_write_metrics(tmp_path, rows, adoption), now=now)
+    assert agg["channels"]["pypi_downloads_month"] == 11943
+    assert agg["channels"]["clones_uniques_14d"] == 335
+    badges = census_rollup.badges(agg)
+    assert badges["savings-tokens"]["message"] == "1.5B"
+    assert badges["downloads-month"]["message"] == "11.9k"
+    assert all(b["schemaVersion"] == 1 for b in badges.values())

--- a/tests/test_updatecheck.py
+++ b/tests/test_updatecheck.py
@@ -1,0 +1,75 @@
+"""Update-notice guarantees: throttled, opt-out, fail-open, notice only when behind."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from distil import updatecheck
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_NO_UPDATE_CHECK", raising=False)
+
+
+def _run_sync(monkeypatch):
+    """Make maybe_notify synchronous so tests can assert on its output."""
+
+    class _T:
+        def __init__(self, target, **kw):
+            self._t = target
+
+        def start(self):
+            self._t()
+
+    monkeypatch.setattr(updatecheck.threading, "Thread", _T)
+
+
+def test_notice_when_outdated(monkeypatch, capsys):
+    _run_sync(monkeypatch)
+    monkeypatch.setattr("distil.onboard.latest_pypi_version", lambda: "999.0.0")
+    assert updatecheck.maybe_notify() is True
+    assert "999.0.0" in capsys.readouterr().err
+
+
+def test_silent_when_current(monkeypatch, capsys):
+    _run_sync(monkeypatch)
+    from distil import __version__
+
+    monkeypatch.setattr("distil.onboard.latest_pypi_version", lambda: __version__)
+    assert updatecheck.maybe_notify() is True
+    assert capsys.readouterr().err == ""
+
+
+def test_throttled_to_daily(monkeypatch):
+    _run_sync(monkeypatch)
+    monkeypatch.setattr("distil.onboard.latest_pypi_version", lambda: "999.0.0")
+    assert updatecheck.maybe_notify() is True
+    assert updatecheck.maybe_notify() is False  # inside 24h → no second check
+
+
+def test_opt_out(monkeypatch):
+    monkeypatch.setenv("DISTIL_NO_UPDATE_CHECK", "1")
+    assert updatecheck.maybe_notify() is False
+
+
+def test_pypi_failure_is_swallowed(monkeypatch, capsys):
+    _run_sync(monkeypatch)
+
+    def boom():
+        raise OSError("pypi down")
+
+    monkeypatch.setattr("distil.onboard.latest_pypi_version", boom)
+    assert updatecheck.maybe_notify() is True  # started, failed silently
+    assert capsys.readouterr().err == ""
+
+
+def test_stale_marker_reenables(monkeypatch):
+    _run_sync(monkeypatch)
+    monkeypatch.setattr("distil.onboard.latest_pypi_version", lambda: "999.0.0")
+    updatecheck.maybe_notify()
+    updatecheck._last_path().write_text(str(time.time() - 100_000), encoding="utf-8")
+    assert updatecheck.maybe_notify() is True


### PR DESCRIPTION
## What this answers

**How many installs (by version), are they active, and how much is the community saving** — without breaking the load-bearing "nothing leaves your machine" claim.

Decision record: `docs/adr/0002-adoption-telemetry-opt-in-census.md` · Plan: `specs/adoption-telemetry.md` · Disclosure: `TELEMETRY.md`

## Design (from the competitor survey)

Headroom publishes fleet savings from an opt-out beacon; Next.js/gh/Continue all drew opt-out backlash (Continue shipped a bug where opt-out still sent). aider (opt-in + radical transparency) is the gold standard. **distil goes: passive registry channels for adoption (zero client code), an OPT-IN schema-frozen census for usage/savings, and full-pipeline auditability as the moat.**

## Phases (all implemented)

- **Phase 0 — passive:** `scripts/adoption_snapshot.py` + nightly `adoption-stats.yml` → `metrics` branch (PyPI downloads, GitHub traffic — 14-day rolling window, so the cron IS the history — stars, Docker pulls). Verified live: baseline 11.9k PyPI downloads/mo, 335 unique cloners/14d.
- **Phase 1 — census client:** `distil census on|off|status|show`; random install id minted on consent, deleted on revoke; `DO_NOT_TRACK`/`DISTIL_NO_TELEMETRY` beat stored consent; ≤1 content-free JSON/24h from the proxy-exit flush, fail-open; onboard asks once, `--yes` never consents. Schema frozen by test — widening it must edit TELEMETRY.md + the test together.
- **Phases 2+3 — ingest + community savings:** `packaging/census-worker/` (zero-dep Vercel fn: strict validation, 1 KB cap, numeric ceilings, stores nothing, no IPs) → `repository_dispatch` → `census-ingest.yml` **re-validates in CI** (defense in depth) → appends to the public `metrics` branch (auditable datastore) → nightly `census_rollup.py` (latest-per-install-id dedupe, skew-row drop) → `aggregates.json` + shields endpoint badges.
- **Phase 4 — update notice:** wrap/proxy check PyPI ≤1/24h (daemon thread, fail-open, `DISTIL_NO_UPDATE_CHECK`), disclosed in TELEMETRY.md.

## Live displays

- **README:** PyPI downloads/month badge + `community tokens saved` + `active installs (30d)` endpoint badges (read the metrics branch).
- **Site:** live adoption strip on `index.html` (downloads / active installs / Σ tokens / Σ $), hydrated from `aggregates.json`, hidden until data exists.

## Verification

- Full suite **1709 passed** (+22 new: census 8, pipeline 6, updatecheck 6, +2 wrap tripwire-adjacent), ruff clean, worker `node:test` 7/7.
- Rollup run end-to-end locally against a real census row + real registry snapshot; badge JSONs verified.
- CLI smoke: consent → preview → DNT override → revoke, all correct.

## Human steps after merge (runbook: `packaging/census-worker/README.md`)

1. Mint a fine-grained PAT (single repo, Contents R/W) → `vercel deploy --prod` the worker → CNAME `census.distil.dev` (until then, opted-in sends fail open — safe).
2. Optionally enable Vercel Firewall rate limiting on `/v1/ping`.
3. First `adoption-stats` run creates the `metrics` branch (or trigger via workflow_dispatch).