### PR TITLE
fix(a11y): restore keyboard access to navigation, sessions, and copy controls

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ This file is the record.
 
 - **pliablepixels** ([@pliablepixels](https://github.com/pliablepixels)) — per-content-type keep policy (`distil/compress/keep_policy.py`), so a digest keeps a test run's verdict instead of folding the answer and keeping the noise ([#23](https://github.com/dshakes/distil/pull/23), shipped 1.15.0); and `distil dissect` — the per-session deep-dive report, including `--serve` and agent-transcript correlation ([#27](https://github.com/dshakes/distil/pull/27), shipped 1.15.1).
 - **Tolga Tuncoglu** ([@tolgatuncoglu](https://github.com/tolgatuncoglu)) — `distil default --always-on`: persist `ANTHROPIC_BASE_URL` into `~/.claude/settings.json` so Claude Code routes through distil on every launch, including sessions started from an IDE extension rather than a terminal ([#31](https://github.com/dshakes/distil/pull/31), shipped 1.26.0).
+- **PJ Doland** ([@pjdoland](https://github.com/pjdoland)): keyboard accessibility across the docs site and dissect portal (working mobile navigation, keyboard-reachable session links, copy-button cleanup, focusable table scrolling), the first in a WCAG 2.2 series ([#34](https://github.com/dshakes/distil/pull/34)).
 
 ---
 

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1672,7 +1672,7 @@ def render_sessions_html(sessions: list[SessionOverview]) -> str:
     rows = (
         "".join(
             f"<tr onclick=\"location='/session/{e(o.sid)}'\">"
-            f"<td><code>{e(o.sid)}</code></td><td>{e(o.tool or '?')}</td>"
+            f"<td><code><a href=\"/session/{e(o.sid)}\">{e(o.sid)}</a></code></td><td>{e(o.tool or '?')}</td>"
             f"<td>{e(_when(o.started))}</td><td>{e(_when(o.last_ts))}</td>"
             f"<td class='r'>{o.requests}</td>"
             f"<td class='r'>{100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens if o.baseline_tokens else 0.0:.1f}%</td>"
@@ -1696,6 +1696,9 @@ th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}}
 tbody tr{{cursor:pointer}} tbody tr:hover td{{background:#10131d}}
 code{{color:#8b7bff}} .muted{{color:#5b6177}}
+code a{{color:inherit;text-decoration:underline}}
+code a:hover,code a:focus{{color:#5ad1c9}}
+code a:focus-visible{{outline:2px solid #8b7bff;outline-offset:2px;border-radius:4px}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
 </style></head><body><div class="wrap">
 <h1>Distil <span class="g">sessions</span></h1>

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -352,17 +352,6 @@ distil proxy listening on http://127.0.0.1:8788
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -158,7 +158,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">&#9776;</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">&#9776;</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -455,17 +455,6 @@ FIDELITY: <span class="g">PASS</span> — Tier-0/1 byte-reversible and history a
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/benchmark.html
+++ b/docs/benchmark.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -297,17 +297,6 @@ distil <span class="c">benchmark</span> --corpus corpus_taubench --runner anthro
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">&#9776;</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">&#9776;</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -968,17 +968,6 @@ fidelity gate: <span class="g">PASS</span></pre>
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -192,17 +192,6 @@
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -290,17 +290,6 @@ distil trajectory-risk certificate
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/corpus.html
+++ b/docs/corpus.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -225,17 +225,6 @@ GATE: <span class="w">FAIL</span> (1 issue(s))
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/deploy-security.html
+++ b/docs/deploy-security.html
@@ -23,7 +23,7 @@
 
 <!-- Top bar -->
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -563,17 +563,6 @@ rust</pre>
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/deploy-security.html
+++ b/docs/deploy-security.html
@@ -222,7 +222,7 @@ distil proxy --verbatim     --upstream https://api.anthropic.com</pre>
     <p>The <strong>managed gateway</strong> extends the basic proxy with per-tenant token and dollar accounting, a live auto-refreshing dashboard, and a JSON stats API. Use it when multiple teams or applications share one distil instance and need visibility into who's saving what.</p>
 
     <h3>Starting the gateway</h3>
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d"># Default: binds 127.0.0.1:8789 and forwards to Anthropic</span>
+    <pre class="term"><span class="d"># Default: binds 127.0.0.1:8789 and forwards to Anthropic</span>
 <span class="d">$ distil gateway --port 8789 --upstream https://api.anthropic.com</span>
 distil gateway listening on http://127.0.0.1:8789
   dashboard: http://127.0.0.1:8789/distil/dashboard
@@ -424,7 +424,7 @@ $ distil gateway --tenant-rpm 60 --tenant-daily-tokens 1000000 \
     </div>
 
     <h3>Starting the async proxy</h3>
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d"># Install the async extra first</span>
+    <pre class="term"><span class="d"># Install the async extra first</span>
 <span class="d">$ pip install 'distil-llm[async]'</span>
 
 <span class="d"># Start the async proxy (same flags as the threaded proxy)</span>
@@ -477,7 +477,7 @@ distil async proxy listening on http://127.0.0.1:8788
     <p>Benchmarks measured on Apple M-series (aarch64-apple-darwin, <code>--release</code>), 100 samples each, on a ~30 KB synthetic log with repeated lines, prose, and JSON snippets. <code>collapse_runs</code> achieves ~12 GB/s throughput. <code>count_tokens</code> is dominated by Unicode character-class scanning.</p>
 
     <h3>Build and install</h3>
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d"># One-time: install maturin</span>
+    <pre class="term"><span class="d"># One-time: install maturin</span>
 <span class="d">$ uv tool install maturin</span>
 
 <span class="d"># Build and install the Rust extension into the project virtualenv</span>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -322,17 +322,6 @@ distil shadow-stats                  <span class="d"># check the de rate</span>
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -23,7 +23,7 @@
 
 <!-- Top bar -->
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -396,18 +396,6 @@ distil census off</pre>
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-// Close sidebar on outside click (mobile)
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -97,6 +97,7 @@
   code{overflow-wrap:anywhere}
   .term .c{color:var(--acc2)} .term .g{color:var(--good)} .term .w{color:var(--warn)} .term .d{color:var(--dim)}
   table{width:100%;border-collapse:collapse;font-size:14px;margin-top:8px}
+  .table-scroll{max-width:100%}
   th,td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line)}
   th{color:var(--dim);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.06em}
   td .new{color:var(--acc);font-weight:700}
@@ -112,7 +113,8 @@
   .muted{color:var(--dim)}
   @media(max-width:840px){
     .stats{grid-template-columns:1fr 1fr}.grid2,.tiers{grid-template-columns:1fr}
-    table{display:block;overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-size:13px}
+    .table-scroll{display:block;overflow-x:auto;-webkit-overflow-scrolling:touch}
+    table{white-space:nowrap;font-size:13px}
     header{padding:56px 0 28px}section{padding:40px 0}
     .cta{flex-direction:column}.cta .btn{text-align:center}
     .doors{grid-template-columns:1fr}
@@ -676,6 +678,25 @@ client = wrap(anthropic.Anthropic())  <span class="d"># compresses + keeps the c
   Distil · compression with a quality contract · stdlib-only core ·
   <span class="muted">prices are representative public list price — verify before billing use.</span>
 </div></footer>
+<script>
+  /* This page has its own layout (no .content), so site.js's generic
+     table-scroll wrap doesn't reach it: wrap the one wide table here too,
+     same fix, a focusable, labeled scroll region for keyboard users. */
+  (function () {
+    "use strict";
+    var table = document.querySelector("table");
+    if (!table) return;
+    var heading = table.closest("section") && table.closest("section").querySelector("h2");
+    var label = heading ? heading.textContent.replace(/#/g, "").trim() : "";
+    var wrap = document.createElement("div");
+    wrap.className = "table-scroll";
+    wrap.setAttribute("tabindex", "0");
+    wrap.setAttribute("role", "region");
+    wrap.setAttribute("aria-label", label || "Scrollable table");
+    table.parentNode.insertBefore(wrap, table);
+    wrap.appendChild(table);
+  })();
+</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -23,7 +23,7 @@
 
 <!-- Top bar -->
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -439,17 +439,6 @@ distil proxy --port 8788</pre>
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/learn-compression.html
+++ b/docs/learn-compression.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -267,15 +267,6 @@
 </div>
 
 <script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
 (function () {
   var $ = function (id) { return document.getElementById(id); };
   var turns = $("te-turns"), prefix = $("te-prefix"), step = $("te-step"), model = $("te-model");

--- a/docs/learn-distil.html
+++ b/docs/learn-distil.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -210,17 +210,6 @@ distil <span class="c">leaderboard</span>      <span class="d"># your real cumul
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/learn-tokens.html
+++ b/docs/learn-tokens.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -208,17 +208,6 @@
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/output.html
+++ b/docs/output.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -226,17 +226,6 @@ distil performance benchmark
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/research.html
+++ b/docs/research.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -607,17 +607,6 @@ verifiable savings — 3 verified instance(s), 0 rejected
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/research.html
+++ b/docs/research.html
@@ -326,7 +326,7 @@
 
     <p>Results are sorted by savings ascending and printed as the frontier table. Run offline with the deterministic runner (structural decision-equivalence). For real task-accuracy on a benchmark (tau-bench, SWE-bench, GSM8K) ingest its traces and run with <code>--runner anthropic</code>.</p>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ distil eval</span>
+    <pre class="term"><span class="d">$ distil eval</span>
 certified compression frontier  (runner=deterministic)
 
 <span class="d">level                   savings   equiv  certified  curve</span>
@@ -384,7 +384,7 @@ certified ceiling: 8.4% savings (beyond this, lossy compression drops decisions 
       <li><strong>Conformal Risk Control (CRC)</strong> &mdash; Angelopoulos, Bates, Fisch, Lei &amp; Schuster, <em>ICLR</em> 2024 (<a href="https://arxiv.org/abs/2208.02814" target="_blank" rel="noopener">arXiv:2208.02814</a>). For a monotone 0/1 loss, controls the <em>expected</em> rate <code>E[L]&le;&alpha;</code>, tight to O(1/n). Use <code>--method crc</code>.</li>
     </ul>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ distil conformal --corpus ./mycorpus --alpha 0.05 --delta 0.05</span>
+    <pre class="term"><span class="d">$ distil conformal --corpus ./mycorpus --alpha 0.05 --delta 0.05</span>
 Decision-Equivalence Risk Certificate (DERC)
 
   method      : LTT  (Learn-Then-Test)
@@ -449,7 +449,7 @@ Decision-Equivalence Risk Certificate (DERC)
 
     <p>The "decision" is the agent's next action &mdash; the first <code>tool_use</code> (Anthropic), <code>tool_call</code> (OpenAI), or <code>functionCall</code> (Gemini). Two responses are equivalent iff that action matches, exactly the <code>{action, target}</code> fingerprint the certificate uses. It is <strong>streaming-aware</strong>: the decision is reconstructed from SSE, so shadow-mode works on real agent sessions (Claude Code, Codex, Gemini CLI) that stream &mdash; not just non-streaming SDK calls. The result is a rolling, live decision-change rate on <em>your</em> traffic:</p>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ distil proxy --shadow 0.05 --upstream https://api.anthropic.com</span>
+    <pre class="term"><span class="d">$ distil proxy --shadow 0.05 --upstream https://api.anthropic.com</span>
   → shadow-mode live decision-equivalence: sampling 5%
 
 <span class="d">$ distil shadow-stats</span>
@@ -525,7 +525,7 @@ Decision-Equivalence Risk Certificate (DERC)
       </div>
     </div>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ distil online --corpus ./mycorpus --promote-to ./weights/keep_model.json</span>
+    <pre class="term"><span class="d">$ distil online --corpus ./mycorpus --promote-to ./weights/keep_model.json</span>
 self-distilling round — keep-model learns from causal labels, gated by non-inferiority
 
   n_labels: 286
@@ -568,7 +568,7 @@ self-distilling round — keep-model learns from causal labels, gated by non-inf
       <li><strong>Only certified submissions</strong> (where <code>certified == True</code>) contribute to headline totals. Uncertified instances are shown but their numbers do not roll into the aggregate.</li>
     </ul>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ distil federated-leaderboard \
+    <pre class="term"><span class="d">$ distil federated-leaderboard \
     --dir ./submissions \
     --keys ./instance-keys.json \
     --html ./leaderboard.html</span>

--- a/docs/site.css
+++ b/docs/site.css
@@ -348,8 +348,8 @@ hr { border: none; border-top: 1px solid var(--line); margin: 40px 0; }
 /* Wide data tables become horizontally scrollable rather than overflowing the
    viewport — applies on tablets too (benchmark tables have 5–7 columns). */
 @media (max-width: 1024px) {
-  .content table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-  .content table th, .content table td { white-space: nowrap; }
+  .content .table-scroll { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .content .table-scroll th, .content .table-scroll td { white-space: nowrap; }
 }
 @media (max-width: 820px) {
   :root { --sidebar-w: 0px; }

--- a/docs/site.css
+++ b/docs/site.css
@@ -353,8 +353,8 @@ hr { border: none; border-top: 1px solid var(--line); margin: 40px 0; }
 }
 @media (max-width: 820px) {
   :root { --sidebar-w: 0px; }
-  .sidebar { width: 264px; transform: translateX(-100%); transition: transform .24s ease; z-index: 40; }
-  .sidebar.open { transform: translateX(0); box-shadow: 6px 0 40px rgba(0,0,0,.7); }
+  .sidebar { width: 264px; transform: translateX(-100%); visibility: hidden; transition: transform .24s ease, visibility .24s ease; z-index: 40; }
+  .sidebar.open { transform: translateX(0); visibility: visible; box-shadow: 6px 0 40px rgba(0,0,0,.7); }
   .content { margin-left: 0; padding: 28px 18px 56px; max-width: 100%; }
   .sidebar-toggle { display: inline-block; }
   .topbar-pill { display: none; }

--- a/docs/site.js
+++ b/docs/site.js
@@ -152,3 +152,28 @@
     });
   });
 })();
+
+/* Wrap content tables in a focusable, labeled scroll region so keyboard
+   users can reach the horizontal scroll that .table-scroll gets on
+   narrower viewports (see site.css). Desktop rendering is unaffected. */
+(function () {
+  "use strict";
+  var container = document.querySelector("main.content, .content");
+  if (!container) return;
+  var lastHeading = null;
+  container.querySelectorAll("h1, h2, h3, h4, table").forEach(function (el) {
+    if (el.tagName !== "TABLE") {
+      lastHeading = el;
+      return;
+    }
+    if (el.closest(".table-scroll")) return; // already wrapped
+    var label = lastHeading ? lastHeading.textContent.replace(/#/g, "").trim() : "";
+    var wrap = document.createElement("div");
+    wrap.className = "table-scroll";
+    wrap.setAttribute("tabindex", "0");
+    wrap.setAttribute("role", "region");
+    wrap.setAttribute("aria-label", label || "Scrollable table");
+    el.parentNode.insertBefore(wrap, el);
+    wrap.appendChild(el);
+  });
+})();

--- a/docs/site.js
+++ b/docs/site.js
@@ -49,7 +49,10 @@
 
   // ── Copy-to-clipboard on every code block ──────────────────────────
   document.querySelectorAll("pre").forEach(function (pre) {
-    var original = (pre.querySelector("code") || pre).textContent; // capture before button
+    var target = pre.querySelector("code") || pre;
+    var clone = target.cloneNode(true); // strip any pre-existing .copy-btn before reading text
+    clone.querySelectorAll(".copy-btn").forEach(function (b) { b.remove(); });
+    var original = clone.textContent;
     var btn = document.createElement("button");
     btn.className = "copy-btn";
     btn.type = "button";

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,5 +1,49 @@
 /* Distil docs — progressive enhancements: copy buttons + "on this page" TOC.
    Vanilla, dependency-free, no external requests. */
+
+/* ── Mobile sidebar toggle: shared by every docs page's ☰ button
+   (onclick="toggleSidebar()") ─────────────────────────────────────────
+   Keeps #sidebar's "open" class and .sidebar-toggle's aria-expanded in
+   sync, closes on outside click or Escape, and returns focus to the
+   toggle button on Escape. */
+(function () {
+  "use strict";
+
+  function getSidebar() { return document.getElementById("sidebar"); }
+  function getToggle() { return document.querySelector(".sidebar-toggle"); }
+
+  function setOpen(open) {
+    var sb = getSidebar();
+    if (!sb) return;
+    sb.classList.toggle("open", open);
+    var btn = getToggle();
+    if (btn) btn.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  window.toggleSidebar = function () {
+    var sb = getSidebar();
+    if (!sb) return;
+    setOpen(!sb.classList.contains("open"));
+  };
+
+  document.addEventListener("click", function (e) {
+    var sb = getSidebar();
+    if (sb && sb.classList.contains("open") && !sb.contains(e.target) && !e.target.closest(".sidebar-toggle")) {
+      setOpen(false);
+    }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Escape") return;
+    var sb = getSidebar();
+    if (sb && sb.classList.contains("open")) {
+      setOpen(false);
+      var btn = getToggle();
+      if (btn) btn.focus();
+    }
+  });
+})();
+
 (function () {
   "use strict";
 

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -331,7 +331,7 @@ tokens provably free to drop: 615 across 2 block(s).</pre>
     <h3>Training the transformer on your traces</h3>
     <p><code>distil/codec/train_transformer.py</code> &middot; Fine-tunes a HuggingFace token-classification model (default: <code>google/bert_uncased_L-2_H-128_A-2</code>, ~4 MB) using the same label pipeline as the logistic model, then exports to ONNX. Requires the <code>train</code> extras.</p>
 
-    <pre class="term"><button class="copy-btn" onclick="copyCode(this)">copy</button><span class="d">$ pip install 'distil-llm[train]'</span>
+    <pre class="term"><span class="d">$ pip install 'distil-llm[train]'</span>
 
 <span class="d"># Train on the bundled corpus (replace with --corpus ./mycorpus for real traces)</span>
 <span class="d">$ distil train-transformer --out ./my-keep-model</span>

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -466,17 +466,6 @@ score = model.score(<span class="g">"ERROR: disk at 94% capacity"</span>, <span 
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs/token-economics.html
+++ b/docs/token-economics.html
@@ -22,7 +22,7 @@
 <body>
 
 <header class="topbar">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">☰</button>
   <a href="index.html" class="topbar-logo"><img src="assets/logo.svg" alt="" width="22" height="22" style="border-radius:6px;vertical-align:-6px;margin-right:8px"/>Dist<b>il</b></a>
   <span class="topbar-pill">compression with a quality contract</span>
   <nav class="topbar-links">
@@ -136,17 +136,6 @@
   </main>
 </div>
 
-<script>
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-}
-document.addEventListener('click', function(e) {
-  var sb = document.getElementById('sidebar');
-  if (sb.classList.contains('open') && !sb.contains(e.target) && !e.target.closest('.sidebar-toggle')) {
-    sb.classList.remove('open');
-  }
-});
-</script>
 <script src="site.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Hi! This is the first of a small series of accessibility PRs coming out of a WCAG 2.2 pass over the docs site and the dissect portal. I've kept this one scoped to the fixes where a keyboard-only or screen-reader user could not complete the action at all, not just cases where it was merely awkward. If you'd rather I bundle the remaining fixes differently (one big PR, split by page vs. by fix type, etc.) just say so and I'll adjust for the rest of the series.

No visual design changes are intended anywhere in this PR: same colors, same layout, same fonts. Everything here is about what is reachable and operable without a mouse.

## Summary

| Fix | Where | What was broken |
|---|---|---|
| Centralize the mobile sidebar toggle | all 20 docs pages, `site.js`, `site.css` | Two pages' mobile nav button was wired to a function that did not exist anywhere (`ReferenceError`); the other 18 each had their own copy-pasted version with no keyboard support at all |
| Remove dead copy buttons, harden clipboard capture | `research.html`, `deploy-security.html`, `techniques.html`, `site.js` | Nine code blocks had a copy button wired to a function that does not exist, and the real copy button on those blocks was copying the word "copy" instead of the code |
| Make session rows reachable | `distil/dissect.py` | The session picker's rows were click-only table rows with no link, so keyboard and screen-reader users could not open a session at all |
| Make mobile table scrolling reachable | `site.js`, `site.css`, `index.html` | Wide tables on mobile screens scrolled sideways, but there was nothing inside them a keyboard could focus, so that scroll was mouse (or touch) only |

## The fixes, in plain English

### 1. Mobile sidebar navigation was either broken or keyboard-inaccessible

Every docs page has a hamburger button that is supposed to open the left-hand navigation on narrow screens. On `benchmarks.html` and `adoption.html`, that button called a JavaScript function, `toggleSidebar()`, that was never actually defined anywhere in the codebase. Clicking it did nothing but throw an error in the console: the mobile nav on those two pages was completely dead.

The other 18 pages each had their own copy-pasted version of `toggleSidebar()` sitting at the bottom of the page. It worked with a mouse, but it never told assistive technology whether the menu was open or closed, there was no way to close it with the keyboard (only by clicking outside it with a mouse), and if you did tab your way in and hit Escape, nothing happened and focus was not returned anywhere sensible.

I moved this logic into `site.js` once, so every page shares the same, tested behavior: the toggle button now reports its state (`aria-expanded`) so a screen reader announces "collapsed" or "expanded," clicking outside the open menu still closes it (same as before), and pressing Escape now closes the menu and puts keyboard focus back on the button that opened it, exactly the pattern screen reader and keyboard users expect from a menu. (WCAG references: 2.1.1 Keyboard, 4.1.2 Name/Role/Value, 2.4.3 Focus Order.)

I also made a small CSS change so that while the mobile menu is closed, its roughly 20 links are removed from the tab order (`visibility: hidden`). Previously, tabbing through a closed page on a narrow screen still stepped through all 20 hidden sidebar links before reaching the visible page content, which was disorienting and slow for keyboard users.

### 2. Dead copy buttons, and the real one was copying the wrong text

Nine code samples across three pages had a "copy" button hard-coded into the HTML, wired to a function called `copyCode()` that does not exist anywhere in this codebase. Clicking it did nothing.

Meanwhile, `site.js` already adds its own working copy button to every code block automatically, so those nine blocks ended up with two buttons stacked on top of each other: a dead one and a working one. Worse, because the working button grabs "all the text in this box" and the dead button's own label ("copy") was part of that text, clicking the button that did work copied the code with the word "copy" stuck onto it.

I removed the nine dead buttons and hardened the real one so it always reads the code cleanly, regardless of what other markup happens to be sitting in the box. (WCAG references: 3.2.4 Consistent Identification, 4.1.2 Name/Role/Value, 2.1.1 Keyboard.)

### 3. Session rows in the dissect portal had no keyboard path at all

`distil dissect` serves a small local page listing your recorded sessions so you can click into one. Each row was rendered as a plain table row with an `onclick` handler and nothing else: no link, no tab stop, no keyboard handler. If you could not or did not use a mouse, there was no way to open a session from that page, full stop.

I put a real link around the session ID in each row, so it is a normal, focusable, screen-reader-friendly link. Clicking anywhere else in the row still opens the session too, exactly as before, that convenience is untouched. (WCAG reference: 2.1.1 Keyboard.)

### 4. Wide tables on mobile scrolled, but only for a mouse or a finger

Several docs pages have data tables wider than a phone screen (comparison tables, benchmark tables). On narrow screens these already scroll sideways so you can see the rest of the columns, that part worked. The problem is there was nothing inside that scrolling area a keyboard could focus, so a keyboard-only user (this is a known Safari behavior in particular) had no way to trigger that scroll and simply could not see the columns that ran off the edge of the screen.

I wrap each table in a labeled, focusable region (you can tab to it, and its name announces which table it is, taken from the heading just above it). Scrolling now happens on that wrapper instead of the table directly, so arrow keys work once it's focused. Desktop layout is identical either way. (WCAG reference: 2.1.1 Keyboard.)

One page, `index.html`, has its own separate styling and does not use the shared page layout the other 19 pages do, so the generic fix above does not reach its one wide table. It does load `site.js` and does have a table that genuinely scrolls on narrow screens, so I applied the same fix directly on that page too, in its own inline script, rather than skip it.

## Gates

- **Lint:** `make lint` fails, but on 428 pre-existing errors unrelated to this diff (mostly `noqa` cleanup and style items across the wider codebase, none on lines this PR touches). Running `ruff check` on just `distil/dissect.py` shows its 18 pre-existing errors are all elsewhere in the file; none on the lines this PR changed.
- **Pytest:** `uv run pytest tests/test_dissect.py -x -q` passes (76 passed). Grepped `tests/` for `render_sessions_html`, `toggleSidebar`, and `copy-btn`; the one hit (`tests/test_coverage_1151.py`) only asserts the sessions HTML is truthy, so it is unaffected and still passes. Ran the full suite too: `1842 passed, 5 skipped` in about three minutes, no failures.
- **Playwright, mobile sidebar (`benchmarks.html`, `adoption.html`, `getting-started.html` at 400x800):** toggle opens/closes the sidebar, `aria-expanded` flips true/false, Escape closes it and returns focus to the toggle button, outside-click still closes it on the previously-working page, zero console errors on any of the three pages. Pass.
- **Playwright, sidebar closed at mobile width:** `getComputedStyle` on the sidebar reports `visibility: hidden` when closed, confirming its links are out of the tab order. Pass.
- **Playwright, `research.html` copy buttons:** exactly one `.copy-btn` per `<pre>` (checked all six on the page). Clicked one and read `navigator.clipboard.readText()` directly: the clipboard held the exact command text, no leftover "copy" text. Zero console errors. Pass.
- **Playwright, `cli.html` at 900x800:** all 25 tables on the page are wrapped in `.table-scroll` with `tabindex="0"`, `role="region"`, and a derived `aria-label` (e.g. "Flags"). Focused a wrapper and confirmed arrow-key scrolling moves `scrollLeft`. Pass.
- **Playwright, `index.html`:** its one wide table is wrapped the same way at 400px width (focusable, labeled, scrolls), and at 1400px the wrapper shows no overflow at all, so desktop is unchanged. Zero console errors. Pass.
- **`dissect.py` targeted check:** built a minimal `SessionOverview` and called `render_sessions_html()` directly; confirmed the output contains a real `<a href="/session/...">` around the session id and that the row's `onclick` convenience is still present. Pass.

The dev server (`python3 -m http.server`) used for the Playwright checks was stopped afterward, and no artifacts from that were left behind.
