### PR TITLE
distil default --always-on: wire ANTHROPIC_BASE_URL into ~/.claude/settings.json

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1441,6 +1441,7 @@ def cmd_onboard(args: argparse.Namespace) -> int:
                 undo=False,
                 always_on=False,
                 no_start=False,
+                force=False,
             )
         )
         print()
@@ -1495,11 +1496,14 @@ def cmd_default(args: argparse.Namespace) -> int:
     from . import onboard
     from .setup import (
         alias_body,
+        default_settings_path,
         detect_shell,
         env_body,
         remove_managed,
         service_spec,
         service_unload_cmd,
+        unwire_settings_env,
+        wire_settings_env,
         write_managed,
     )
 
@@ -1527,6 +1531,11 @@ def cmd_default(args: argparse.Namespace) -> int:
                 print(f"✓ removed proxy service {path}")
             except OSError:
                 pass
+        if agent == "claude":  # inverse of the settings.json wiring below
+            st2, msg2 = unwire_settings_env(
+                default_settings_path(), "ANTHROPIC_BASE_URL", f"http://127.0.0.1:{args.port}"
+            )
+            print(("✓ " if st2 in ("ok", "absent", "foreign") else "✗ ") + msg2)
         print(f"  open a new terminal (or: source {rc}) to finish")
         return 0
 
@@ -1546,6 +1555,20 @@ def cmd_default(args: argparse.Namespace) -> int:
         print(f"✓ wrote proxy service → {path}")
         _st, msg = write_managed(rc, env_body(args.port, shell=shell))
         print(f"✓ {msg}  (ANTHROPIC_BASE_URL → http://127.0.0.1:{args.port})")
+        if agent == "claude":
+            # The rc export above only reaches a shell that sources it — an IDE
+            # extension (VSCode's Claude Code extension, or that same extension
+            # inside Cursor) execs the `claude` binary directly and never sources
+            # an rc file. Claude Code reads ~/.claude/settings.json on every
+            # launch regardless, so that's the channel that actually reaches it.
+            sp = default_settings_path()
+            st2, msg2 = wire_settings_env(
+                sp, "ANTHROPIC_BASE_URL", f"http://127.0.0.1:{args.port}", force=args.force
+            )
+            glyph2 = "✓" if st2 in ("ok", "exists") else ("⚠" if st2 == "conflict" else "✗")
+            print(f"{glyph2} {msg2}")
+            if st2 == "conflict":
+                print(f"  re-run with: distil default --always-on --force  (backs up {sp} first)")
         if load and not args.no_start:
             ok = subprocess.run(load, shell=True).returncode == 0
             print("  ✓ proxy service running" if ok else f"  ⚠ start it manually: {load}")
@@ -1594,6 +1617,7 @@ def cmd_offboard(args: argparse.Namespace) -> int:
         remove_managed,
         service_spec,
         service_unload_cmd,
+        unwire_settings_env,
         unwire_statusline,
     )
 
@@ -1636,6 +1660,13 @@ def cmd_offboard(args: argparse.Namespace) -> int:
     sp = default_settings_path()
     if sp.exists() and ask(f"Unwire the distil status line from {sp}?"):
         st, msg = unwire_statusline(sp)
+        print(("✓ " if st in ("ok", "absent", "foreign") else "✗ ") + msg)
+
+    # 3b · the settings.json ANTHROPIC_BASE_URL that --always-on wires for IDE-
+    # launched Claude Code (VSCode, Cursor's Claude Code extension, ...), which
+    # never goes through a shell rc file and so isn't touched by step 1.
+    if sp.exists() and ask(f"Unwire distil's ANTHROPIC_BASE_URL from {sp}?"):
+        st, msg = unwire_settings_env(sp, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
         print(("✓ " if st in ("ok", "absent", "foreign") else "✗ ") + msg)
 
     # 4 · local data (opt-in; it's the user's measured savings history)
@@ -2779,6 +2810,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     de.add_argument(
         "--no-start", action="store_true", help="--always-on: write the service but don't start it"
+    )
+    de.add_argument(
+        "--force",
+        action="store_true",
+        help="--always-on: replace a conflicting ANTHROPIC_BASE_URL in ~/.claude/settings.json "
+        "(backed up first)",
     )
     de.add_argument("--undo", action="store_true", help="remove the distil default")
     de.add_argument("--rc", help="shell rc/profile path (default: auto-detected)")

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -69,6 +69,83 @@ def wire_statusline(
     return ("ok", f"wired the distil status line into {settings_path}")
 
 
+def wire_settings_env(
+    settings_path: Path, env_var: str, value: str, *, force: bool = False
+) -> tuple[str, str]:
+    """Wire ``{env_var: value}`` into ``settings_path``'s ``env`` block.
+
+    Claude Code reads its own ``settings.json`` on every launch, regardless of
+    how the ``claude`` binary was started — unlike a shell alias or an
+    ``export`` in an rc file, this also reaches IDE-launched sessions (VSCode's
+    Claude Code extension, or that same extension installed inside Cursor),
+    since those exec the binary directly and never source an interactive
+    shell's rc file. Idempotent; preserves every other key including other
+    ``env`` entries; backs up before replacing a conflicting value.
+
+    Returns ``(status, message)``: ``ok`` | ``exists`` | ``conflict`` | ``error``.
+    """
+    data: object = {}
+    if settings_path.exists():
+        try:
+            data = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            return ("error", f"{settings_path} is not valid JSON ({exc}) — fix it or edit by hand")
+    if not isinstance(data, dict):
+        return ("error", f"{settings_path} is not a JSON object")
+
+    env = data.get("env")
+    existing = env.get(env_var) if isinstance(env, dict) else None
+    if existing == value:
+        return ("exists", f"distil's {env_var} already wired")
+    if existing and not force:
+        return (
+            "conflict",
+            f"{env_var} is already set to {existing!r} in {settings_path}; "
+            "re-run with --force to replace it (it'll be backed up first)",
+        )
+    if existing:  # force: back up the current settings before replacing
+        settings_path.with_name(settings_path.name + ".bak").write_text(
+            settings_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+    data["env"] = {**env, env_var: value} if isinstance(env, dict) else {env_var: value}
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return ("ok", f"wired {env_var} into {settings_path}")
+
+
+def unwire_settings_env(settings_path: Path, env_var: str, value: str) -> tuple[str, str]:
+    """Remove distil's ``env_var`` from ``settings_path`` (inverse of
+    :func:`wire_settings_env`). Only touches the entry if it still holds the
+    exact value distil set — a foreign value (the user repointed it, or set it
+    to something else) is left untouched. Backs up before changing. Returns
+    ``(status, message)``: ``ok`` | ``absent`` | ``foreign`` | ``error``."""
+    if not settings_path.exists():
+        return ("absent", f"no settings file at {settings_path}")
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return ("error", f"{settings_path} is not valid JSON ({exc})")
+    if not isinstance(data, dict):
+        return ("error", f"{settings_path} is not a JSON object")
+
+    env = data.get("env")
+    existing = env.get(env_var) if isinstance(env, dict) else None
+    if existing != value:
+        if existing is None:
+            return ("absent", f"no distil {env_var} to remove")
+        return ("foreign", f"{env_var} is {existing!r}, not distil's — left as-is")
+
+    settings_path.with_name(settings_path.name + ".bak").write_text(
+        settings_path.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    del env[env_var]
+    if not env:
+        del data["env"]
+    settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return ("ok", f"removed distil's {env_var} from {settings_path}")
+
+
 def unwire_statusline(settings_path: Path) -> tuple[str, str]:
     """Remove the distil status line from ``settings_path`` (the inverse of
     :func:`wire_statusline`). Only touches a status line that is distil's — a

--- a/tests/test_cli_onboard.py
+++ b/tests/test_cli_onboard.py
@@ -1562,6 +1562,7 @@ def test_cmd_default_always_on_content_none(tmp_path, monkeypatch, capsys) -> No
             agent="claude",
             mode="lossless-only",
             no_start=False,
+            force=False,
         )
     )
     assert rc == 1
@@ -1612,6 +1613,7 @@ def test_cmd_default_always_on_service_start(tmp_path, monkeypatch, capsys) -> N
             agent="claude",
             mode="lossless-only",
             no_start=False,
+            force=False,
         )
     )
     assert rc == 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,6 +11,8 @@ from distil.setup import (
     env_body,
     remove_managed,
     service_spec,
+    unwire_settings_env,
+    wire_settings_env,
     wire_statusline,
     write_managed,
 )
@@ -56,6 +58,100 @@ def test_wire_rejects_non_object(tmp_path) -> None:
     p.write_text("[1, 2, 3]")
     status, _ = wire_statusline(p)
     assert status == "error"
+
+
+# ── settings.json env wiring — reaches IDE-launched Claude Code (VSCode, ────
+# Cursor's Claude Code extension) that a shell rc export never touches ──────
+
+
+def test_wire_settings_env_fresh(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "ok"
+    assert json.loads(p.read_text())["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8788"
+
+
+def test_wire_settings_env_idempotent(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "exists"
+
+
+def test_wire_settings_env_conflict_needs_force_and_does_not_clobber(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://mine.example"}}))
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "conflict"
+    assert "mine.example" in p.read_text()  # untouched
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788", force=True)
+    assert status == "ok"
+    assert (tmp_path / "settings.json.bak").exists()
+    assert json.loads(p.read_text())["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8788"
+
+
+def test_wire_settings_env_preserves_other_settings_and_env_keys(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"model": "opus", "env": {"OTHER_VAR": "1"}}))
+    wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    data = json.loads(p.read_text())
+    assert data["model"] == "opus"
+    assert data["env"]["OTHER_VAR"] == "1"
+    assert data["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8788"
+
+
+def test_wire_settings_env_rejects_non_object(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    p.write_text("[1, 2, 3]")
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "error"
+
+
+def test_wire_settings_env_bad_json_is_error(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    p.write_text("{not json")
+    status, _ = wire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "error"
+
+
+def test_unwire_settings_env_removes_only_distils(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    # foreign value is preserved
+    p.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://mine.example"}}))
+    status, _ = unwire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "foreign"
+    assert "mine.example" in p.read_text()
+
+    # distil's value is removed, other env keys + settings preserved, backup made
+    p.write_text(
+        json.dumps(
+            {"model": "opus", "env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8788", "X": "1"}}
+        )
+    )
+    status, _ = unwire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert status == "ok"
+    data = json.loads(p.read_text())
+    assert "ANTHROPIC_BASE_URL" not in data["env"]
+    assert data["env"]["X"] == "1"
+    assert data["model"] == "opus"
+    assert (tmp_path / "settings.json.bak").exists()
+
+    # idempotent: nothing left to remove
+    assert unwire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")[0] == "absent"
+
+
+def test_unwire_settings_env_drops_empty_env_block(tmp_path) -> None:
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8788"}}))
+    unwire_settings_env(p, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
+    assert "env" not in json.loads(p.read_text())
+
+
+def test_unwire_settings_env_absent_and_bad(tmp_path) -> None:
+    assert unwire_settings_env(tmp_path / "nope.json", "ANTHROPIC_BASE_URL", "x")[0] == "absent"
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert unwire_settings_env(bad, "ANTHROPIC_BASE_URL", "x")[0] == "error"
 
 
 # ── distil default: managed-block + shell detection (reliable across machines) ──
@@ -158,6 +254,7 @@ def _default_args(tmp_path, **over):
         undo=False,
         always_on=False,
         no_start=True,
+        force=False,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -187,6 +284,8 @@ def test_cmd_default_always_on_writes_service_and_env(tmp_path, monkeypatch, cap
     monkeypatch.setattr(
         setup, "service_spec", lambda port, mode: (svc, f"PLIST {port} --{mode}", "true")
     )
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
     # Record shell-outs so we can assert install is silent but undo stops the service.
     import subprocess
 
@@ -197,8 +296,11 @@ def test_cmd_default_always_on_writes_service_and_env(tmp_path, monkeypatch, cap
     assert svc.exists() and "8788" in svc.read_text()
     assert setup.env_body(8788) in rc.read_text()
     assert calls == []  # --no-start never shells out
+    # settings.json is wired too — reaches IDE-launched Claude Code (VSCode,
+    # Cursor's Claude Code extension) that never sources the rc file above.
+    assert json.loads(settings.read_text())["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8788"
 
-    # undo stops the running service (one shell-out) and cleans up rc + file
+    # undo stops the running service (one shell-out) and cleans up rc + file + settings.json
     assert cli.cmd_default(_default_args(tmp_path, undo=True)) == 0
     if setup.service_unload_cmd() is not None:
         assert calls  # unload was invoked
@@ -206,6 +308,49 @@ def test_cmd_default_always_on_writes_service_and_env(tmp_path, monkeypatch, cap
         assert calls == []  # no service manager on this platform (e.g. Windows)
     assert not svc.exists()
     assert "ANTHROPIC_BASE_URL" not in rc.read_text()
+    assert "ANTHROPIC_BASE_URL" not in settings.read_text()
+
+
+def test_cmd_default_always_on_non_claude_agent_skips_settings_json(
+    tmp_path, monkeypatch
+) -> None:
+    """Only Claude Code reads ~/.claude/settings.json — wiring it for another
+    wrapped agent (e.g. codex) would be a no-op at best, confusing at worst."""
+    from distil import cli, setup
+
+    svc = tmp_path / "svc.plist"
+    monkeypatch.setattr(
+        setup, "service_spec", lambda port, mode: (svc, f"PLIST {port} --{mode}", "true")
+    )
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    assert (
+        cli.cmd_default(
+            _default_args(tmp_path, always_on=True, agent="codex", no_start=True)
+        )
+        == 0
+    )
+    assert not settings.exists()
+
+
+def test_cmd_default_always_on_settings_env_conflict_needs_force(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    from distil import cli, setup
+
+    monkeypatch.setattr(
+        setup, "service_spec", lambda port, mode: (tmp_path / "svc.plist", "PLIST", "true")
+    )
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://mine.example"}}))
+    monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    assert cli.cmd_default(_default_args(tmp_path, always_on=True)) == 0
+    assert "mine.example" in settings.read_text()  # left untouched without --force
+    out = capsys.readouterr().out
+    assert "--force" in out
+
+    assert cli.cmd_default(_default_args(tmp_path, always_on=True, force=True)) == 0
+    assert json.loads(settings.read_text())["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8788"
 
 
 def test_cmd_default_always_on_unsupported_platform(tmp_path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
Fixes (partially) #30

`distil default --always-on` currently discovers the proxy via `ANTHROPIC_BASE_URL` exported in the shell rc file. That only reaches a `claude` process that's a descendant of a shell which sourced that rc — an IDE extension execing the `claude` binary directly never sees it, and the install silently does nothing for that session.

Confirmed via process-tree inspection for both VSCode's and Cursor's Claude Code extensions:

```
Code Helper (Plugin) → .../vscode/extensions/anthropic.claude-code-2.1.215-.../native-binary/claude
Cursor Helper (Plugin): extension-host → .../cursor/extensions/anthropic.claude-code-2.1.216-.../native-binary/claude
```

No shell in between in either case — each extension host execs its own bundled copy of the same `claude` binary directly.

The `claude` binary reads `~/.claude/settings.json` on every launch regardless of how it was started, and that file already supports a top-level `env` object. This PR adds:

- `setup.wire_settings_env` / `unwire_settings_env` — same idempotent, backup-before-clobber, preserve-everything-else pattern as the existing `wire_statusline`/`unwire_statusline`, generalized to any `(env_var, value)` pair.
- Wired into `cmd_default`'s `--always-on` path (writes it, gated to `agent == "claude"` since this settings file is Claude-Code-specific) and into `--undo` / `offboard` (removes it).
- A new `--force` flag for `distil default`, mirroring `wire_statusline`'s existing conflict/`--force` behavior, for when the user already has a different `ANTHROPIC_BASE_URL` in their settings.

**What this does not solve** (see #30 for the full breakdown): Windsurf, Google Antigravity, and Cursor's own native "Agents" feature (a separate, proprietary system from the actual Claude Code extension — confirmed by inspecting its process tree too, which shows no `claude` binary at all) don't exec the `claude` CLI or read this settings file. This fix can't reach them; doing so would need either a documented per-app config surface (none found) or a TLS-intercepting proxy, which is a separate, much larger design discussion given this repo's stated zero-trust-footprint posture in `THREAT_MODEL.md`.

**Testing:** `make test` and `make lint` both green (11 new tests covering fresh-wire, idempotency, conflict+force, key preservation, non-`claude`-agent skip, and the offboard cleanup path). Not a compression-path change, so `make gate` doesn't apply per CONTRIBUTING.md.
