### PR TITLE
fix(a11y): raise muted-text contrast to WCAG AA across docs and dashboards

### DIFF
--- a/distil/benchmark.py
+++ b/distil/benchmark.py
@@ -429,9 +429,9 @@ h1{{font-size:28px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden;font-size:13.5px}}
 th,td{{padding:10px 13px;border-bottom:1px solid #1b2030;text-align:left}}
-th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+th{{color:#7d8598;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 td.r{{text-align:right;font-variant-numeric:tabular-nums}} td.d{{color:#9aa1b3}}
-.foot{{color:#5b6177;font-size:12.5px;margin-top:20px}}
+.foot{{color:#7d8598;font-size:12.5px;margin-top:20px}}
 </style></head><body><div class="wrap">
 <h1>Compression <span class="g">benchmark</span></h1>
 <p class="sub">model {report.model} · runner {report.runner} · every technique through the same

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1563,7 +1563,7 @@ h3{{font-size:14px;font-weight:700;margin:20px 0 8px}}
 .tot .card{{flex:1;min-width:150px}}
 .card .l{{color:#9aa1b3;font-size:12px}} .card .v{{font-size:30px;font-weight:800;margin-top:4px}}
 .card .v2{{font-size:22px;font-weight:700;margin-top:4px}}
-.card .n{{color:#5b6177;font-size:12px;margin-top:6px;line-height:1.45}}
+.card .n{{color:#7d8598;font-size:12px;margin-top:6px;line-height:1.45}}
 .tile{{cursor:help}} .card[data-tip] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
  padding-bottom:1px}}
 [data-tip]{{outline:none}}
@@ -1577,7 +1577,7 @@ g[data-tip]:hover .mark,g[data-tip]:focus .mark{{filter:brightness(1.35)}}
 #tip .tkey{{width:10px;height:3px;border-radius:1.5px;flex:none}}
 #tip .trow b{{font-variant-numeric:tabular-nums}}
 #tip .tlab{{color:#9aa1b3}}
-.desc{{color:#5b6177;font-size:13px;line-height:1.55;margin:-4px 0 14px}}
+.desc{{color:#7d8598;font-size:13px;line-height:1.55;margin:-4px 0 14px}}
 .story{{background:linear-gradient(180deg,#12151f,#0b0d15);border:1px solid #252c3e;
  border-radius:14px;padding:16px 20px;margin:0 0 10px}}
 .story b{{font-size:15px}}
@@ -1585,16 +1585,16 @@ g[data-tip]:hover .mark,g[data-tip]:focus .mark{{filter:brightness(1.35)}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
-th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
-td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
+th{{color:#7d8598;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#7d8598}}
 code{{color:#8b7bff}}
 .callout{{border:1px solid #6b5416;background:#14100a;border-radius:12px;
  padding:14px 18px;margin:24px 0}}
 .callout b{{color:#e8b34b}}
 ul.warn{{margin:8px 0 0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:6px 0}}
 ul.notes{{margin:14px 0 0;padding-left:20px}} ul.notes li{{color:#9aa1b3;margin:8px 0}}
-details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
-.foot{{color:#5b6177;font-size:12.5px;margin-top:26px}}
+details{{margin:10px 0}} details summary{{cursor:pointer;color:#7d8598}}
+.foot{{color:#7d8598;font-size:12.5px;margin-top:26px}}
 </style></head><body><div class="wrap">
 <h1>Session <span class="g">dissected</span></h1>
 <p class="sub">{e(d.sid)} — {e(man.get("tool") or "unknown tool")},
@@ -1692,11 +1692,11 @@ h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
-th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+th{{color:#7d8598;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}}
 tbody tr{{cursor:pointer}} tbody tr:hover td{{background:#10131d}}
-code{{color:#8b7bff}} .muted{{color:#5b6177}}
-.foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+code{{color:#8b7bff}} .muted{{color:#7d8598}}
+.foot{{color:#7d8598;font-size:12.5px;margin-top:22px}}
 </style></head><body><div class="wrap">
 <h1>Distil <span class="g">sessions</span></h1>
 <p class="sub">Pick a session to dissect — newest activity first. This page refreshes itself.</p>

--- a/distil/gateway.py
+++ b/distil/gateway.py
@@ -418,7 +418,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     background-clip: text;
   }}
   .subtitle {{
-    color: #6b7280;
+    color: #8b93a3;
     font-size: 0.85rem;
     margin-bottom: 2rem;
   }}
@@ -440,7 +440,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     font-size: 0.72rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #6b7280;
+    color: #8b93a3;
     margin-bottom: 0.35rem;
   }}
   .card-value {{
@@ -458,7 +458,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     text-align: left;
     padding: 0.7rem 1rem;
     border-bottom: 2px solid #1e2130;
-    color: #6b7280;
+    color: #8b93a3;
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.07em;
@@ -501,7 +501,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     overflow: hidden;
   }}
   .refresh-note {{
-    color: #374151;
+    color: #8b93a3;
     font-size: 0.72rem;
     text-align: right;
     margin-top: 0.75rem;

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -397,9 +397,9 @@ h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
-th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
-td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
-.foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+th{{color:#7d8598;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
+td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#7d8598}}
+.foot{{color:#7d8598;font-size:12.5px;margin-top:22px}}
 </style></head><body><div class="wrap">
 <h1>Your <span class="g">savings</span></h1>
 <p class="sub">Genuine, local-first — measured from your own runs and proxy traffic. No content leaves your machine.</p>

--- a/distil/telemetry.py
+++ b/distil/telemetry.py
@@ -198,7 +198,7 @@ def render_leaderboard_html(lb: Leaderboard) -> str:
         certified_cell = (
             '<td class="cert yes">&#10004; certified</td>'
             if r.get("certified")
-            else '<td class="cert no">&#8212;</td>'
+            else '<td class="cert no">not certified</td>'
         )
         rows_html += (
             f"<tr>"
@@ -237,7 +237,7 @@ def render_leaderboard_html(lb: Leaderboard) -> str:
   .iid{{font-family:monospace;color:#5ad1c9}}
   .num{{text-align:right;font-variant-numeric:tabular-nums}}
   .cert.yes{{color:#5ad1c9;font-weight:600}}
-  .cert.no{{color:#3a3c4e}}
+  .cert.no{{color:#8b8ea8}}
   .badge{{display:inline-block;background:#1a1c2e;border:1px solid #8b7bff;
           color:#8b7bff;font-size:.7rem;padding:.1rem .4rem;border-radius:.25rem;
           margin-left:.5rem;vertical-align:middle}}

--- a/distil/webdash.py
+++ b/distil/webdash.py
@@ -79,7 +79,7 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>distil · live savings</title>
 <style>
-  :root{--bg:#0b0c13;--panel:#101420;--panel2:#141a28;--line:#1c2233;--mut:#8a8ca0;--dim:#5a5c70;--good:#5ad19a;--acc:#8b7bff;--tl:#5ad1c9}
+  :root{--bg:#0b0c13;--panel:#101420;--panel2:#141a28;--line:#1c2233;--mut:#8a8ca0;--dim:#878ba2;--good:#5ad19a;--acc:#8b7bff;--tl:#5ad1c9}
   *{box-sizing:border-box}
   body{margin:0;min-height:100vh;background:radial-gradient(120% 90% at 15% -10%,rgba(90,209,154,.10),transparent 55%),radial-gradient(120% 120% at 100% 0%,rgba(139,123,255,.10),transparent 50%),var(--bg);
     color:#eaf0ff;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;display:flex;align-items:center;justify-content:center;padding:32px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     --disp:"Space Grotesk",ui-sans-serif,-apple-system,"Segoe UI",Inter,sans-serif;
     --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
     --bg:#06070a; --panel:#0c0e14; --panel2:#0f1219; --line:#1b1f2a;
-    --ink:#e7e9ee; --mut:#8b91a1; --dim:#5b6173;
+    --ink:#e7e9ee; --mut:#8b91a1; --dim:#7d8598;
     --acc:#8b7bff; --acc2:#5ad1c9; --warn:#ff8a6b; --good:#5ad19a;
     --grad:linear-gradient(135deg,#8b7bff 0%,#5ad1c9 100%);
   }
@@ -64,7 +64,7 @@
   .heroterm{box-shadow:0 24px 60px -20px rgba(0,0,0,.7),0 0 0 1px rgba(139,123,255,.06)}
   .heroterm .bar{display:flex;align-items:center;gap:6px;padding:10px 14px;border-bottom:1px solid var(--line)}
   .heroterm .bar i{width:10px;height:10px;border-radius:50%;display:inline-block}
-  .heroterm .bartitle{margin-left:auto;margin-right:auto;padding-right:44px;font-size:11.5px;color:#5b6173;letter-spacing:.02em}
+  .heroterm .bartitle{margin-left:auto;margin-right:auto;padding-right:44px;font-size:11.5px;color:#7d8598;letter-spacing:.02em}
   .heroterm pre{margin:0;border:0;border-radius:0;background:transparent;padding:14px 18px;
     font:12.5px/1.7 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-x:auto}
   .heroterm .cap{padding:8px 18px 12px;color:var(--dim);font-size:12px}
@@ -82,7 +82,7 @@
   h2{font-size:30px;letter-spacing:-.02em;margin:0 0 6px}
   h2 .g{background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent}
   .lead{color:var(--mut);max-width:680px;margin:0 0 26px}
-  .hlink{margin-left:10px;color:var(--acc2);opacity:.45;font-weight:600;text-decoration:none;
+  .hlink{margin-left:10px;color:var(--acc2);opacity:.7;font-weight:600;text-decoration:none;
     transition:opacity .15s;font-size:.7em;vertical-align:middle}
   h2:hover .hlink{opacity:.75}
   .hlink:hover{opacity:1!important;text-decoration:underline}
@@ -602,7 +602,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <div class="seyebrow gr">Drop-in</div>
   <h2>Works with every SDK <span class="g">— one proxy, no code change</span><a class="hlink" href="#integrations" aria-label="Link to this section">#</a></h2>
   <p class="lead">Point any <code>base_url</code>-honoring client at the proxy — Python, TypeScript, any language —
-    and get cache-aware lossless compression. <a href="integrations.html" style="color:var(--acc2)">See integrations →</a></p>
+    and get cache-aware lossless compression. <a href="integrations.html" style="color:var(--acc2);text-decoration:underline">See integrations →</a></p>
   <img loading="lazy" src="assets/cross-sdk.svg" alt="one proxy, every SDK" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
 </div></section>
 

--- a/docs/site.css
+++ b/docs/site.css
@@ -24,7 +24,7 @@
   --line2:  #252c3e;
   --ink:    #f2f3f7;
   --mut:    #9aa1b3;
-  --dim:    #5b6177;
+  --dim:    #7d8598;
   --acc:    #8b7bff;
   --acc2:   #5ad1c9;
   --warn:   #ff8a6b;
@@ -175,7 +175,7 @@ li::marker { color: var(--dim); }
 /* prose links (scoped so nav/cards keep their styling) */
 .content p a, .content li a, .callout a {
   color: var(--acc2); background: linear-gradient(var(--acc2), var(--acc2)) no-repeat;
-  background-size: 0% 1px; background-position: 0 100%;
+  background-size: 100% 1px; background-position: 0 100%;
   transition: background-size .25s, color .15s;
 }
 .content p a:hover, .content li a:hover, .callout a:hover { background-size: 100% 1px; color: #7fe6df; }
@@ -473,7 +473,7 @@ pre:hover .copy-btn { opacity: 1; }
 }
 
 /* Header ref links — clickable "#" anchor, revealed on hover/focus. */
-.hanchor { margin-left: .45em; color: var(--acc2); text-decoration: none; opacity: .45; font-weight: 600; font-size: .72em; transition: opacity .12s; }
+.hanchor { margin-left: .45em; color: var(--acc2); text-decoration: none; opacity: .7; font-weight: 600; font-size: .72em; transition: opacity .12s; }
 .content h2:hover .hanchor, .content h3:hover .hanchor, .hanchor:hover, .hanchor:focus { opacity: 1; text-decoration: underline; }
 
 /* Tabbed panels (installers, code variants) — compass-style */


### PR DESCRIPTION
## Why

This follows #34 in the accessibility series. Roughly 1 in 12 people has some form of low vision or color-vision deficiency, and WCAG 2.2 AA sets a floor of 4.5:1 contrast for normal-size text specifically so that group can read it. Several grays we use everywhere, in the docs site and in every Python-generated dashboard, measured around 3:1 (some as low as 1.86:1). This PR raises those grays just enough to clear 4.5:1, with a small margin so they hold up even against the lightest background each one sits on.

It also fixes one related "use of color" issue: prose links were told apart from body text only by a subtle teal color shift (about 1.4:1 contrast against the surrounding text), which is not enough for someone with a color-vision deficiency to reliably spot a link.

## What this changes visually

Heads up: this PR intentionally changes how a few things look. Nothing about hue or layout changes, only lightness, so the aesthetic should feel the same at a glance:

- Muted/secondary text (table headers, footers, captions, sidebar labels, the docs TOC, dashboard cards) is a bit lighter and easier to read.
- Prose links inside paragraphs and lists are now underlined by default, not just on hover.
- The small "#" heading-permalink icons are more visible at rest (still subtle, just no longer near-invisible).
- The gateway dashboard's "Auto-refresh every 5 s" note, which used to be almost unreadable, is now legible.
- The telemetry leaderboard's "not certified" marker is now spelled out in words instead of a bare, nearly-invisible dash, so it reads clearly and screen readers announce something meaningful instead of a dash character.

## Before / after contrast ratios

All ratios computed with the standard WCAG relative-luminance formula against every background each color actually sits on in the codebase. Target is 4.5:1 for normal text.

| Where | Old color | Background | Old ratio | New color | New ratio |
|---|---|---|---|---|---|
| docs/site.css `--dim` (th, TOC, footer, sidebar labels, etc.) | #5b6177 | page #06070b | 3.28:1 | #7d8598 | 5.45:1 |
| docs/site.css `--dim` | #5b6177 | code block #0a0c14 | 3.18:1 | #7d8598 | 5.28:1 |
| docs/site.css `--dim` | #5b6177 | card gradient top #12151f | 2.97:1 | #7d8598 | 4.93:1 |
| docs/index.html `--dim` (.stat .foot, .muted, .vfoot) | #5b6173 | page #06070a | 3.26:1 | #7d8598 | 5.45:1 |
| docs/index.html `.heroterm .bartitle` | #5b6173 | terminal bg #070810 | 3.24:1 | #7d8598 | 5.40:1 |
| docs/site.css `.hanchor` (opacity .45 -> .7) | #5ad1c9 @ 45% | page #06070b | 2.90:1 | #5ad1c9 @ 70% | 5.62:1 |
| docs/index.html `.hlink` (opacity .45 -> .7) | #5ad1c9 @ 45% | page #06070a | 2.90:1 | #5ad1c9 @ 70% | 5.62:1 |
| distil/dissect.py, benchmark.py, ledger.py muted text | #5b6177 | page #06070b | 3.28:1 | #7d8598 | 5.45:1 |
| ...same, on card gradient top | #5b6177 | #12151f | 2.97:1 | #7d8598 | 4.93:1 |
| ...same, on card gradient bottom | #5b6177 | #0b0d15 | 3.16:1 | #7d8598 | 5.25:1 |
| distil/gateway.py `.subtitle` / `.card-label` / `thead th` | #6b7280 | page #06070a | 4.17:1 | #8b93a3 | 6.52:1 |
| ...same, on card bg | #6b7280 | #0f1117 | 3.90:1 | #8b93a3 | 6.11:1 |
| distil/gateway.py `.refresh-note` | #374151 | page #06070a | 1.95:1 | #8b93a3 | 6.52:1 |
| distil/webdash.py `--dim` (.foot, odometer separators) | #5a5c70 | panel #101420 | 2.80:1 | #878ba2 | 5.46:1 |
| ...same, on card top panel2 #141a28 | #5a5c70 | #141a28 | 2.65:1 | #878ba2 | 5.17:1 |
| ...same, on outer bg | #5a5c70 | #0b0c13 | 2.97:1 | #878ba2 | 5.80:1 |
| distil/telemetry.py `.cert.no` | #3a3c4e | page #06070b | 1.86:1 | #8b8ea8 | 6.26:1 |
| ...same, on hover row bg | #3a3c4e | #0d0f17 | 1.76:1 | #8b8ea8 | 5.95:1 |

The prose-link fix (S2) isn't a contrast-ratio change: the underline is now shown by default (`background-size: 100% 1px` instead of `0%`), so the link no longer depends on color at all to be identifiable, which is what SC 1.4.1 actually asks for.

## Gates

- **ruff**: `uvx ruff check` on every touched `.py` file (dissect.py, benchmark.py, ledger.py, gateway.py, webdash.py, telemetry.py) shows the same 36 pre-existing errors before and after this change, none on the lines touched here, and none new.
- **pytest**: full suite (`uv run pytest -q`) passes: 1859 passed, 0 failed.
- **Ratio verification**: computed with a small standalone script implementing the WCAG relative-luminance/contrast formula, checked against every background each changed color actually sits on (page, card gradients top and bottom, code blocks, panels, hover rows). Every pairing clears 4.5:1 with margin; see table above.
- **Screenshots reviewed**: took screenshots of index.html and getting-started.html with a real browser (dark theme intact, sidebar and body copy readable, prose links underlined, heading "#" links visible at rest) and read back the live computed styles (`--dim`, link `background-size`, `.hanchor`/`.hlink` opacity) to confirm the new values are actually applied, not just present in the CSS source.
- Honest note: grep of `tests/` for the changed hex values and for `hanchor`/`hlink`/copy-button/background-size patterns turned up nothing, so no test assertions needed updating.
