### PR TITLE
fix(a11y): announce status changes and repair ARIA wiring in the docs

### DIFF
--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -201,7 +201,7 @@
     <div class="seyebrow live gr" style="margin-top:0">Live telemetry &middot; auditable end-to-end</div>
     <h1>Adoption &amp; <span class="g">Community Savings</span></h1>
     <p class="lead">Most projects show you raw download counts and hope you don't ask questions. We ask them for you: downloads are <b>bot-filtered</b>, savings come from an <b>opt-in census</b> that starts at zero and can't be inflated, and every number below is computed by public code from a <a href="https://github.com/dshakes/distil/tree/metrics">public git branch</a>.</p>
-    <p class="updated" id="updated">connecting to the metrics branch&hellip;</p>
+    <p class="updated" id="updated" role="status">connecting to the metrics branch&hellip;</p>
 
     <!-- ── next-gen live hero: ticking odometer + trust ring ── -->
     <div class="hero">
@@ -250,7 +250,7 @@
     <div class="seyebrow gr">Downloads &middot; honestly</div>
     <h2 style="margin-top:0">The number everyone shows <span class="g">vs. the one that's true</span></h2>
     <p>A public PyPI package receives constant traffic from supply-chain scanners (Snyk/Socket-class), package-intel crawlers (deps.dev, libraries.io), and malware sandboxes — every new release triggers fleet-wide sweeps. They report no operating system; <code>pip</code> on a real machine does. Even the filtered number counts <em>events</em> (CI reinstalls, upgrades), not people — provable people are the census tile. So we split:</p>
-    <div class="split" id="splitband" aria-label="real vs bot download split">
+    <div class="split" id="splitband" role="img" aria-label="real vs bot download split">
       <div class="seg real" id="seg-real" style="flex-grow:1"></div>
       <div class="seg bots" id="seg-bots" style="flex-grow:1"></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -611,12 +611,12 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <h2>Install <span class="g">— pick a format</span><a class="hlink" href="#install" aria-label="Link to this section">#</a></h2>
   <p class="lead">The stdlib-only core makes the packaging clean: zero runtime deps, corpus bundled.</p>
   <div class="tabs" id="install-tabs">
-    <div class="tabbar" role="tablist">
-      <button class="tab is-active" data-tab="uvx" role="tab">uvx <span class="tab-hint">zero install</span></button>
-      <button class="tab" data-tab="pipx" role="tab">pipx <span class="tab-hint">isolated cli</span></button>
-      <button class="tab" data-tab="brew" role="tab">Homebrew</button>
-      <button class="tab" data-tab="docker" role="tab">Docker</button>
-      <button class="tab" data-tab="pyz" role="tab">zipapp</button>
+    <div class="tabbar">
+      <button class="tab is-active" data-tab="uvx" aria-pressed="true">uvx <span class="tab-hint">zero install</span></button>
+      <button class="tab" data-tab="pipx" aria-pressed="false">pipx <span class="tab-hint">isolated cli</span></button>
+      <button class="tab" data-tab="brew" aria-pressed="false">Homebrew</button>
+      <button class="tab" data-tab="docker" aria-pressed="false">Docker</button>
+      <button class="tab" data-tab="pyz" aria-pressed="false">zipapp</button>
     </div>
     <p class="tabrec"><b>uvx</b> — zero install, <span class="rec">recommended</span>. Runs straight from PyPI, nothing to clean up.</p>
     <div class="tabpanels">

--- a/docs/learn-compression.html
+++ b/docs/learn-compression.html
@@ -161,6 +161,7 @@
       <div class="stat-box"><div class="stat-n" id="te-cached">$0</div><div class="stat-l">With prompt caching (prefix read @ 0.1×)</div></div>
       <div class="stat-box hl"><div class="stat-n g" id="te-distil">$0</div><div class="stat-l">With caching <em>+</em> Distil lossless (−26.8%)</div></div>
     </div>
+    <div id="te-live" role="status" aria-live="polite" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;"></div>
     <p style="font-size:12px;color:#5b6177;margin-top:-10px;"><strong>Assumptions:</strong> input-token cost only (output excluded for clarity); prefix is cacheable and byte-stable; per-turn input = prefix + accumulated history; cached line writes the prefix once at 1.25× then reads it at 0.10× while the growing tail stays fresh; Distil line additionally removes 26.8% of fresh tokens losslessly. Illustrative — your numbers depend on your traffic.</p>
 
     <h2>Compression, the whole <span class="g">family tree</span></h2>
@@ -298,12 +299,27 @@ document.addEventListener('click', function(e) {
     $("te-turns-v").textContent = n;
     $("te-prefix-v").textContent = fmtN(F);
     $("te-step-v").textContent = fmtN(b);
-    $("te-naive").textContent = fmt$(naiveTok * inP);
-    $("te-cached").textContent = fmt$(cachedCost);
-    $("te-distil").textContent = fmt$(distilCost);
+    var naiveTxt = fmt$(naiveTok * inP), cachedTxt = fmt$(cachedCost), distilTxt = fmt$(distilCost);
+    $("te-naive").textContent = naiveTxt;
+    $("te-cached").textContent = cachedTxt;
+    $("te-distil").textContent = distilTxt;
+    return { naive: naiveTxt, cached: cachedTxt, distil: distilTxt };
+  }
+  // Debounced polite live region: the sliders fire "input" continuously while
+  // dragging, so we only announce the recalculated totals once input settles
+  // for ~500ms, to avoid flooding screen reader users.
+  var teLive = $("te-live");
+  var teLiveTimer = null;
+  function scheduleAnnounce(vals) {
+    if (!teLive) return;
+    clearTimeout(teLiveTimer);
+    teLiveTimer = setTimeout(function () {
+      teLive.textContent = "Naive " + vals.naive + ", with caching " + vals.cached + ", with caching and Distil " + vals.distil + ".";
+    }, 500);
   }
   [turns, prefix, step, model].forEach(function (el) {
-    el.addEventListener("input", recalc); el.addEventListener("change", recalc);
+    el.addEventListener("input", function () { scheduleAnnounce(recalc()); });
+    el.addEventListener("change", function () { scheduleAnnounce(recalc()); });
   });
   recalc();
 })();

--- a/docs/site.js
+++ b/docs/site.js
@@ -4,6 +4,19 @@
   "use strict";
 
   // ── Copy-to-clipboard on every code block ──────────────────────────
+  // Shared visually-hidden polite live region: announces the copy result to
+  // screen reader users, since the visual button-label swap alone is not
+  // reliably announced.
+  var copyStatus = document.createElement("span");
+  copyStatus.setAttribute("aria-live", "polite");
+  copyStatus.setAttribute("role", "status");
+  copyStatus.style.cssText = "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0";
+  document.body.appendChild(copyStatus);
+  function announceCopy(msg) {
+    copyStatus.textContent = "";
+    setTimeout(function () { copyStatus.textContent = msg; }, 50);
+  }
+
   document.querySelectorAll("pre").forEach(function (pre) {
     var original = (pre.querySelector("code") || pre).textContent; // capture before button
     var btn = document.createElement("button");
@@ -14,6 +27,7 @@
       var done = function () {
         btn.textContent = "✓ Copied";
         btn.classList.add("copied");
+        announceCopy("Copied to clipboard");
         setTimeout(function () {
           btn.textContent = "Copy";
           btn.classList.remove("copied");
@@ -31,7 +45,13 @@
         ta.style.opacity = "0";
         document.body.appendChild(ta);
         ta.select();
-        try { document.execCommand("copy"); done(); } catch (e) { btn.textContent = "Ctrl-C"; }
+        try {
+          document.execCommand("copy");
+          done();
+        } catch (e) {
+          btn.textContent = "Ctrl-C";
+          announceCopy("Copy failed, press Ctrl+C to copy manually");
+        }
         document.body.removeChild(ta);
       }
     });
@@ -54,8 +74,18 @@
   nav.innerHTML = '<div class="toc-title">On this page</div>';
 
   var entries = [];
+  var seenIds = {};
+  var lastH2 = "";
   heads.forEach(function (h) {
-    if (!h.id) h.id = slug(h.textContent) || "section";
+    if (!h.id) {
+      var base = slug(h.textContent) || "section";
+      // Prefix h3 ids with the nearest h2's id so repeated subheadings
+      // (e.g. every command's "Flags" section) still get unique, readable ids.
+      h.id = (h.tagName === "H3" && lastH2) ? lastH2 + "-" + base : base;
+    }
+    var n = seenIds[h.id] = (seenIds[h.id] || 0) + 1;
+    if (n > 1) h.id = h.id + "-" + n;
+    if (h.tagName === "H2") lastH2 = h.id;
     // Clickable "#" ref link on the header itself (deep-link any section).
     if (!h.querySelector(".hanchor")) {
       var ha = document.createElement("a");

--- a/docs/site.js
+++ b/docs/site.js
@@ -121,7 +121,11 @@
   }
 })();
 
-/* Tab groups: .tabs > .tab[data-tab] switches .tabpanel[data-panel]. */
+/* Tab groups: .tabs > .tab[data-tab] switches .tabpanel[data-panel].
+   These are plain toggle buttons (not the ARIA tabs/tablist pattern): each
+   button reports its own pressed state via aria-pressed, so they stay
+   ordinary Tab-and-Enter-operable buttons with no roving tabindex or
+   arrow-key contract to maintain. */
 (function () {
   document.querySelectorAll(".tabs").forEach(function (grp) {
     var tabs = grp.querySelectorAll(".tab");
@@ -129,7 +133,11 @@
     tabs.forEach(function (tab) {
       tab.addEventListener("click", function () {
         var key = tab.getAttribute("data-tab");
-        tabs.forEach(function (t) { t.classList.toggle("is-active", t === tab); });
+        tabs.forEach(function (t) {
+          var active = t === tab;
+          t.classList.toggle("is-active", active);
+          t.setAttribute("aria-pressed", active ? "true" : "false");
+        });
         panels.forEach(function (p) { p.classList.toggle("is-active", p.getAttribute("data-panel") === key); });
       });
     });


### PR DESCRIPTION
## Summary

This is another installment in the accessibility remediation series that started with #34. It's a small, focused batch: two ARIA-status announcement fixes, one duplicate-id bug in the shared docs script, and one incomplete widget pattern on the landing page. Nothing here touches Python, layout, or color; it's all wiring that was either silently broken or silently missing for screen reader users.

**The fun fact worth knowing:** the duplicate-id bug (see below) means 23 of the 24 "Flags" links in `cli.html`'s page outline currently jump to the wrong section, for every single user who clicks them, sighted or not. This wasn't an assistive-tech-only bug; it's just that nobody happened to click the third "Flags" link recently.

References use WCAG 2.2 success criterion numbers (SC) as citations only; no normative claims beyond what's fixed here.

---

### Duplicate heading ids break the "On this page" TOC and anchors (SC 4.1.2)

`site.js` builds each heading's `id` by slugifying its text, with no de-duplication. `cli.html` has 24 `<h3>Flags</h3>` headings (one per CLI subcommand), so all 24 got `id="flags"`. Every "On this page" TOC entry labeled "Flags" pointed at the same element, so clicking any of them except the first one scrolled you to the wrong command's flag table. The injected "#" permalink on each heading, and the scrollspy highlighting, had the same problem.

The fix prefixes `h3` ids with their nearest `h2`'s id (e.g. `bench-flags`, `certify-flags`, `holdout-flags`), falling back to a numeric suffix for any collision that scheme doesn't resolve. Verified in-browser: all 63 ids on `cli.html` are now unique, and two different "Flags" TOC links now scroll to genuinely different points in the page (roughly 575px and 6543px down the document).

### Copy-to-clipboard confirmation was silent for screen readers (SC 4.1.3)

Every code block's Copy button swaps its own label to "Copied" for 1.6 seconds. That's a purely visual cue; there was no live region, so screen reader users who clicked Copy had no way to know the clipboard write actually happened. Added one shared, visually-hidden `aria-live="polite"` region that announces "Copied to clipboard" (or a failure message in the rare execCommand-fails fallback path). Verified the region's text updates immediately after clicking a Copy button.

### Adoption page's live status paragraph was never announced (SC 4.1.3)

`adoption.html` has a `<p id="updated">` that starts as "connecting to the metrics branch…" and gets rewritten to report success, staleness, or failure of the live data fetch. That's a textbook status message, but it had no `role="status"` or `aria-live`, so screen reader users never learned whether the numbers on the page were live, stale, or broken. Added `role="status"`, which is appropriately quiet (this text changes at most every 45 seconds). Left the fast-polling rate labels and the odometer alone, exactly as the audit recommended, since those update every few seconds and would flood a screen reader with noise if wired into a live region.

### Compression calculator results updated silently (SC 4.1.3)

`learn-compression.html` has an interactive calculator: three sliders and a model picker recompute three dollar figures on every input. The figures were plain text with no live region, so a screen reader user adjusting a slider had to manually go find the results afterward; the whole point of the widget (see the numbers move as you change the inputs) was lost. Added a debounced, visually-hidden `aria-live="polite"` summary that announces all three figures 500ms after the last input event settles, so dragging a slider doesn't fire a wall of announcements. The visible stat boxes still update instantly for sighted users; only the screen-reader summary is debounced.

### Installer tabs on the landing page were half-implemented (SC 4.1.2)

The install-format switcher (`uvx` / `pipx` / `Homebrew` / `Docker` / `zipapp`) declared `role="tablist"` and `role="tab"`, which tells a screen reader "this is a tab widget, expect selection state and arrow-key navigation." Neither existed: no `aria-selected`, no roving `tabindex`, no arrow-key handling, no `role="tabpanel"`. The widget itself worked fine by mouse and by Tab-plus-Enter, since these are native `<button>` elements; the mismatch was purely in what screen readers were told to expect versus what was actually there.

I chose to drop the tablist/tab roles and use plain buttons with `aria-pressed` instead, rather than build out the full ARIA tabs pattern (roving tabindex, ArrowLeft/ArrowRight handling, ids wiring tabs to panels). Reasoning: this is a five-way format picker wired with nothing more than a plain click handler in `site.js` (the same handler every other `.tabs` widget on the site would use, if there were others); adding a second navigation contract (arrow keys) on top of working Tab-and-Enter behavior is more surface area to maintain for no real benefit to this particular widget, and the two-line `aria-pressed` toggle change is the smaller, lower-risk fix. Verified in-browser: focusing the "pipx" button and pressing Enter toggles `aria-pressed` correctly on all five buttons and switches the visible panel, with zero console errors.

### Invalid aria-label on a generic div (SC 4.1.2)

`adoption.html` had `<div class="split" id="splitband" aria-label="real vs bot download split">`. Under ARIA 1.2, a plain `div` has an implicit role of `generic`, and generic elements aren't allowed to carry an accessible name, so browsers and assistive tech either ignore that `aria-label` or expose it inconsistently. Added `role="img"` so the element has a role that supports naming. The adjacent legend already states the real numbers, so no information depends on this label either way; it's a validity fix, not a content fix.

---

## Gates

- **No Python files changed.** This PR is docs/site.js/site markup only (`docs/site.js`, `docs/index.html`, `docs/adoption.html`, `docs/learn-compression.html`). The pytest suite is unaffected; confirmed by grepping `tests/` for any of the HTML ids/strings touched here (`role="tab"`, `copy-btn`, `te-naive`, `te-live`, `splitband`, `id="updated"`, `flags"`): the only hits are unrelated Python dict keys named `"flags"` in manifest test fixtures (`tests/test_dissect.py`, `tests/test_upgrade.py`, `tests/test_coverage_1151.py`), not the docs markup. No pytest was actually runnable in this environment (module not installed), but since no Python changed, that's moot.
- **`make lint` not relevant**, per scope (no Python changed).
- **Browser-verified** with a real Playwright session against this worktree's docs on port 8647: all 63 heading ids on `cli.html` are unique post-fix, two different "Flags" TOC links scroll to different document offsets, the copy button's live region updates after a click, the installer tabs are fully keyboard-operable (`aria-pressed` and panel state update correctly on Enter) with zero console errors on `index.html`, `cli.html`, or `adoption.html`, and the compression calculator's live region populates only after the 500ms debounce (confirmed empty at 0ms and 200ms, populated at 700ms).
- **Working tree clean**, 4 commits on `fix/a11y-aria-status`, branched from `main`.
- **Deviations / out of scope:** none. All six findings (M8, M9, M10, M11, N12, N9) were implemented as scoped; no other findings from the audit were touched, and CONTRIBUTORS.md was not modified.
