### PR TITLE
fix(ci): gate integrity — coverage-floor precision + pinned linters (closes #32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
       - name: ruff check
-        run: uvx ruff check distil tests
+        run: uvx ruff@0.15.10 check distil tests
       - name: mypy (the package ships py.typed — keep it actually typed)
-        run: uvx mypy --python-version 3.12 --ignore-missing-imports distil
+        run: uvx mypy@1.17.1 --python-version 3.12 --ignore-missing-imports distil
 
   node:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.27.0] — the coverage gate enforces the floor it advertises
+
+Bug fix + test-debt paydown (issue #32). The `coverage` CI job reported **success while its own log printed** `FAIL … Total coverage: 94.90%`. Root cause: `[tool.coverage.report]` set no `precision`, and coverage.py defaults it to `0` — which rounds the number used for the `--cov-fail-under` decision, not just the printed report. `94.90%` rounded to `95`, so `95 >= 95` passed a floor the suite was actually under. For a project whose whole pitch is *certified gates*, a gate that lies is worse than a red build.
+
+- **`precision = 2`** in `[tool.coverage.report]` (`pyproject.toml`): the fail_under comparison now uses the real two-decimal figure. (Diagnosed in #32 by @dshakes.)
+- **Real coverage lifted honestly above the floor**, not by lowering the bar. Meaningful tests for genuinely-untested branches: the phase-2 learned-salience trio `query_flywheel` / `query_train` / `query_assoc` went **80.6% → 100%** (deterministic-sampling boundaries, both certify-gate rejection floors, every fail-open / skip / malformed-row path), and `census.py`'s accrual persistence gained corrupt-channel-repair + write-fail-open tests. Total coverage now **95.48%**, enforced honestly.
+
+### Gates
+- Full suite green (1818 tests); coverage ≥95% enforced at 2-decimal precision; ruff + mypy clean; `distil verify` / `bench` / `validate` unaffected and PASS.
+
 ## [1.26.0] — the community counter is monotonic; `distil default --always-on`
 
 ### The live counter never un-counts again — count-time delta calibration

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.26.0
-date-released: 2026-07-23
+version: 1.27.0
+date-released: 2026-07-24
 keywords:
   - llm
   - context-compression

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -139,6 +139,7 @@ def unwire_settings_env(settings_path: Path, env_var: str, value: str) -> tuple[
     settings_path.with_name(settings_path.name + ".bak").write_text(
         settings_path.read_text(encoding="utf-8"), encoding="utf-8"
     )
+    assert isinstance(env, dict)  # existing == value (a real str) ⇒ env is the dict we read it from
     del env[env_var]
     if not env:
         del data["env"]

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Compress your AI agent's context and prove its decisions don't change — cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.26.0"
+version = "1.27.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The
@@ -98,6 +98,11 @@ omit = [
 ]
 
 [tool.coverage.report]
+# Compare fail_under at 2-decimal precision. coverage.py defaults precision to 0,
+# which ALSO rounds the number used for the --cov-fail-under decision (not just
+# the printed report): 94.90% rounds to 95 and silently passes a 95 floor. Pin it
+# so the gate enforces the real figure. (Issue #32.)
+precision = 2
 exclude_also = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -301,6 +301,41 @@ def test_agents_and_modes_from_sessions(tmp_path, monkeypatch):
     assert p["modes"]["sdk"] == 2  # python + weird-tool
 
 
+def test_load_savings_resets_only_a_corrupt_channel(monkeypatch, tmp_path):
+    """A partially-corrupt accrual file (one channel is not a dict) is repaired
+    in place — the bad channel resets to fresh, the intact one is preserved —
+    rather than throwing away all banked savings."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    census.opt_in()
+    census._savings_path().write_text(
+        json.dumps(
+            {
+                "v": 1,
+                "by_model": {},
+                "tokens": "corrupt",  # not a dict
+                "dollars": {"saved": 5.0, "raw_seen": 10},  # intact
+            }
+        ),
+        encoding="utf-8",
+    )
+    st = census._load_savings()
+    assert st["tokens"] == {"saved": 0.0, "raw_seen": 0}  # reset to fresh
+    assert st["dollars"] == {"saved": 5.0, "raw_seen": 10}  # preserved
+
+
+def test_save_savings_is_fail_open(monkeypatch, tmp_path):
+    """A failed write to census-savings.json must never propagate — the census
+    rides the host's exit path and can't be allowed to break it. The delta just
+    re-accrues on the next send."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    census.opt_in()
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x", encoding="utf-8")  # a FILE where a dir is needed
+    monkeypatch.setattr(census, "_savings_path", lambda: blocker / "census-savings.json")
+    census._save_savings({"v": 1, "tokens": {}, "dollars": {}, "by_model": {}})  # must not raise
+    assert not (blocker / "census-savings.json").exists()
+
+
 def test_equivalence_from_shadow(tmp_path, monkeypatch):
     monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
     census.opt_in()

--- a/tests/test_query_flywheel_train_assoc_edges.py
+++ b/tests/test_query_flywheel_train_assoc_edges.py
@@ -1,0 +1,358 @@
+"""Phase-2 query-aware salience — edge/error paths of query_flywheel, query_train, and
+query_assoc not exercised by test_query_relevance.py / test_semantic_bridge.py: sample-rate
+clamping, deterministic sampling boundaries, fail-open on malformed/unreadable logs, and the
+training gate's reject branches (empty input, bad width, sub-floor recall/precision)."""
+
+import json
+
+import pytest
+
+from distil.codec.features import FEATURE_NAMES
+from distil.compress.query_relevance import QUERY_FEATURE_NAMES
+
+_BASE = len(FEATURE_NAMES)
+_W = len(QUERY_FEATURE_NAMES)
+
+
+def _synthetic_samples(n: int = 250) -> list[tuple[list[float], float]]:
+    """Deterministic (no RNG) label set: even index -> near a hit (positive), odd -> far
+    (negative). Enough rows to clear the default min_samples floor."""
+    samples: list[tuple[list[float], float]] = []
+    for i in range(n):
+        x = [0.0] * _W
+        x[0] = 1.0
+        if i % 2 == 0:
+            x[_BASE + 3] = 0.05
+            samples.append((x, 1.0))
+        else:
+            x[_BASE + 3] = 0.9
+            samples.append((x, 0.0))
+    return samples
+
+
+# --- query_flywheel: enable/disable/is_enabled + path resolution --------------------
+
+
+def test_enable_clamps_sample_rate_and_toggles_state():
+    from distil import query_flywheel as fw
+
+    fw.enable(2.5)  # above 1.0 -> clamped
+    assert fw.is_enabled() is True
+    assert fw._sample_rate == 1.0
+    fw.enable(-1.0)  # below 0.0 -> clamped
+    assert fw._sample_rate == 0.0
+    fw.disable()
+    assert fw.is_enabled() is False
+    fw._sample_rate = 0.25  # restore module default so it can't leak into other tests
+
+
+def test_default_path_honors_distil_home(monkeypatch, tmp_path):
+    from distil import query_flywheel as fw
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    assert fw._default_path() == tmp_path / "query_flywheel.jsonl"
+
+
+# --- query_flywheel: _sampled boundary + invalid-hex fail-open ----------------------
+
+
+def test_sampled_rate_zero_always_false():
+    from distil import query_flywheel as fw
+
+    assert fw._sampled("ffffffff", 0.0) is False
+
+
+def test_sampled_invalid_hex_handle_fails_open():
+    from distil import query_flywheel as fw
+
+    assert fw._sampled("not-hex!", 0.5) is False
+
+
+def test_sampled_mid_rate_boundary():
+    from distil import query_flywheel as fw
+
+    assert fw._sampled("00000000", 0.5) is True  # bucket 0.0 < 0.5
+    assert fw._sampled("ffffffff", 0.5) is False  # bucket 1.0 not < 0.5
+
+
+# --- query_flywheel: maybe_record's sampled-out and no-rows no-ops ------------------
+
+
+def test_maybe_record_sampled_out_writes_nothing(monkeypatch, tmp_path):
+    from distil import query_flywheel as fw
+
+    p = tmp_path / "fw.jsonl"
+    monkeypatch.setattr(fw, "_enabled", True)
+    monkeypatch.setattr(fw, "_sample_rate", 0.5)
+    # "ffffffff" buckets to 1.0, never < 0.5 -> sampled out
+    fw.maybe_record("ffffffff", frozenset({"x"}), ["a line"], "tool_output", {0}, path=p)
+    assert not p.exists()
+
+
+def test_maybe_record_no_rows_when_dropped_indices_out_of_range(monkeypatch, tmp_path):
+    from distil import query_flywheel as fw
+
+    p = tmp_path / "fw.jsonl"
+    monkeypatch.setattr(fw, "_enabled", True)
+    monkeypatch.setattr(fw, "_sample_rate", 1.0)
+    fw.maybe_record("aaaa1111", frozenset({"x"}), ["a", "b"], "tool_output", {99}, path=p)
+    assert not p.exists()  # every dropped index out of [0, n) -> rows stays empty -> no-op
+
+
+# --- query_flywheel: load_labels fail-open + skip paths -----------------------------
+
+
+def test_load_labels_missing_flywheel_file_returns_empty(tmp_path):
+    from distil import query_flywheel as fw
+
+    labels = fw.load_labels(
+        flywheel_path=tmp_path / "missing.jsonl", signal_path=tmp_path / "missing_sig.jsonl"
+    )
+    assert labels == []
+
+
+def test_load_labels_skips_malformed_flywheel_rows(tmp_path):
+    from distil import query_flywheel as fw
+
+    good_row = [0.0] * _W
+    fwp = tmp_path / "fw.jsonl"
+    fwp.write_text(
+        "\n".join(
+            [
+                "",  # blank line -> skipped
+                "not valid json{",  # bad json -> skipped
+                json.dumps({"h": 123, "rows": [good_row]}),  # handle not a str -> skipped
+                json.dumps({"h": "x", "rows": "nope"}),  # rows not a list -> skipped
+                json.dumps({"h": "good", "rows": [good_row]}),  # valid, never expanded
+            ]
+        )
+        + "\n"
+    )
+    labels = fw.load_labels(flywheel_path=fwp, signal_path=tmp_path / "sig.jsonl")
+    assert labels == [(good_row, 0.0)]
+
+
+def test_load_labels_skips_malformed_signal_rows(tmp_path):
+    from distil import query_flywheel as fw
+
+    good_row = [0.0] * _W
+    fwp = tmp_path / "fw.jsonl"
+    fwp.write_text(json.dumps({"h": "e1", "rows": [good_row]}) + "\n")
+    sig = tmp_path / "sig.jsonl"
+    sig.write_text(
+        "\n".join(
+            [
+                "",  # blank -> skipped
+                "not json{",  # bad json -> skipped
+                json.dumps({"handle": "e1"}),  # valid -> marks e1 expanded
+            ]
+        )
+        + "\n"
+    )
+    labels = fw.load_labels(flywheel_path=fwp, signal_path=sig)
+    assert labels == [(good_row, 1.0)]
+
+
+def test_load_labels_signal_read_error_fails_open(tmp_path):
+    from distil import query_flywheel as fw
+
+    good_row = [0.0] * _W
+    fwp = tmp_path / "fw.jsonl"
+    fwp.write_text(json.dumps({"h": "e1", "rows": [good_row]}) + "\n")
+    sig_dir = tmp_path / "sig_is_a_dir.jsonl"
+    sig_dir.mkdir()  # exists() True but read_text() raises IsADirectoryError (an OSError)
+    labels = fw.load_labels(flywheel_path=fwp, signal_path=sig_dir)
+    # signal read failed -> nothing counted as expanded -> weak negative, no crash
+    assert labels == [(good_row, 0.0)]
+
+
+def test_load_labels_flywheel_read_error_fails_open(tmp_path):
+    from distil import query_flywheel as fw
+
+    fw_dir = tmp_path / "fw_is_a_dir.jsonl"
+    fw_dir.mkdir()
+    labels = fw.load_labels(flywheel_path=fw_dir, signal_path=tmp_path / "sig.jsonl")
+    assert labels == []
+
+
+# --- query_train: _baseline_recall + train_query_relevance guard rails --------------
+
+
+def test_baseline_recall_zero_without_positives():
+    from distil import query_train
+
+    assert query_train._baseline_recall([([0.0] * _W, 0.0)]) == 0.0
+
+
+def test_train_query_relevance_rejects_empty_samples():
+    from distil import query_train
+
+    with pytest.raises(ValueError, match="empty label set"):
+        query_train.train_query_relevance([])
+
+
+def test_train_query_relevance_rejects_bad_width():
+    from distil import query_train
+
+    with pytest.raises(ValueError, match="width"):
+        query_train.train_query_relevance([([0.0] * (_W - 1), 1.0)])
+
+
+def test_train_query_relevance_rejects_empty_train_split():
+    from distil import query_train
+
+    samples = _synthetic_samples(n=10)
+    # every sample buckets into the test split -> train split empty
+    with pytest.raises(RuntimeError, match="Empty train split"):
+        query_train.train_query_relevance(samples, test_fraction=1.0)
+
+
+# --- query_train: certify_and_promote's default-samples + reject branches -----------
+
+
+def test_certify_and_promote_default_samples_loads_from_flywheel(monkeypatch, tmp_path):
+    from distil import query_train
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))  # no flywheel/signal files present
+    report = query_train.certify_and_promote(weights_path=tmp_path / "qw.json")
+    assert report["promoted"] is False
+    assert report["n_labels"] == 0
+    assert "too few" in report["reason"]
+
+
+def test_certify_and_promote_rejects_on_recall_gain_floor(tmp_path):
+    from distil import query_train
+
+    samples = _synthetic_samples()
+    # an unreachable gain floor forces the "doesn't beat baseline" branch regardless of the
+    # actual trained metrics (gain is bounded in [-1, 1])
+    report = query_train.certify_and_promote(
+        samples, weights_path=tmp_path / "qw.json", min_samples=200, min_recall_gain=2.0
+    )
+    assert report["promoted"] is False
+    assert "does not beat phase-1 baseline" in report["reason"]
+    assert not (tmp_path / "qw.json").exists()
+
+
+def test_certify_and_promote_rejects_on_precision_floor(tmp_path):
+    from distil import query_train
+
+    samples = _synthetic_samples()
+    # gain floor trivially satisfied (-2.0), precision floor unreachable (2.0 > any precision)
+    report = query_train.certify_and_promote(
+        samples,
+        weights_path=tmp_path / "qw.json",
+        min_samples=200,
+        min_recall_gain=-2.0,
+        min_precision=2.0,
+    )
+    assert report["promoted"] is False
+    assert "precision" in report["reason"] and "floor" in report["reason"]
+    assert not (tmp_path / "qw.json").exists()
+
+
+# --- query_assoc: record_cooccurrence no-op branches ---------------------------------
+
+
+def test_record_cooccurrence_noop_on_empty_terms(tmp_path):
+    from distil import query_assoc
+
+    p = tmp_path / "co.jsonl"
+    query_assoc.record_cooccurrence("h1", frozenset(), {"o"}, path=p)
+    query_assoc.record_cooccurrence("h1", frozenset({"q"}), set(), path=p)
+    assert not p.exists()
+
+
+def test_record_cooccurrence_noop_when_cap_zero(tmp_path):
+    from distil import query_assoc
+
+    p = tmp_path / "co.jsonl"
+    query_assoc.record_cooccurrence("h1", frozenset({"q"}), {"o"}, path=p, cap=0)
+    assert not p.exists()  # hashed sets sliced to [:0] -> empty -> no-op
+
+
+# --- query_assoc: build_associations fail-open + skip paths -------------------------
+
+
+def test_build_associations_missing_file_returns_empty(tmp_path):
+    from distil import query_assoc
+
+    table = query_assoc.build_associations(
+        cooccur_path=tmp_path / "missing.jsonl", save_to=tmp_path / "assoc.json"
+    )
+    assert table == {}
+
+
+def test_build_associations_skips_malformed_rows(tmp_path):
+    from distil import query_assoc
+
+    cp = tmp_path / "co.jsonl"
+    sp = tmp_path / "sig.jsonl"
+    good = json.dumps({"h": "e0", "q": ["aa"], "o": ["bb"]})
+    cp.write_text(
+        "\n".join(
+            [
+                "",  # blank -> skipped
+                "not json{",  # bad json -> skipped
+                json.dumps({"h": "e1", "q": "notalist", "o": ["bb"]}),  # malformed -> skipped
+                good,
+                good,
+                good,  # 3x co-occurrence, all in the expanded block e0
+            ]
+        )
+        + "\n"
+    )
+    sp.write_text(json.dumps({"handle": "e0"}) + "\n")
+    table = query_assoc.build_associations(
+        cooccur_path=cp, signal_path=sp, min_count=3, min_ratio=0.6, save_to=tmp_path / "assoc.json"
+    )
+    assert table == {"aa": ["bb"]}
+
+
+def test_build_associations_cooccur_read_error_returns_empty(tmp_path):
+    from distil import query_assoc
+
+    cp = tmp_path / "co_is_a_dir.jsonl"
+    cp.mkdir()  # exists() True, read_text() raises an OSError
+    table = query_assoc.build_associations(cooccur_path=cp, save_to=tmp_path / "assoc.json")
+    assert table == {}
+
+
+def test_build_associations_save_error_fails_open(tmp_path):
+    from distil import query_assoc
+
+    cp = tmp_path / "co.jsonl"
+    cp.write_text("")  # empty -> no pairs, but the save_to write is still attempted
+    bad_dest = tmp_path / "missing_dir" / "assoc.json"  # parent doesn't exist -> write raises
+    table = query_assoc.build_associations(cooccur_path=cp, save_to=bad_dest)
+    assert table == {}
+    assert not bad_dest.exists()
+
+
+# --- query_assoc: _expanded_handles skip paths + fail-open ---------------------------
+
+
+def test_expanded_handles_skips_blank_and_bad_json(tmp_path):
+    from distil import query_assoc
+
+    sp = tmp_path / "sig.jsonl"
+    sp.write_text(
+        "\n".join(
+            [
+                "",  # blank -> skipped
+                "not json{",  # bad json -> skipped
+                json.dumps({"handle": 123}),  # not a str -> skipped
+                json.dumps({"handle": "h1"}),
+            ]
+        )
+        + "\n"
+    )
+    assert query_assoc._expanded_handles(sp) == {"h1"}
+
+
+def test_expanded_handles_read_error_fails_open(tmp_path):
+    from distil import query_assoc
+
+    sp = tmp_path / "sig_is_a_dir.jsonl"
+    sp.mkdir()
+    assert query_assoc._expanded_handles(sp) == set()

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.26.0"
+version = "1.27.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #32.

The `coverage` CI job was reporting **success while genuinely below the 95% floor**. coverage.py defaults `[tool.coverage.report] precision` to `0`, and that setting also rounds the number used for the `--cov-fail-under` decision (not just the printed report): 94.90% rounded to 95, so `95 >= 95` passed a floor the suite was actually under. For a "certified gates" project, a gate that lies is worse than a red build.

## Fix — honest, not lowered

- **`precision = 2`** in `[tool.coverage.report]` (`pyproject.toml`) — the fail_under comparison now uses the real two-decimal figure.
- **Real coverage lifted above the floor with meaningful tests**, not by dropping the bar:
  - phase-2 learned-salience trio `query_flywheel` / `query_train` / `query_assoc`: **80.6% → 100%** — sampling boundaries, both certify-gate rejection floors, and every fail-open / skip / malformed-row branch (27 new tests in `tests/test_query_flywheel_train_assoc_edges.py`).
  - `census.py` accrual persistence: corrupt-channel repair + write-fail-open (2 new tests).

Gate now clears 95% on the true figure with margin.

## Gates
- Full suite green; coverage ≥95% enforced honestly (`precision=2`); ruff + mypy clean; `distil verify` / `bench` / `validate` unaffected and PASS.

---

## Also fixed here: the CI `lint` job was silently red (unrelated to #32, found while making this PR green)

`lint` ran `uvx ruff` / `uvx mypy` **unpinned**. ruff auto-upgraded 0.15.10 → 0.16.0, whose new default rules flag 405 violations across untouched files — so `lint` has been red on `main` and every PR since 0.16.0 shipped (the tag-triggered *release* gate doesn't run `uvx ruff`, so 1.26.0 still published over a red `main` lint).

- **Pinned `ruff@0.15.10` and `mypy@1.17.1`** in `.github/workflows/ci.yml` — the versions the repo develops against, so a new tool release can't silently break the gate again.
- That unmasked a **real latent mypy error** the ruff failure was hiding: `distil/setup.py:142` (`unwire_settings_env`, from the 1.26.0 always-on merge) — `del env[env_var]` where mypy can't prove `env` is a dict. The code is safe (`existing == value` with a real string ⇒ `env` is the dict we read it from); asserting the invariant lets mypy narrow it.

Both pinned linters now clean; the always-on suite (108 tests) still passes.
