### PR TITLE
fix(a11y): visible focus, skip links, and an accessible dissect tooltip system

### DIFF
--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1224,6 +1224,10 @@ def _tip_attr(title: str, rows: list[tuple[str, str, str]] | None = None, body: 
     innerHTML), so model/tool/signature names stay data, not markup. ``rows``
     are (series_color, label, value) triples; values render strong, labels
     secondary, keyed by a short stroke of the series color.
+
+    Also wires ``aria-describedby="tip"`` so a screen reader announces the
+    same explanation a sighted mouse or keyboard user sees in the floating
+    tooltip (the shared ``#tip`` element rendered once per page).
     """
     payload: dict[str, Any] = {"t": title}
     if rows:
@@ -1232,7 +1236,7 @@ def _tip_attr(title: str, rows: list[tuple[str, str, str]] | None = None, body: 
         payload["body"] = body
     return (
         f' data-tip="{_html.escape(json.dumps(payload, ensure_ascii=False), quote=True)}"'
-        ' tabindex="0"'
+        ' tabindex="0" aria-describedby="tip"'
     )
 
 
@@ -1481,7 +1485,7 @@ text. Only these labels are stored, never the content.</p>
 <p class="desc">The biggest single blocks distil summarized. The handle is the short ID the
 model can use to ask for the original back; “recoverable” means those original bytes are
 still on this machine.</p>
-<table><tr><th>handle</th><th>kind</th><th>tokens</th><th title="how many requests carried this block">seen</th><th title="is the original still on disk (restore/)?">restore</th></tr>{top_rows}</table>"""
+<table><tr><th>handle</th><th>kind</th><th>tokens</th><th{_tip_attr("seen", body="How many requests carried this block.")}>seen</th><th{_tip_attr("restore", body="Is the original still on disk (restore/)?")}>restore</th></tr>{top_rows}</table>"""
     else:
         detail_body = (
             "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
@@ -1566,11 +1570,11 @@ h3{{font-size:14px;font-weight:700;margin:20px 0 8px}}
 .card .n{{color:#5b6177;font-size:12px;margin-top:6px;line-height:1.45}}
 .tile{{cursor:help}} .card[data-tip] .l{{border-bottom:1px dotted #3a4257;display:inline-block;
  padding-bottom:1px}}
-[data-tip]{{outline:none}}
+[data-tip]:focus-visible{{outline:2px solid #8b7bff;outline-offset:2px}}
 g[data-tip]:hover .mark,g[data-tip]:focus .mark{{filter:brightness(1.35)}}
 #tip{{position:fixed;display:none;background:#161a26;border:1px solid #2c3550;
  border-radius:10px;padding:10px 13px;font-size:12.5px;line-height:1.5;
- pointer-events:none;z-index:9;max-width:340px;box-shadow:0 8px 24px rgba(0,0,0,.55)}}
+ z-index:9;max-width:340px;box-shadow:0 8px 24px rgba(0,0,0,.55)}}
 #tip .tt{{color:#f2f3f7;font-weight:600;margin-bottom:2px}}
 #tip .tb{{color:#9aa1b3}}
 #tip .trow{{display:flex;align-items:center;gap:8px;margin:3px 0}}
@@ -1602,9 +1606,9 @@ details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 · billing: {e(d.billing)}</p>
 {warn_card}
 <div class="tot">
-<div class="card" title="Input tokens are everything sent TO the model (your conversation so far, tool outputs, prompts) — the part that grows every turn and that distil compresses."><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div><div class="n">would have been sent → actually sent</div></div>
-<div class="card" title="Share of input tokens distil kept off the wire across the whole session."><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div><div class="n">of input tokens never sent</div></div>
-<div class="card" title="What those saved tokens are worth at API prices. On a flat-rate subscription nothing is billed per token, so this is notional — the real win is headroom."><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div><div class="n">at API prices for this model mix</div></div>
+<div class="card"{_tip_attr("Input tokens", body="Input tokens are everything sent TO the model (your conversation so far, tool outputs, prompts), the part that grows every turn and that distil compresses.")}><div class="l">Input tokens</div><div class="v">{_human(d.baseline_tokens)} → {_human(d.distil_tokens)}</div><div class="n">would have been sent → actually sent</div></div>
+<div class="card"{_tip_attr("Saved", body="Share of input tokens distil kept off the wire across the whole session.")}><div class="l">Saved</div><div class="v g">{d.pct_saved:.1f}%</div><div class="n">of input tokens never sent</div></div>
+<div class="card"{_tip_attr("Dollars", body="What those saved tokens are worth at API prices. On a flat-rate subscription nothing is billed per token, so this is notional: the real win is headroom.")}><div class="l">Dollars{e(dol_note)}</div><div class="v">${d.dollars_saved:.2f}</div><div class="n">at API prices for this model mix</div></div>
 </div>
 {story}
 <h2>Per model</h2>
@@ -1652,6 +1656,7 @@ shadow.jsonl on this machine. Content-free — handles and kind:size signatures 
     tip.style.left = Math.max(8, px) + "px"; tip.style.top = Math.max(8, py) + "px";
   }}
   document.addEventListener("mousemove", function (e) {{
+    if (e.target === tip || tip.contains(e.target)) return; // hoverable: don't hide over the tip itself
     var el = e.target.closest && e.target.closest("[data-tip]");
     if (el && fill(el)) place(e.clientX, e.clientY);
     else tip.style.display = "none";
@@ -1661,6 +1666,9 @@ shadow.jsonl on this machine. Content-free — handles and kind:size signatures 
     if (el && fill(el)) {{ var r = el.getBoundingClientRect(); place(r.right, r.top); }}
   }});
   document.addEventListener("focusout", function () {{ tip.style.display = "none"; }});
+  document.addEventListener("keydown", function (e) {{
+    if (e.key === "Escape") tip.style.display = "none";
+  }});
 }})();
 </script></body></html>"""
 

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1744,7 +1744,13 @@ def make_server(host: str = "127.0.0.1", port: int = 8790, transcript: str | Non
                 if path.startswith(prefix):
                     sid = resolve_sid(path[len(prefix) :])
                     if sid is None:
-                        self._send(404, "<h1>unknown session</h1>")
+                        self._send(
+                            404,
+                            '<!doctype html><html lang="en"><head><meta charset="utf-8"/>'
+                            "<title>Unknown session: distil</title></head>"
+                            "<body><h1>Unknown session</h1>"
+                            '<p><a href="/">sessions</a></p></body></html>',
+                        )
                         return
                     d = dissect(sid)
                     peers = list_sessions()
@@ -1786,7 +1792,12 @@ def make_server(host: str = "127.0.0.1", port: int = 8790, transcript: str | Non
                         )
                         self._send(200, page)
                     return
-            self._send(404, "<h1>not found</h1><p><a href='/'>sessions</a></p>")
+            self._send(
+                404,
+                '<!doctype html><html lang="en"><head><meta charset="utf-8"/>'
+                "<title>Not found: distil</title></head>"
+                '<body><h1>Not found</h1><p><a href="/">sessions</a></p></body></html>',
+            )
 
         def log_message(self, *args: Any) -> None:  # quiet by design, like the proxy
             pass

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Adapters <span class="g">&amp; Integration</span></h1>
     <p class="lead">Three paths to production: a one-line Python wrapper that compresses in-process, a standalone HTTP proxy that works with any SDK or framework, or <code>distil wrap</code> — a zero-config launcher that routes any existing command through the proxy automatically.</p>

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -156,6 +156,7 @@
 </style>
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">&#9776;</button>
@@ -196,7 +197,7 @@
     <a href="index.html">&larr; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <div class="seyebrow live gr" style="margin-top:0">Live telemetry &middot; auditable end-to-end</div>
     <h1>Adoption &amp; <span class="g">Community Savings</span></h1>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Architecture <span class="g">Overview</span></h1>
     <p class="lead">Distil is a cost-optimized cache hierarchy with a statistical quality contract. Six components, one invariant: the agent makes the same decisions on compressed context as on the original — provably, not heuristically.</p>

--- a/docs/benchmark.html
+++ b/docs/benchmark.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -59,7 +60,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>The <span class="g">Benchmark</span></h1>
     <p class="lead">Every compression method shrinks tokens — the only number that matters is how much it saves <em>without changing what the agent decides</em>, once prompt caching is priced in. This head-to-head runs every technique through the <strong>same</strong> decision-equivalence gate and the <strong>same</strong> cache-aware cost model: the winner is computed, not assumed.</p>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">&#9776;</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&larr; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Reproduce the <span class="g">Numbers</span></h1>
     <p class="lead">Every headline number has a command. This page shows exactly how each one is produced — what is synthetic, what is live, and what we ran but chose not to ship as the default (E7). None of it requires you to trust our word; it requires you to run the script.</p>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>CLI <span class="g">Reference</span></h1>
     <p class="lead">Every subcommand, its flags, and a real sample output. All commands work offline with zero API key — the bundled corpus is self-contained.</p>

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -58,7 +59,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Distil vs <span class="g">everything else</span></h1>
     <p class="lead"><a href="benchmark.html">Benchmark</a> measures savings and decision-equivalence head-to-head; this page covers the other axis — what each tool actually <em>guarantees</em>, and what happens to real task success on a real harness. Competitors here are real, shipping tools, and the honest gap is narrower on savings than on proof.</p>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Core <span class="g">Concepts</span></h1>
     <p class="lead">Three ideas explain why Distil's numbers are real and why the approach is different: decision-equivalence as the correct quality target, a statistical certificate that enforces it, and cache-aware cost modeling that makes aggressive compression financially correct.</p>

--- a/docs/corpus.html
+++ b/docs/corpus.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>The <span class="g">Corpus</span></h1>
     <p class="lead">The asset that makes certification meaningful — 7 real, captured-style agent trajectories across 7 domains. Every strategy must pass the gate on every one of them.</p>

--- a/docs/deploy-security.html
+++ b/docs/deploy-security.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <!-- Top bar -->
 <header class="topbar">
@@ -64,7 +65,7 @@
   </aside>
 
   <!-- Main content -->
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Deploy &amp; <span class="g">Security</span></h1>
     <p class="lead">Three deployment topologies, one security model. The proxy is designed to be safe by default — it binds localhost, forwards only to the single configured upstream, and never touches your secrets.</p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Frequently Asked <span class="g">Questions</span></h1>
     <p class="lead">Honest answers to the questions that matter most — including the things Distil won't paper over.</p>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <!-- Top bar -->
 <header class="topbar">
@@ -64,7 +65,7 @@
   </aside>
 
   <!-- Main content -->
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Getting <span class="g">Started</span></h1>
     <p class="lead">Install, then run <code>distil onboard</code> — one command that detects your agent (Claude Code, Codex, Gemini CLI) and billing, wires the savings status line, and hands you the exact next steps. No code change required.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,7 +159,7 @@
     font:600 11px/1 "Inter",ui-sans-serif,system-ui,sans-serif;color:var(--mut);background:rgba(255,255,255,.04);
     border:1px solid var(--line);border-radius:8px;padding:5px 9px;cursor:pointer;opacity:.55;z-index:2;
     transition:opacity .15s,color .15s,border-color .15s,background .15s}
-  pre:hover .copy-btn{opacity:1}
+  pre:hover .copy-btn,.copy-btn:focus-visible{opacity:1}
   .copy-btn:hover{color:var(--ink);border-color:#34405e;background:rgba(255,255,255,.07)}
   .copy-btn.copied{color:var(--good);border-color:rgba(90,209,154,.4);opacity:1}
   /* tabbed installer */

--- a/docs/index.html
+++ b/docs/index.html
@@ -474,7 +474,7 @@
 
 <section id="plain"><div class="wrap">
   <div class="seyebrow">In plain English</div>
-  <h2>How it works <span class="g">— in plain English</span><a class="hlink" href="#plain" aria-label="Link to this section">#</a></h2>
+  <h2>How it works <span class="g">— in plain English</span><a class="hlink" href="#plain" aria-label="Link to section: How it works — in plain English">#</a></h2>
   <p class="lead">No jargon. Here's the whole idea in three pictures.</p>
   <div class="tiers">
     <div class="card">
@@ -495,7 +495,7 @@
 
 <section id="how"><div class="wrap">
   <div class="seyebrow p">The architecture</div>
-  <h2>Under the hood <span class="g">— a cost-optimized cache hierarchy with a contract</span><a class="hlink" href="#how" aria-label="Link to this section">#</a></h2>
+  <h2>Under the hood <span class="g">— a cost-optimized cache hierarchy with a contract</span><a class="hlink" href="#how" aria-label="Link to section: Under the hood — a cost-optimized cache hierarchy with a contract">#</a></h2>
   <p class="lead">Most compressors optimize bytes. In an agent loop the money is somewhere else.</p>
   <img loading="lazy" src="assets/architecture.svg" alt="architecture" style="width:100%;border:1px solid var(--line);border-radius:16px;margin:6px 0 24px"/>
   <h3 style="font-size:22px">Two highest-leverage techniques <span class="g">— and why they win</span></h3>
@@ -530,7 +530,7 @@
 
 <section id="proof"><div class="wrap">
   <div class="seyebrow gr">Receipts, not vibes</div>
-  <h2>The proof <span class="g">— a quality contract, not an estimate</span><a class="hlink" href="#proof" aria-label="Link to this section">#</a></h2>
+  <h2>The proof <span class="g">— a quality contract, not an estimate</span><a class="hlink" href="#proof" aria-label="Link to section: The proof — a quality contract, not an estimate">#</a></h2>
   <p class="lead">We didn't just benchmark ourselves. We ran the real LLMLingua-2 and Headroom
     packages through the same gate, graded <b>live by the real model</b>.</p>
   <img loading="lazy" src="assets/head-to-head.svg" alt="Live head-to-head: Distil vs LLMLingua-2 vs Headroom" style="width:100%;border:1px solid var(--line);border-radius:16px;margin:6px 0 10px"/>
@@ -562,7 +562,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
 
 <section id="domains"><div class="wrap">
   <div class="seyebrow">Coverage</div>
-  <h2>Measured across 7 domains <span class="g">— the same gate, not one example</span><a class="hlink" href="#domains" aria-label="Link to this section">#</a></h2>
+  <h2>Measured across 7 domains <span class="g">— the same gate, not one example</span><a class="hlink" href="#domains" aria-label="Link to section: Measured across 7 domains — the same gate, not one example">#</a></h2>
   <p class="lead">A strategy isn't trustworthy because it works once. <code>distil bench</code> certifies
     every domain — ops, coding, support, research, data, devops, finance — or it doesn't ship.</p>
   <img loading="lazy" src="assets/domains.svg" alt="measured across 7 domains" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
@@ -570,7 +570,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
 
 <section id="tiers"><div class="wrap">
   <div class="seyebrow p">Risk grading</div>
-  <h2>Risk-graded tiers<a class="hlink" href="#tiers" aria-label="Link to this section">#</a></h2>
+  <h2>Risk-graded tiers<a class="hlink" href="#tiers" aria-label="Link to section: Risk-graded tiers">#</a></h2>
   <p class="lead">Apply the provably-safe ones everywhere; gate the rest on evidence.</p>
   <div class="tiers">
     <div class="tier"><div class="k">Tier 0</div><h4>Provably lossless</h4>
@@ -584,7 +584,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
 
 <section id="bestof"><div class="wrap">
   <div class="seyebrow">The cost stack</div>
-  <h2>Capabilities <span class="g">— every layer of the cost stack</span><a class="hlink" href="#bestof" aria-label="Link to this section">#</a></h2>
+  <h2>Capabilities <span class="g">— every layer of the cost stack</span><a class="hlink" href="#bestof" aria-label="Link to section: Capabilities — every layer of the cost stack">#</a></h2>
   <table>
     <tr><th>Capability</th><th>What it does</th><th>Loss profile</th></tr>
     <tr><td>Priced cache-aware engine</td><td>Models the multi-turn loop and proves naive recompression busts the cache</td><td>—</td></tr>
@@ -606,7 +606,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
 
 <section id="integrations"><div class="wrap">
   <div class="seyebrow gr">Drop-in</div>
-  <h2>Works with every SDK <span class="g">— one proxy, no code change</span><a class="hlink" href="#integrations" aria-label="Link to this section">#</a></h2>
+  <h2>Works with every SDK <span class="g">— one proxy, no code change</span><a class="hlink" href="#integrations" aria-label="Link to section: Works with every SDK — one proxy, no code change">#</a></h2>
   <p class="lead">Point any <code>base_url</code>-honoring client at the proxy — Python, TypeScript, any language —
     and get cache-aware lossless compression. <a href="integrations.html" style="color:var(--acc2)">See integrations →</a></p>
   <img loading="lazy" src="assets/cross-sdk.svg" alt="one proxy, every SDK" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
@@ -614,7 +614,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
 
 <section id="install"><div class="wrap">
   <div class="seyebrow p">Get started</div>
-  <h2>Install <span class="g">— pick a format</span><a class="hlink" href="#install" aria-label="Link to this section">#</a></h2>
+  <h2>Install <span class="g">— pick a format</span><a class="hlink" href="#install" aria-label="Link to section: Install — pick a format">#</a></h2>
   <p class="lead">The stdlib-only core makes the packaging clean: zero runtime deps, corpus bundled.</p>
   <div class="tabs" id="install-tabs">
     <div class="tabbar" role="tablist">
@@ -655,7 +655,7 @@ client = wrap(anthropic.Anthropic())  <span class="d"># compresses + keeps the c
 
 <section id="honest"><div class="wrap">
   <div class="seyebrow">No overselling</div>
-  <h2>What we won't pretend<a class="hlink" href="#honest" aria-label="Link to this section">#</a></h2>
+  <h2>What we won't pretend<a class="hlink" href="#honest" aria-label="Link to section: What we won't pretend">#</a></h2>
   <div class="callout">
     A headline like "87% reduction, 100% accuracy" is <b>unverified marketing</b> until you
     see the eval. Published quality numbers in this space are typically measured at far lower

--- a/docs/index.html
+++ b/docs/index.html
@@ -262,6 +262,11 @@
   .close h2{font-size:clamp(28px,3.4vw,40px);margin:0 0 8px}
   .close p{color:var(--mut);max-width:560px;margin:0 auto 26px}
   .close .cta{justify-content:center}
+  /* ── Skip link ── */
+  .skip-link{position:absolute;top:0;left:8px;z-index:100;padding:10px 16px;border-radius:0 0 10px 10px;
+    background:var(--acc);color:#06070a;font-weight:700;font-size:13px;
+    transform:translateY(-140%);transition:transform .15s ease}
+  .skip-link:focus{transform:translateY(0)}
 </style>
 <meta property="og:type" content="website"/>
 <meta property="og:site_name" content="Distil"/>
@@ -278,6 +283,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 <nav><div class="wrap">
   <a href="index.html" class="logo" aria-label="Distil home"><img src="assets/logo.svg" alt="" width="26" height="26" style="border-radius:7px;vertical-align:-7px;margin-right:9px"/>Dist<b>il</b></a>
   <span class="pill">compression with a quality contract</span>
@@ -291,7 +297,7 @@
   </div>
 </div></nav>
 
-<header>
+<header id="content" tabindex="-1">
   <svg class="still" viewBox="0 0 440 620" fill="none" aria-hidden="true">
     <defs>
       <linearGradient id="stg" x1="0" y1="0" x2="1" y2="1">

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <!-- Top bar -->
 <header class="topbar">
@@ -64,7 +65,7 @@
   </aside>
 
   <!-- Main content -->
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Integrations — <span class="g">one proxy, every SDK</span></h1>
     <p class="lead">Start <code>distil proxy</code> once and point any SDK's <code>baseURL</code> at it. No library changes, no monkey-patching — compression happens at the network layer.</p>

--- a/docs/learn-compression.html
+++ b/docs/learn-compression.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <div class="course-meta">
       <span class="course-kicker"><a href="token-economics.html" style="color:inherit;text-decoration:none;">Token Economics</a> · Module 2 of 3</span>

--- a/docs/learn-distil.html
+++ b/docs/learn-distil.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <div class="course-meta">
       <span class="course-kicker"><a href="token-economics.html" style="color:inherit;text-decoration:none;">Token Economics</a> · Module 3 of 3</span>

--- a/docs/learn-tokens.html
+++ b/docs/learn-tokens.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <div class="course-meta">
       <span class="course-kicker"><a href="token-economics.html" style="color:inherit;text-decoration:none;">Token Economics</a> · Module 1 of 3</span>

--- a/docs/output.html
+++ b/docs/output.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Output <span class="g">&amp; I/O</span></h1>
     <p class="lead">Most compressors only touch the input side; Distil compresses <strong>both sides</strong> — input context in, generation verbosity out — plus a lossless re-entry digest that keeps long outputs from re-billing as full history. This page covers all three, plus real-trace ingestion and the performance benchmark.</p>

--- a/docs/research.html
+++ b/docs/research.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Research <span class="g">&amp; Frontier</span></h1>
     <p class="lead">The proof artifacts no competitor publishes: a savings-vs-quality curve where every point carries a certification verdict, a <strong>distribution-free risk certificate</strong> on the decision-change rate, a never-regressing self-distilling loop, and savings telemetry you can verify yourself.</p>

--- a/docs/site.css
+++ b/docs/site.css
@@ -72,6 +72,15 @@ a { color: inherit; text-decoration: none; }
 *::-webkit-scrollbar-thumb { background: var(--line2); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
 *::-webkit-scrollbar-thumb:hover { background: #34405e; }
 
+/* ── Skip link ─────────────────────────────────────────────────────── */
+.skip-link {
+  position: absolute; top: 0; left: 8px; z-index: 100;
+  padding: 10px 16px; border-radius: 0 0 10px 10px;
+  background: var(--acc); color: #06070b; font-weight: 700; font-size: 13px;
+  transform: translateY(-140%); transition: transform .15s ease;
+}
+.skip-link:focus { transform: translateY(0); }
+
 /* ── Top bar ───────────────────────────────────────────────────────── */
 .topbar {
   position: fixed; top: 0; left: 0; right: 0; z-index: 50;

--- a/docs/site.css
+++ b/docs/site.css
@@ -385,7 +385,7 @@ pre { /* room for the button */ }
   padding: 5px 9px; cursor: pointer; opacity: 0;
   transition: opacity .15s, color .15s, border-color .15s, background .15s;
 }
-pre:hover .copy-btn { opacity: 1; }
+pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
 .copy-btn:hover { color: var(--ink); border-color: #34405e; background: rgba(255,255,255,.07); }
 .copy-btn.copied { color: var(--good); border-color: rgba(90,209,154,.4); opacity: 1; }
 

--- a/docs/site.js
+++ b/docs/site.js
@@ -62,7 +62,7 @@
       ha.className = "hanchor";
       ha.href = "#" + h.id;
       ha.textContent = "#";
-      ha.setAttribute("aria-label", "Link to this section");
+      ha.setAttribute("aria-label", "Link to section: " + h.textContent.trim());
       h.appendChild(ha);
     }
     var a = document.createElement("a");
@@ -72,7 +72,7 @@
     nav.appendChild(a);
     entries.push({ a: a, h: h });
   });
-  document.body.appendChild(nav);
+  content.insertBefore(nav, content.firstChild);
 
   // ── Scrollspy: highlight the section currently in view ──────────────
   var byId = {};

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">← Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <h1>Compression <span class="g">Techniques</span></h1>
     <p class="lead">Each technique targets a specific slice of agent cost, but two carry the bulk of the win: <strong>cache-aware lossless compression</strong> keeps the prefix byte-stable so every cached token stays cached, and <strong>causal pruning</strong> drops what ablation proves never changed a decision. The rest stack cleanly on top — and one of them, recoverable compression, is something no lossy compressor can structurally replicate.</p>

--- a/docs/token-economics.html
+++ b/docs/token-economics.html
@@ -20,6 +20,7 @@
   <link rel="icon" type="image/svg+xml" href="assets/logo.svg">
 </head>
 <body>
+<a class="skip-link" href="#content">Skip to main content</a>
 
 <header class="topbar">
   <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
@@ -60,7 +61,7 @@
     <a href="index.html">&#8592; Landing page</a>
   </aside>
 
-  <main class="content">
+  <main class="content" id="content" tabindex="-1">
 
     <div class="course-meta">
       <span class="course-kicker">A short course</span>


### PR DESCRIPTION
Hey team. This is the next installment in the accessibility remediation series that started with #34: it follows on from the keyboard, ARIA, contrast, and text-alternative fixes and covers navigation and focus. Nothing here changes how the site looks, except that a couple of controls now show a visible focus outline where they didn't before (that's the point).

## Skip link on every page

Before: on every one of the 21 docs pages, a keyboard user had to tab through the top bar and the roughly 20-link sidebar (about 24 stops) before reaching the actual page content. There was no way to skip past it.

After: pressing Tab once now surfaces a "Skip to main content" link at the very top of every page. Activating it jumps straight to the content area. It's invisible until it receives keyboard focus, so sighted mouse users won't notice any change.

The landing page (index.html) doesn't have a `<main>` element yet, so its skip link points at the hero section instead, its first real content block today. A follow-up PR is adding a proper `<main>` there.

WCAG reference: 2.4.1 (Bypass Blocks).

## Copy button visible when tabbed to

Before: every code block on every docs page has a "Copy" button that only appeared on mouse hover. A keyboard user tabbing to it landed on an invisible button with no visible focus ring at all, there was simply no way to tell it was there.

After: the button now appears as soon as it receives keyboard focus, same as it does on hover.

WCAG reference: 2.4.7 (Focus Visible).

## "On this page" outline in the right place

Before: the little "On this page" navigation box floats visually at the top-right of every docs article, but in the underlying document it was tacked on after the site footer. That meant screen reader users and keyboard users only reached it after reading (or tabbing through) the entire page, the opposite of where it visually sits.

After: it's now inserted at the top of the article in the document itself. Nothing changes visually, it's still the same floating box in the same place, but reading order and tab order now match what you see.

WCAG reference: 1.3.2 (Meaningful Sequence), 2.4.3 (Focus Order).

## Heading links that don't repeat themselves

Before: every section heading has a small "#" link for deep-linking, and every single one of them had the exact same accessible label: "Link to this section." A screen reader user jumping through the page's heading list heard dozens of identically named links and no way to tell them apart.

After: each one now announces the section it actually links to, e.g. "Link to section: Install."

WCAG reference: 2.4.6 (Headings and Labels).

## Dissect portal 404 pages

Before: when the `distil dissect` session portal returned a "not found" response, it sent a bare HTML fragment: no title, no doctype, no declared language. Browsers and assistive tech had nothing to announce for the page.

After: both 404 responses are now complete, minimal HTML documents with a proper title and `lang="en"`. Same wording, same link back to the session list.

WCAG reference: 2.4.2 (Page Titled), 3.1.1 (Language of Page).

## Dissect report tooltips, now genuinely usable

This was the biggest chunk of the PR: the dissect report page has stat tiles, chart marks, and table headers that show a custom-styled tooltip on hover or focus. Four things were wrong with it:

- **No focus indicator at all.** The tiles were keyboard-focusable but the stylesheet explicitly suppressed the outline (`outline: none`), so a keyboard user tabbing through the page had no idea where they were. Now there's a clear purple focus ring.
- **The tooltip wasn't wired to its trigger.** A screen reader user could focus a tile and hear nothing about what its tooltip said. Each trigger now points at the tooltip via `aria-describedby`, so its content gets announced.
- **You couldn't dismiss or hover into the tooltip.** There was no Escape key to close it, and it vanished the instant your mouse left the trigger, so you could never read a long tooltip by hovering into it. Escape now closes it, and you can now move the mouse onto the tooltip itself to read it.
- **Some explanations only existed in a mouse tooltip attribute.** The three headline stat cards, and the "seen"/"restore" column headers, explained themselves only through a browser `title` attribute, invisible to keyboard and touch users. They now go through the same accessible tooltip mechanism as everything else on the page.

WCAG reference: 2.4.7 (Focus Visible), 4.1.2 (Name, Role, Value), 1.4.13 (Content on Hover or Focus), 1.1.1 (Non-text Content).

## Gates

- `uv run ruff check` on the one Python file touched (`distil/dissect.py`): 18 pre-existing errors before and after my changes, no new ones introduced. (Repo-wide `ruff check` still fails with the ~428 pre-existing errors noted in the audit; unrelated to this PR.)
- `uv run pytest -q`: 1842 passed, 5 skipped, 0 failed, both before committing and again on the final branch state.
- Grepped `tests/` for every string this PR touches (`data-tip`, `outline`, the 404 fragment text, `hanchor`): the one hit (`tests/test_dissect.py`'s `data-tip=` count assertion) is a `>=` lower bound that my additions only push higher, so it still passes; confirmed by running that test file directly.
- Browser-verified against a live server on the shared Playwright browser (with the lock properly acquired and released): skip link is the first Tab stop and moving focus into main/header on activation, keyboard focus reveals the copy button (`opacity: 1`), the TOC now precedes the footer in DOM order, heading anchor labels are unique, and on a synthetically rendered dissect report: focus-visible outline shows on a tooltip tile, `aria-describedby` resolves to the tooltip element, the tooltip's content is announced, Escape hides it, and the pointer can move onto the tooltip without it disappearing.

No deviations from the plan. Everything in scope landed; nothing was cut.
