### PR TITLE
fix(a11y): expose diagrams, charts, and their links to assistive technology

### DIFF
--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1076,11 +1076,15 @@ def _svg_hbars(
     rows: list[tuple[str, int, list[tuple[str, str, str]]]],
     *,
     color: str = _C_OVERHEAD,
+    name: str = "Bar chart",
 ) -> str:
     """Horizontal bar chart (single measure, one hue): label, thin bar, value.
 
     Each row is (label, value, tooltip_rows). The whole row — label through
-    value — is one oversized hit target for the styled tooltip.
+    value — is one oversized hit target for the styled tooltip. ``name`` is
+    the chart's accessible name (SC 1.1.1): it is rendered both as the
+    ``aria-label`` and as an ``<svg><title>`` so it survives in AT that
+    ignores one or the other.
     """
     if not rows:
         return ""
@@ -1089,7 +1093,9 @@ def _svg_hbars(
     plot_w = width - label_w - val_w
     parts = [
         f'<svg viewBox="0 0 {width} {len(rows) * rh + 6}" role="img" '
+        f'aria-label="{_html.escape(name, quote=True)}" '
         f'style="width:100%;height:auto;font:12px Inter,ui-sans-serif,sans-serif">'
+        f"<title>{_html.escape(name)}</title>"
     ]
     for i, (label, val, tip_rows) in enumerate(rows):
         y = i * rh + 4
@@ -1129,9 +1135,16 @@ def _svg_stack_timeline(requests: list[dict[str, Any]]) -> str:
     n = len(comp)
     step = plot_w / n
     bar_w = max(2, min(28, round(step - 2)))
+    total_saved = sum(saved for _o, _s, saved, _r in comp)
+    name = (
+        f"Per-request token composition for {n} requests: stacked overhead, sent content, "
+        f"and tokens saved, {_human(total_saved)} saved in total"
+    )
     parts = [
         f'<svg viewBox="0 0 {width} {height}" role="img" '
+        f'aria-label="{_html.escape(name, quote=True)}" '
         f'style="width:100%;height:auto;font:11px Inter,ui-sans-serif,sans-serif">'
+        f"<title>{_html.escape(name)}</title>"
     ]
     for frac in (0.0, 0.5, 1.0):  # recessive grid, three lines
         y = 8 + plot_h * (1 - frac)
@@ -1214,6 +1227,20 @@ def _timeline_table(requests: list[dict[str, Any]]) -> str:
         "<details><summary class='muted'>data table</summary>"
         "<table><tr><th>#</th><th>model</th><th>overhead</th><th>sent</th>"
         f"<th>saved</th><th>billed in</th><th>ms</th></tr>{rows}</table></details>"
+    )
+
+
+def _tool_cost_table(tool_costs: list[tuple[str, int, int]]) -> str:
+    """Data-table fallback for the tool-definition-cost chart, mirroring
+    :func:`_timeline_table` so the same numbers are available without a chart."""
+    rows = "".join(
+        f"<tr><td>{_html.escape(name)}</td><td class='r'>{per:,}</td><td class='r'>{tot:,}</td></tr>"
+        for name, per, tot in tool_costs
+    )
+    return (
+        "<details><summary class='muted'>data table</summary>"
+        "<table><tr><th>tool</th><th>tokens per request</th>"
+        f"<th>session total</th></tr>{rows}</table></details>"
     )
 
 
@@ -1424,6 +1451,7 @@ def render_html(
             else ""
         )
 
+        tool_costs = d.tool_costs()[:10]
         tool_rows = [
             (
                 name,
@@ -1433,17 +1461,19 @@ def render_html(
                     ("", "session total (× every request)", f"{tot:,}"),
                 ],
             )
-            for name, per, tot in d.tool_costs()[:10]
+            for name, per, tot in tool_costs
         ]
         tools_chart = (
             "<h2>Tool definitions <span class='muted'>(tokens per request)</span></h2>"
             "<p class='desc'>Every enabled tool is re-described to the model on every "
             "request, so each bar is a standing cost you pay per call. Long bars from "
             "tools you rarely use are the cheapest tokens to reclaim — disable them.</p>"
-            f"{_svg_hbars(tool_rows)}"
+            f"{_svg_hbars(tool_rows, name='Tool definition cost, tokens per request, top 10 tools')}"
+            f"{_tool_cost_table(tool_costs)}"
             if tool_rows
             else ""
         )
+        kind_rows_chart = d.blocks_by_kind()[:10]
         kind_chart = _svg_hbars(
             [
                 (
@@ -1454,9 +1484,10 @@ def render_html(
                         ("", "distinct blocks", str(uniq)),
                     ],
                 )
-                for sig, uniq, toks in d.blocks_by_kind()[:10]
+                for sig, uniq, toks in kind_rows_chart
             ],
             color=_C_SAVED,
+            name="Tokens folded by block kind, top 10 kinds",
         )
         detail_body = f"""<h2>Request detail</h2>
 <p class="desc">Every API request this session made, and where its tokens went — hover any

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -422,8 +422,10 @@
     var line = "M" + pts.join(" L");
     var area = line + " L" + W + "," + H + " L0," + H + " Z";
     var hx = px(x1).toFixed(2), hy = py(y1).toFixed(2);
+    var trendLabel = "Community tokens saved trending from " + human(y0) + " to " + human(y1) +
+      " over " + history.length + " censuses";
     el.innerHTML =
-      '<svg viewBox="0 0 100 40" preserveAspectRatio="none"><defs>' +
+      '<svg viewBox="0 0 100 40" preserveAspectRatio="none" role="img" aria-label="' + trendLabel + '"><defs>' +
       '<linearGradient id="sg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#5ad19a" stop-opacity=".28"/><stop offset="1" stop-color="#5ad19a" stop-opacity="0"/></linearGradient></defs>' +
       '<path class="area" d="' + area + '"/><path class="line" d="' + line + '"/>' +
       '<circle class="head" cx="' + hx + '" cy="' + hy + '" r="2.4"/></svg>' +

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -65,8 +65,8 @@
     <h1>Architecture <span class="g">Overview</span></h1>
     <p class="lead">Distil is a cost-optimized cache hierarchy with a statistical quality contract. Six components, one invariant: the agent makes the same decisions on compressed context as on the original — provably, not heuristically.</p>
 
-    <figure class="archfig" aria-label="Interactive Distil architecture diagram — click a block to open its concept">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" font-family="Inter,ui-sans-serif,Segoe UI,Roboto,sans-serif" role="img" aria-label="Distil architecture: agent to cache-aware compression pipeline to upstream LLM, with the recovery loop and the decision-equivalence quality contract">
+    <figure class="archfig" aria-label="Interactive Distil architecture diagram — select a block to open its concept">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" font-family="Inter,ui-sans-serif,Segoe UI,Roboto,sans-serif" role="group" aria-label="Distil architecture: agent to cache-aware compression pipeline to upstream LLM, with the recovery loop and the decision-equivalence quality contract">
       <defs>
         <linearGradient id="iabg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0c13"/><stop offset="1" stop-color="#06070b"/></linearGradient>
         <linearGradient id="iag" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#8b7bff"/><stop offset="1" stop-color="#5ad1c9"/></linearGradient>
@@ -95,19 +95,19 @@
       <text x="600" y="140" text-anchor="middle" font-size="16" font-weight="800" fill="url(#iag)">compress → cache-pin → forward</text>
 
       <g font-size="12.5" text-anchor="middle">
-        <a href="techniques.html#tiers"><title>Tier-0 — lossless verbatim transforms (always on)</title><g><rect x="340" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="401" y="181" fill="#dbe0ee" font-weight="700">Tier-0</text><text x="401" y="197" fill="#9aa0b2" font-size="10.5">lossless</text></g></a>
-        <a href="techniques.html#tiers"><title>Tier-1 — reversible decision-aware digest</title><g><rect x="472" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="533" y="181" fill="#dbe0ee" font-weight="700">Tier-1 digest</text><text x="533" y="197" fill="#9aa0b2" font-size="10.5">reversible</text></g></a>
-        <a href="techniques.html#causal"><title>Causal / counterfactual pruning — ablation-proven</title><g><rect x="604" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="665" y="181" fill="#dbe0ee" font-weight="700">causal prune</text><text x="665" y="197" fill="#9aa0b2" font-size="10.5">ablation-proven</text></g></a>
-        <a href="techniques.html#salience-protection"><title>Salience protection — model-free needle-keeping</title><g><rect x="736" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="797" y="181" fill="#dbe0ee" font-weight="700">salience</text><text x="797" y="197" fill="#9aa0b2" font-size="10.5">model-free</text></g></a>
+        <a href="techniques.html#tiers" aria-label="Tier-0 — lossless verbatim transforms (always on)"><title>Tier-0 — lossless verbatim transforms (always on)</title><g><rect x="340" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="401" y="181" fill="#dbe0ee" font-weight="700">Tier-0</text><text x="401" y="197" fill="#9aa0b2" font-size="10.5">lossless</text></g></a>
+        <a href="techniques.html#tiers" aria-label="Tier-1 — reversible decision-aware digest"><title>Tier-1 — reversible decision-aware digest</title><g><rect x="472" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="533" y="181" fill="#dbe0ee" font-weight="700">Tier-1 digest</text><text x="533" y="197" fill="#9aa0b2" font-size="10.5">reversible</text></g></a>
+        <a href="techniques.html#causal" aria-label="Causal / counterfactual pruning — ablation-proven"><title>Causal / counterfactual pruning — ablation-proven</title><g><rect x="604" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="665" y="181" fill="#dbe0ee" font-weight="700">causal prune</text><text x="665" y="197" fill="#9aa0b2" font-size="10.5">ablation-proven</text></g></a>
+        <a href="techniques.html#salience-protection" aria-label="Salience protection — model-free needle-keeping"><title>Salience protection — model-free needle-keeping</title><g><rect x="736" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="797" y="181" fill="#dbe0ee" font-weight="700">salience</text><text x="797" y="197" fill="#9aa0b2" font-size="10.5">model-free</text></g></a>
       </g>
       <g stroke="#3a486a" stroke-width="1.4" fill="none"><path d="M462,182 L472,182"/><path d="M594,182 L604,182"/><path d="M726,182 L736,182"/></g>
 
-      <a href="techniques.html#cache-aware"><title>Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate</title><rect x="340" y="220" width="518" height="36" rx="9" fill="#0e1320" stroke="#2a5740"/>
+      <a href="techniques.html#cache-aware" aria-label="Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate"><title>Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate</title><rect x="340" y="220" width="518" height="36" rx="9" fill="#0e1320" stroke="#2a5740"/>
       <circle cx="361" cy="238" r="4" fill="#5ad19a"/>
       <text x="377" y="243" font-size="12.5" fill="#dbe0ee">cache-aware placement — stable prefix billed at the <tspan fill="#6fe0aa" font-weight="700">0.1× cache-read</tspan> rate</text></a>
 
-      <a href="techniques.html#tiers"><title>RestoreStore — originals kept locally, never sent to the model</title><g transform="translate(340,268)"><rect width="248" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#bcacff">RestoreStore</text><text x="15" y="43" font-size="11" fill="#9aa0b2">originals kept locally · 0 tokens on wire</text><text x="15" y="55" font-size="10" fill="#727a92">never sent to the model</text></g></a>
-      <a href="techniques.html#tiers"><title>distil_expand — the model recovers any digested detail on demand</title><g transform="translate(602,268)"><rect width="256" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#5ad1c9">distil_expand</text><text x="15" y="43" font-size="11" fill="#9aa0b2">model recovers any digested detail</text><text x="15" y="55" font-size="10" fill="#727a92">transparent re-query · PAYG</text></g></a>
+      <a href="techniques.html#tiers" aria-label="RestoreStore — originals kept locally, never sent to the model"><title>RestoreStore — originals kept locally, never sent to the model</title><g transform="translate(340,268)"><rect width="248" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#bcacff">RestoreStore</text><text x="15" y="43" font-size="11" fill="#9aa0b2">originals kept locally · 0 tokens on wire</text><text x="15" y="55" font-size="10" fill="#727a92">never sent to the model</text></g></a>
+      <a href="techniques.html#tiers" aria-label="distil_expand — the model recovers any digested detail on demand"><title>distil_expand — the model recovers any digested detail on demand</title><g transform="translate(602,268)"><rect width="256" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#5ad1c9">distil_expand</text><text x="15" y="43" font-size="11" fill="#9aa0b2">model recovers any digested detail</text><text x="15" y="55" font-size="10" fill="#727a92">transparent re-query · PAYG</text></g></a>
 
       <g transform="translate(966,122)"><rect width="186" height="84" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <text x="18" y="31" font-size="14" font-weight="700" fill="#eef0f5">Anthropic · OpenAI</text>
@@ -122,24 +122,24 @@
       <text x="600" y="396" text-anchor="middle" font-size="12.5" fill="#7fe6ad">response → transparent expand loop → agent (it just gets the right answer)</text>
 
       <text x="48" y="436" font-size="12" letter-spacing="2" font-weight="700" fill="#7b8298">THE QUALITY CONTRACT — every operating point is certified decision-equivalent</text>
-      <a href="concepts.html#contract"><title>Decision-Equivalence Certificate — the conformal guarantee</title><g transform="translate(48,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="concepts.html#contract" aria-label="Decision-Equivalence Certificate — the conformal guarantee"><title>Decision-Equivalence Certificate — the conformal guarantee</title><g transform="translate(48,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#8b7bff"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Decision-Equivalence Certificate</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">conformal risk control (LTT/CRC) · distribution-free</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">P(decision-change ≤ α) ≥ 1 − δ</text>
       </g></a>
-      <a href="concepts.html#contract"><title>Shadow mode — live decision-equivalence on real traffic</title><g transform="translate(420,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="concepts.html#contract" aria-label="Shadow mode — live decision-equivalence on real traffic"><title>Shadow mode — live decision-equivalence on real traffic</title><g transform="translate(420,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#5ad1c9"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Shadow mode — live</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">samples real traffic, runs it both ways</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">rolling decision-change rate · streaming-aware</text>
       </g></a>
-      <a href="techniques.html#keep-model"><title>Learned keep-model — the self-improving, never-regressing flywheel</title><g transform="translate(792,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="techniques.html#keep-model" aria-label="Learned keep-model — the self-improving, never-regressing flywheel"><title>Learned keep-model — the self-improving, never-regressing flywheel</title><g transform="translate(792,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#5ad19a"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Learned keep-model — flywheel</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">every expand is a label; only ever gets</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">more conservative — never-regressing</text>
       </g></a>
     </svg>
     </figure>
-    <p class="archfig-hint"><b>Interactive</b> — click any block to open the concept or technique behind it.</p>
+    <p class="archfig-hint"><b>Interactive</b> — select any block (click, or Tab then Enter) to open the concept or technique behind it.</p>
 
     <div class="callout">
       <strong>The six-layer story.</strong> (1) Cache-aware compression keeps the prefix byte-stable. (2) Tier-0 lossless transforms run unconditionally. (3) Tier-1 reversible digests handle large tool outputs behind content handles. (4) Causal/counterfactual pruning discovers what is safe to drop. (5) The conformal DERC certificate gates everything lossy. (6) Salience protection and a sub-millisecond, model-free hot path make it viable as an inline proxy.

--- a/docs/benchmark.html
+++ b/docs/benchmark.html
@@ -75,7 +75,7 @@
     <h2 id="live-head-to-head">Live head-to-head <span class="g">— real packages, real model</span></h2>
     <p>Not reference implementations: the <strong>actual installed packages</strong> (<code>llmlingua</code> 0.2.2, <code>headroom-ai</code> 0.27.0), each invoked the way that gives it its <em>best</em> fair result, all graded <strong>live by <code>claude-opus-4-8</code></strong> (majority-of-3) on the same realistic corpus (5 domains, 120 turns, 4.5–6.5&nbsp;KB/turn). Savings are measured identically for everyone; the decision is the agent's actual next <code>{action, target}</code>.</p>
 
-    <p align="center"><img src="assets/head-to-head.svg" alt="Live head-to-head: savings vs decision-equivalence" width="100%" style="max-width:760px"/></p>
+    <p align="center"><img src="assets/head-to-head.svg" alt="Bar chart: Distil achieves 83.2% token savings with 0.0% decision-change (certified, 0.026 ms/turn); LLMLingua-2 reaches 53.1% savings but 12.5% decision-change (fails the gate); Headroom reaches 39.7% savings with 0.0% decision-change (certified, 26 ms/turn); full figures in the table below" width="100%" style="max-width:760px"/></p>
 
     <table>
       <thead>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -65,8 +65,8 @@
     <h1>Core <span class="g">Concepts</span></h1>
     <p class="lead">Three ideas explain why Distil's numbers are real and why the approach is different: decision-equivalence as the correct quality target, a statistical certificate that enforces it, and cache-aware cost modeling that makes aggressive compression financially correct.</p>
 
-    <figure class="archfig" aria-label="Interactive Distil architecture diagram — click a block to open its concept">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" font-family="Inter,ui-sans-serif,Segoe UI,Roboto,sans-serif" role="img" aria-label="Distil architecture: agent to cache-aware compression pipeline to upstream LLM, with the recovery loop and the decision-equivalence quality contract">
+    <figure class="archfig" aria-label="Interactive Distil architecture diagram — select a block to open its concept">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" font-family="Inter,ui-sans-serif,Segoe UI,Roboto,sans-serif" role="group" aria-label="Distil architecture: agent to cache-aware compression pipeline to upstream LLM, with the recovery loop and the decision-equivalence quality contract">
       <defs>
         <linearGradient id="iabg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0c13"/><stop offset="1" stop-color="#06070b"/></linearGradient>
         <linearGradient id="iag" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#8b7bff"/><stop offset="1" stop-color="#5ad1c9"/></linearGradient>
@@ -95,19 +95,19 @@
       <text x="600" y="140" text-anchor="middle" font-size="16" font-weight="800" fill="url(#iag)">compress → cache-pin → forward</text>
 
       <g font-size="12.5" text-anchor="middle">
-        <a href="techniques.html#tiers"><title>Tier-0 — lossless verbatim transforms (always on)</title><g><rect x="340" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="401" y="181" fill="#dbe0ee" font-weight="700">Tier-0</text><text x="401" y="197" fill="#9aa0b2" font-size="10.5">lossless</text></g></a>
-        <a href="techniques.html#tiers"><title>Tier-1 — reversible decision-aware digest</title><g><rect x="472" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="533" y="181" fill="#dbe0ee" font-weight="700">Tier-1 digest</text><text x="533" y="197" fill="#9aa0b2" font-size="10.5">reversible</text></g></a>
-        <a href="techniques.html#causal"><title>Causal / counterfactual pruning — ablation-proven</title><g><rect x="604" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="665" y="181" fill="#dbe0ee" font-weight="700">causal prune</text><text x="665" y="197" fill="#9aa0b2" font-size="10.5">ablation-proven</text></g></a>
-        <a href="techniques.html#salience-protection"><title>Salience protection — model-free needle-keeping</title><g><rect x="736" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="797" y="181" fill="#dbe0ee" font-weight="700">salience</text><text x="797" y="197" fill="#9aa0b2" font-size="10.5">model-free</text></g></a>
+        <a href="techniques.html#tiers" aria-label="Tier-0 — lossless verbatim transforms (always on)"><title>Tier-0 — lossless verbatim transforms (always on)</title><g><rect x="340" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="401" y="181" fill="#dbe0ee" font-weight="700">Tier-0</text><text x="401" y="197" fill="#9aa0b2" font-size="10.5">lossless</text></g></a>
+        <a href="techniques.html#tiers" aria-label="Tier-1 — reversible decision-aware digest"><title>Tier-1 — reversible decision-aware digest</title><g><rect x="472" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="533" y="181" fill="#dbe0ee" font-weight="700">Tier-1 digest</text><text x="533" y="197" fill="#9aa0b2" font-size="10.5">reversible</text></g></a>
+        <a href="techniques.html#causal" aria-label="Causal / counterfactual pruning — ablation-proven"><title>Causal / counterfactual pruning — ablation-proven</title><g><rect x="604" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="665" y="181" fill="#dbe0ee" font-weight="700">causal prune</text><text x="665" y="197" fill="#9aa0b2" font-size="10.5">ablation-proven</text></g></a>
+        <a href="techniques.html#salience-protection" aria-label="Salience protection — model-free needle-keeping"><title>Salience protection — model-free needle-keeping</title><g><rect x="736" y="158" width="122" height="48" rx="10" fill="#111726" stroke="#2a3650"/><text x="797" y="181" fill="#dbe0ee" font-weight="700">salience</text><text x="797" y="197" fill="#9aa0b2" font-size="10.5">model-free</text></g></a>
       </g>
       <g stroke="#3a486a" stroke-width="1.4" fill="none"><path d="M462,182 L472,182"/><path d="M594,182 L604,182"/><path d="M726,182 L736,182"/></g>
 
-      <a href="techniques.html#cache-aware"><title>Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate</title><rect x="340" y="220" width="518" height="36" rx="9" fill="#0e1320" stroke="#2a5740"/>
+      <a href="techniques.html#cache-aware" aria-label="Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate"><title>Cache-aware placement — pin the stable prefix at the 0.1× cache-read rate</title><rect x="340" y="220" width="518" height="36" rx="9" fill="#0e1320" stroke="#2a5740"/>
       <circle cx="361" cy="238" r="4" fill="#5ad19a"/>
       <text x="377" y="243" font-size="12.5" fill="#dbe0ee">cache-aware placement — stable prefix billed at the <tspan fill="#6fe0aa" font-weight="700">0.1× cache-read</tspan> rate</text></a>
 
-      <a href="techniques.html#tiers"><title>RestoreStore — originals kept locally, never sent to the model</title><g transform="translate(340,268)"><rect width="248" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#bcacff">RestoreStore</text><text x="15" y="43" font-size="11" fill="#9aa0b2">originals kept locally · 0 tokens on wire</text><text x="15" y="55" font-size="10" fill="#727a92">never sent to the model</text></g></a>
-      <a href="techniques.html#tiers"><title>distil_expand — the model recovers any digested detail on demand</title><g transform="translate(602,268)"><rect width="256" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#5ad1c9">distil_expand</text><text x="15" y="43" font-size="11" fill="#9aa0b2">model recovers any digested detail</text><text x="15" y="55" font-size="10" fill="#727a92">transparent re-query · PAYG</text></g></a>
+      <a href="techniques.html#tiers" aria-label="RestoreStore — originals kept locally, never sent to the model"><title>RestoreStore — originals kept locally, never sent to the model</title><g transform="translate(340,268)"><rect width="248" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#bcacff">RestoreStore</text><text x="15" y="43" font-size="11" fill="#9aa0b2">originals kept locally · 0 tokens on wire</text><text x="15" y="55" font-size="10" fill="#727a92">never sent to the model</text></g></a>
+      <a href="techniques.html#tiers" aria-label="distil_expand — the model recovers any digested detail on demand"><title>distil_expand — the model recovers any digested detail on demand</title><g transform="translate(602,268)"><rect width="256" height="60" rx="10" fill="#0e1320" stroke="#343f63"/><text x="15" y="25" font-size="13" font-weight="700" fill="#5ad1c9">distil_expand</text><text x="15" y="43" font-size="11" fill="#9aa0b2">model recovers any digested detail</text><text x="15" y="55" font-size="10" fill="#727a92">transparent re-query · PAYG</text></g></a>
 
       <g transform="translate(966,122)"><rect width="186" height="84" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <text x="18" y="31" font-size="14" font-weight="700" fill="#eef0f5">Anthropic · OpenAI</text>
@@ -122,24 +122,24 @@
       <text x="600" y="396" text-anchor="middle" font-size="12.5" fill="#7fe6ad">response → transparent expand loop → agent (it just gets the right answer)</text>
 
       <text x="48" y="436" font-size="12" letter-spacing="2" font-weight="700" fill="#7b8298">THE QUALITY CONTRACT — every operating point is certified decision-equivalent</text>
-      <a href="concepts.html#contract"><title>Decision-Equivalence Certificate — the conformal guarantee</title><g transform="translate(48,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="concepts.html#contract" aria-label="Decision-Equivalence Certificate — the conformal guarantee"><title>Decision-Equivalence Certificate — the conformal guarantee</title><g transform="translate(48,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#8b7bff"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Decision-Equivalence Certificate</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">conformal risk control (LTT/CRC) · distribution-free</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">P(decision-change ≤ α) ≥ 1 − δ</text>
       </g></a>
-      <a href="concepts.html#contract"><title>Shadow mode — live decision-equivalence on real traffic</title><g transform="translate(420,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="concepts.html#contract" aria-label="Shadow mode — live decision-equivalence on real traffic"><title>Shadow mode — live decision-equivalence on real traffic</title><g transform="translate(420,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#5ad1c9"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Shadow mode — live</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">samples real traffic, runs it both ways</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">rolling decision-change rate · streaming-aware</text>
       </g></a>
-      <a href="techniques.html#keep-model"><title>Learned keep-model — the self-improving, never-regressing flywheel</title><g transform="translate(792,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
+      <a href="techniques.html#keep-model" aria-label="Learned keep-model — the self-improving, never-regressing flywheel"><title>Learned keep-model — the self-improving, never-regressing flywheel</title><g transform="translate(792,448)"><rect width="360" height="80" rx="14" fill="url(#iacard)" stroke="#2c344a"/>
         <circle cx="26" cy="31" r="6" fill="#5ad19a"/><text x="44" y="29" font-size="14" font-weight="700" fill="#eef0f5">Learned keep-model — flywheel</text>
         <text x="20" y="52" font-size="11.5" fill="#9aa0b2">every expand is a label; only ever gets</text>
         <text x="20" y="69" font-size="11.5" fill="#9aa0b2">more conservative — never-regressing</text>
       </g></a>
     </svg>
     </figure>
-    <p class="archfig-hint"><b>Interactive</b> — click any block to open the concept or technique behind it.</p>
+    <p class="archfig-hint"><b>Interactive</b> — select any block (click, or Tab then Enter) to open the concept or technique behind it.</p>
 
     <hr/>
 

--- a/docs/corpus.html
+++ b/docs/corpus.html
@@ -65,7 +65,7 @@
     <h1>The <span class="g">Corpus</span></h1>
     <p class="lead">The asset that makes certification meaningful — 7 real, captured-style agent trajectories across 7 domains. Every strategy must pass the gate on every one of them.</p>
 
-    <img src="assets/domains.svg" alt="Measured across 7 domains" class="svg-embed"/>
+    <img src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 33.1%, coding 28.7%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 25.0%, finance 29.1%; aggregate 26.8% cheaper losslessly across 5,761 prunable tokens; figures repeated in the table below" class="svg-embed"/>
 
     <hr/>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -333,11 +333,11 @@
 
   <div class="doors">
     <a class="door" href="getting-started.html">
-      <span class="door-ico">⚡</span>
+      <span class="door-ico" aria-hidden="true">⚡</span>
       <span class="door-body"><span class="door-t">Get saving (2 min)</span><span class="door-d">One command, no code changes</span></span>
     </a>
     <div class="door door-alt">
-      <span class="door-ico">🔬</span>
+      <span class="door-ico" aria-hidden="true">🔬</span>
       <span class="door-body"><span class="door-t"><a href="compare.html">See the proof</a></span><span class="door-d">Benchmarks &amp; <a href="research.html">full research</a></span></span>
     </div>
   </div>
@@ -472,15 +472,15 @@
   <p class="lead">No jargon. Here's the whole idea in three pictures.</p>
   <div class="tiers">
     <div class="card">
-      <h3>🗂️ Don't re-send what's already remembered</h3>
+      <h3><span aria-hidden="true">🗂️</span> Don't re-send what's already remembered</h3>
       <p style="color:var(--mut)">Every turn, your agent re-sends the <em>entire</em> conversation — and you pay for all of it, again. The model can cheaply "remember" the parts that haven't changed, so Distil keeps those parts perfectly stable and only touches the new bits. <b>Like not re-reading someone the whole book to add one sentence.</b></p>
     </div>
     <div class="card">
-      <h3>✂️ Drop only what doesn't matter</h3>
+      <h3><span aria-hidden="true">✂️</span> Drop only what doesn't matter</h3>
       <p style="color:var(--mut)">Most of that context never changes what the agent decides to do next. Distil finds those dead-weight parts with a simple test — <em>remove it, replay, did the decision change?</em> If no, it was safe to cut. <b>Keep the clues, drop the filler.</b></p>
     </div>
     <div class="card">
-      <h3>🧾 Prove it — don't just trust it</h3>
+      <h3><span aria-hidden="true">🧾</span> Prove it — don't just trust it</h3>
       <p style="color:var(--mut)">Here's the part nobody else does: Distil <em>measures</em> that your agent still makes the same choice on the shrunk context. If it can't prove that, it sends everything, untouched. <b>A warranty on the compression, not a promise.</b></p>
     </div>
   </div>
@@ -491,7 +491,7 @@
   <div class="seyebrow p">The architecture</div>
   <h2>Under the hood <span class="g">— a cost-optimized cache hierarchy with a contract</span><a class="hlink" href="#how" aria-label="Link to this section">#</a></h2>
   <p class="lead">Most compressors optimize bytes. In an agent loop the money is somewhere else.</p>
-  <img loading="lazy" src="assets/architecture.svg" alt="architecture" style="width:100%;border:1px solid var(--line);border-radius:16px;margin:6px 0 24px"/>
+  <img loading="lazy" src="assets/architecture.svg" alt="Architecture: agent traffic flows through the Distil proxy (Tier-0 lossless, Tier-1 digest, causal prune, salience, cache-aware placement) to the provider, with a recovery loop and decision-equivalence certificate" style="width:100%;border:1px solid var(--line);border-radius:16px;margin:6px 0 24px"/>
   <h3 style="font-size:22px">Two highest-leverage techniques <span class="g">— and why they win</span></h3>
   <div class="grid2">
     <div class="card">
@@ -551,7 +551,7 @@ VERDICT: <span class="g">PASS</span>  (certified non-inferior)
 <span class="d">$ distil certify --strategy aggressive</span>
 decision-equivalence match rate: <span class="w">0.0%</span>
 VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
-  <img loading="lazy" src="assets/cache-aware.svg" alt="cache-aware savings" style="width:100%;border:1px solid var(--line);border-radius:16px;margin-top:18px"/>
+  <img loading="lazy" src="assets/cache-aware.svg" alt="Bar chart of per-run cost: baseline (no cache, no compress) $0.01524; cache only $0.01115 (-27%); naive recompression busts the prefix cache and costs more, $0.01691; distil's cache-aware lossless approach $0.01019 (-33%), the lowest of the four" style="width:100%;border:1px solid var(--line);border-radius:16px;margin-top:18px"/>
 </div></section>
 
 <section id="domains"><div class="wrap">
@@ -559,7 +559,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <h2>Measured across 7 domains <span class="g">— the same gate, not one example</span><a class="hlink" href="#domains" aria-label="Link to this section">#</a></h2>
   <p class="lead">A strategy isn't trustworthy because it works once. <code>distil bench</code> certifies
     every domain — ops, coding, support, research, data, devops, finance — or it doesn't ship.</p>
-  <img loading="lazy" src="assets/domains.svg" alt="measured across 7 domains" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
+  <img loading="lazy" src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 33.1%, coding 28.7%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 25.0%, finance 29.1%; aggregate 26.8% cheaper losslessly across 5,761 prunable tokens" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
 </div></section>
 
 <section id="tiers"><div class="wrap">
@@ -603,7 +603,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <h2>Works with every SDK <span class="g">— one proxy, no code change</span><a class="hlink" href="#integrations" aria-label="Link to this section">#</a></h2>
   <p class="lead">Point any <code>base_url</code>-honoring client at the proxy — Python, TypeScript, any language —
     and get cache-aware lossless compression. <a href="integrations.html" style="color:var(--acc2)">See integrations →</a></p>
-  <img loading="lazy" src="assets/cross-sdk.svg" alt="one proxy, every SDK" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
+  <img loading="lazy" src="assets/cross-sdk.svg" alt="Diagram: five client SDKs (Anthropic, OpenAI, Vercel AI, LangChain, LiteLLM) all point base_url at the Distil proxy on localhost:8788, which does cache-aware compression, lossless reversible transforms, and auth-mode gating (or runs in-process via wrap(client)), then forwards to Anthropic, OpenAI-compatible, or Google Gemini APIs with no code changes" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
 </div></section>
 
 <section id="install"><div class="wrap">


### PR DESCRIPTION
Hi team, this is the next installment in the accessibility remediation series that started with #34. It closes out the "non-text content" findings from the audit: images, charts, and an interactive diagram that either say nothing to a screen reader or say the wrong thing.

## The headline fix: the architecture diagram was inviting clicks nobody could hear

`architecture.html` and `concepts.html` both ship the same interactive SVG: six pipeline stages and four "quality contract" cards, each one a real link into `techniques.html` or `concepts.html`. The page literally tells sighted visitors "Interactive: click any block to open the concept behind it." The problem: the `<svg>` had `role="img"`, which tells assistive tech "this is one flat picture, nothing inside it matters." Screen reader users got a single unlabeled image announcement and never learned the ten links existed, even though they were still sitting in the keyboard tab order, silent and unlabeled, when focused.

Fix: the svg is now `role="group"` (keeps the same overall `aria-label` describing the whole diagram), and every one of the ten links gets its own `aria-label` so its name is announced reliably (the existing `<title>` elements weren't consistently exposed cross-browser). The "click any block" copy is now "select any block (click, or Tab then Enter)" so it doesn't assume a mouse. Same change, same wording, on both pages, since they share the identical figure. (WCAG 1.1.1, 4.1.2)

## Dissect report charts now have names, and the tools chart got its missing table

`distil dissect --html` renders three charts: the per-request timeline, the tool-cost bars, and the folded-blocks bars. All three were `<svg role="img">` with nothing to tell a screen reader what they showed. They now carry a descriptive `aria-label` (and a matching `<svg><title>` as a belt-and-suspenders backup) built from the actual data, e.g. "Tokens folded by block kind, top 10 kinds." The timeline chart already had a collapsible data-table fallback; the tool-cost chart didn't, so it's the odd one out no longer, it gets the same pattern (tool name, tokens per request, session total). (WCAG 1.1.1)

## Four diagram alts on the marketing and docs pages actually describe the diagram now

`index.html`, `corpus.html`, and `benchmark.html` had a handful of images whose alt text named the topic but not the content, things like `alt="architecture"` or `alt="one proxy, every SDK"`. I opened each SVG and read what it actually draws, then wrote alts that carry the real message: the architecture alt now names the five pipeline stages and the recovery loop, the cache-aware chart alt states all four bar values, the "7 domains" chart alt lists all seven domains and their pass rates, and the cross-SDK alt names the five client SDKs and three provider groups it connects. Where a table right below the image already had the numbers (corpus.html, benchmark.html), the alt says so explicitly instead of repeating every digit. (WCAG 1.1.1)

## The adoption page's sparkline can now say what it's showing

The tiny JS-drawn sparkline on `adoption.html` (community tokens saved over time) was an `<svg>` with zero role or name. It now gets `role="img"` plus a data-driven `aria-label` computed at render time, e.g. "Community tokens saved trending from 1.2k to 8.4k over 12 censuses," so the trend it's drawing is actually stated, not just implied by a squiggly line.

## Decorative emoji stop announcing themselves

The two hero door icons and the three plain-English card headings on `index.html` use emoji purely for visual flavor, the text next to them already carries the meaning. Screen readers were reading them out by their Unicode names ("high voltage," "card file box"). They're now wrapped in `aria-hidden="true"` so they're silent, decorative flourishes the way they were meant to be. (best practice, WCAG 1.1.1 framing)

## Visual changes

None. Every fix here is either an ARIA attribute, an alt/aria-label string, or a wording tweak in visible instructional text (the "select any block" hint); no layout, color, or markup structure changed. Screenshots confirmed the architecture diagram renders pixel-identical.

## Gates

- `uv run ruff check` on every `.py` file touched (`distil/dissect.py`): pass, no new errors (18 pre-existing errors before and after, same categories).
- `uv run pytest -q`: pass, 1842 passed, 5 skipped, in 169.87s. No test assertions needed updating; the existing dissect chart tests check for content by substring (`"data table" in page`, `page.count("<svg") == 3`), which still hold.
- Browser verification (shared Playwright instance, served this worktree's `docs/` on port 8646): pass. On `architecture.html`, an accessibility snapshot shows all 10 diagram links exposed by name (e.g. "Cache-aware placement, pin the stable prefix at the 0.1x cache-read rate" and "Learned keep-model, the self-improving, never-regressing flywheel") inside a `group`, not swallowed by a flat image label; a DOM check confirms all 10 are natively focusable (`tabIndex: 0`). A screenshot of the figure matches the pre-change layout pixel for pixel, confirming no visual change. On `adoption.html`, the live sparkline's rendered aria-label read "Community tokens saved trending from 1.2B to 1.5B over 10 censuses," confirming the data-driven label works against real fetched data, not just the synthetic case.
- Dissect chart rendering: rendered a synthetic session report via the existing test-suite fixture (`tests/test_dissect.py::_seed_state`) and confirmed all 3 chart svgs (timeline, tools, block kinds) carry both `role="img"` and a descriptive `aria-label`, and the tools chart now has its own collapsible data table alongside the existing timeline one (2 "data table" fallbacks total, up from 1).
