### PR TITLE
fix(a11y): give users control over timed refreshes and auto-updating content

### DIFF
--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1666,29 +1666,58 @@ shadow.jsonl on this machine. Content-free — handles and kind:size signatures 
 
 
 # ------------------------------------------------------------------- portal
+def _session_row(o: SessionOverview) -> dict[str, Any]:
+    """One session as JSON-serializable data, shared by the initial HTML
+    render and the ``/sessions.json`` poll endpoint so both stay in sync."""
+    pct = (
+        100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens
+        if o.baseline_tokens
+        else 0.0
+    )
+    return {
+        "sid": o.sid,
+        "tool": o.tool or "?",
+        "started": _when(o.started),
+        "last": _when(o.last_ts),
+        "requests": o.requests,
+        "pct": round(pct, 1),
+        "status": o.status,
+    }
+
+
+def sessions_json(sessions: list[SessionOverview]) -> str:
+    """JSON payload backing the portal's in-place poll (``/sessions.json``)."""
+    return json.dumps([_session_row(o) for o in sessions])
+
+
 def render_sessions_html(sessions: list[SessionOverview]) -> str:
-    """The portal index: the session picker as a clickable page."""
+    """The portal index: the session picker as a clickable page.
+
+    Polls ``/sessions.json`` every 15 s and patches the table body in place
+    (keyed by session id) rather than reloading the whole page, so keyboard
+    focus and reading position survive an update. A visible Pause button
+    lets a user stop the polling entirely.
+    """
     e = _html.escape
     rows = (
         "".join(
-            f"<tr onclick=\"location='/session/{e(o.sid)}'\">"
-            f"<td><code>{e(o.sid)}</code></td><td>{e(o.tool or '?')}</td>"
-            f"<td>{e(_when(o.started))}</td><td>{e(_when(o.last_ts))}</td>"
-            f"<td class='r'>{o.requests}</td>"
-            f"<td class='r'>{100.0 * (o.baseline_tokens - o.distil_tokens) / o.baseline_tokens if o.baseline_tokens else 0.0:.1f}%</td>"
-            f"<td>{e(o.status)}</td></tr>"
-            for o in sessions
+            f"<tr data-sid=\"{e(r['sid'])}\" onclick=\"location='/session/{e(r['sid'])}'\">"
+            f"<td><code>{e(r['sid'])}</code></td><td>{e(r['tool'])}</td>"
+            f"<td>{e(r['started'])}</td><td>{e(r['last'])}</td>"
+            f"<td class='r'>{r['requests']}</td>"
+            f"<td class='r'>{r['pct']:.1f}%</td>"
+            f"<td>{e(r['status'])}</td></tr>"
+            for r in (_session_row(o) for o in sessions)
         )
         or "<tr><td class='muted' colspan='7'>no sessions recorded yet — run a wrap first</td></tr>"
     )
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<meta http-equiv="refresh" content="15"/>
 <title>Distil — sessions</title><style>
 body{{margin:0;background:#06070b;color:#f2f3f7;font:15px/1.6 Inter,ui-sans-serif,sans-serif}}
 .wrap{{max-width:820px;margin:0 auto;padding:48px 24px}}
 h1{{font-size:30px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px}}
-.sub{{color:#9aa1b3;margin:0 0 28px}}
+.sub{{color:#9aa1b3;margin:0 0 28px;display:flex;align-items:center;gap:12px;flex-wrap:wrap}}
 .g{{background:linear-gradient(135deg,#8b7bff,#5ad1c9);-webkit-background-clip:text;background-clip:text;color:transparent}}
 table{{width:100%;border-collapse:collapse;border:1px solid #1b2030;border-radius:12px;overflow:hidden}}
 th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
@@ -1697,14 +1726,88 @@ td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}}
 tbody tr{{cursor:pointer}} tbody tr:hover td{{background:#10131d}}
 code{{color:#8b7bff}} .muted{{color:#5b6177}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+.pause-btn{{background:#10131d;border:1px solid #1b2030;color:#e0e2ea;font-size:12.5px;
+  padding:5px 12px;border-radius:6px;cursor:pointer}}
+.pause-btn:hover{{background:#171a28}}
+.pause-btn:focus-visible{{outline:2px solid #8b7bff;outline-offset:2px}}
 </style></head><body><div class="wrap">
 <h1>Distil <span class="g">sessions</span></h1>
-<p class="sub">Pick a session to dissect — newest activity first. This page refreshes itself.</p>
+<p class="sub"><span>Pick a session to dissect — newest activity first. Updates automatically.</span>
+<button type="button" id="pause-btn" class="pause-btn" aria-pressed="false">Pause</button></p>
 <table><thead><tr><th>session</th><th>tool</th><th>started</th><th>last</th><th>reqs</th>
-<th>saved</th><th>status</th></tr></thead><tbody>{rows}</tbody></table>
-<p class="foot">Local-first: served from this machine's ~/.distil only. Reports are per-session;
-JSON at /json/&lt;session&gt;.</p>
-</div></body></html>"""
+<th>saved</th><th>status</th></tr></thead><tbody id="sessions-body">{rows}</tbody></table>
+<p class="foot" id="foot-note">Local-first: served from this machine's ~/.distil only. Reports are
+per-session; JSON at /json/&lt;session&gt;. Updates every 15 s.</p>
+</div>
+<script>
+(function () {{
+  var POLL_MS = 15000;
+  var tbody = document.getElementById("sessions-body");
+  var pauseBtn = document.getElementById("pause-btn");
+  var note = document.getElementById("foot-note");
+  var timer = null, paused = false;
+  var FOOT = "Local-first: served from this machine's ~/.distil only. Reports are per-session; " +
+    "JSON at /json/<session>.";
+
+  function render(list) {{
+    var seen = {{}};
+    list.forEach(function (r) {{
+      seen[r.sid] = true;
+      var tr = tbody.querySelector('tr[data-sid="' + r.sid + '"]');
+      if (!tr) {{
+        tr = document.createElement("tr");
+        tr.dataset.sid = r.sid;
+        tr.addEventListener("click", function () {{ location = "/session/" + r.sid; }});
+        tr.innerHTML = "<td><code></code></td><td></td><td></td><td></td>" +
+          "<td class='r'></td><td class='r'></td><td></td>";
+        tbody.appendChild(tr);
+      }}
+      var c = tr.children;
+      c[0].firstChild.textContent = r.sid;
+      c[1].textContent = r.tool;
+      c[2].textContent = r.started;
+      c[3].textContent = r.last;
+      c[4].textContent = r.requests;
+      c[5].textContent = r.pct.toFixed(1) + "%";
+      c[6].textContent = r.status;
+    }});
+    Array.prototype.slice.call(tbody.querySelectorAll("tr[data-sid]")).forEach(function (tr) {{
+      if (!seen[tr.dataset.sid]) tr.remove();
+    }});
+    var placeholder = tbody.querySelector("tr:not([data-sid])");
+    if (list.length && placeholder) placeholder.remove();
+    if (!list.length && !tbody.querySelector("tr[data-sid]") && !placeholder) {{
+      tbody.innerHTML = "<tr><td class='muted' colspan='7'>no sessions recorded yet — " +
+        "run a wrap first</td></tr>";
+    }}
+  }}
+
+  function poll() {{
+    fetch("/sessions.json", {{cache: "no-store"}})
+      .then(function (r) {{ return r.json(); }})
+      .then(render)
+      .catch(function () {{}});
+  }}
+
+  function schedule() {{ timer = setInterval(poll, POLL_MS); }}
+
+  pauseBtn.addEventListener("click", function () {{
+    paused = !paused;
+    pauseBtn.textContent = paused ? "Resume" : "Pause";
+    pauseBtn.setAttribute("aria-pressed", paused ? "true" : "false");
+    note.textContent = FOOT + (paused ? " Updates paused." : " Updates every 15 s.");
+    if (paused) {{
+      clearInterval(timer);
+    }} else {{
+      poll();
+      schedule();
+    }}
+  }});
+
+  schedule();
+}})();
+</script>
+</body></html>"""
 
 
 def make_server(host: str = "127.0.0.1", port: int = 8790, transcript: str | None = None) -> Any:
@@ -1738,6 +1841,9 @@ def make_server(host: str = "127.0.0.1", port: int = 8790, transcript: str | Non
             path = self.path.split("?", 1)[0]
             if path in ("/", "/index.html"):
                 self._send(200, render_sessions_html(list_sessions()))
+                return
+            if path == "/sessions.json":
+                self._send(200, sessions_json(list_sessions()), ctype="application/json")
                 return
             query = self.path.partition("?")[2]
             for prefix, as_json in (("/session/", False), ("/json/", True)):

--- a/distil/gateway.py
+++ b/distil/gateway.py
@@ -395,7 +395,6 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="5">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>distil gateway — live dashboard</title>
 <style>
@@ -505,7 +504,22 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     font-size: 0.72rem;
     text-align: right;
     margin-top: 0.75rem;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.6rem;
   }}
+  .pause-btn {{
+    background: #0f1117;
+    border: 1px solid #1e2130;
+    color: #c7c9d1;
+    font-size: 0.72rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }}
+  .pause-btn:hover {{ background: #171a24; }}
+  .pause-btn:focus-visible {{ outline: 2px solid #8b7bff; outline-offset: 2px; }}
 </style>
 </head>
 <body>
@@ -515,19 +529,19 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
 <div class="headline-cards">
   <div class="card">
     <div class="card-label">Total Requests</div>
-    <div class="card-value">{totals["requests"]}</div>
+    <div class="card-value" id="c-requests">{totals["requests"]}</div>
   </div>
   <div class="card">
     <div class="card-label">Tokens Saved</div>
-    <div class="card-value teal">{totals["tokens_saved"]:,}</div>
+    <div class="card-value teal" id="c-tokens">{totals["tokens_saved"]:,}</div>
   </div>
   <div class="card">
     <div class="card-label">Dollars Saved</div>
-    <div class="card-value">${totals["dollars_saved"]:.4f}</div>
+    <div class="card-value" id="c-dollars">${totals["dollars_saved"]:.4f}</div>
   </div>
   <div class="card">
     <div class="card-label">Compression Rate</div>
-    <div class="card-value teal">{totals["pct_saved"]:.1f}%</div>
+    <div class="card-value teal" id="c-pct">{totals["pct_saved"]:.1f}%</div>
   </div>
 </div>
 
@@ -542,13 +556,87 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
       <th>% Saved</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody id="tenant-rows">
     {rows}
     {totals_row}
   </tbody>
 </table>
 </div>
-<p class="refresh-note">Auto-refresh every 5 s &bull; distil gateway</p>
+<p class="refresh-note">
+  <span id="refresh-note">Updates every 5 s &bull; distil gateway</span>
+  <button type="button" class="pause-btn" id="pause-btn" aria-pressed="false">Pause</button>
+</p>
+<script>
+(function() {{
+  var POLL_MS = 5000;
+  var tbody = document.getElementById("tenant-rows");
+  var pauseBtn = document.getElementById("pause-btn");
+  var note = document.getElementById("refresh-note");
+  var timer = null, paused = false;
+
+  function esc(s) {{
+    return String(s).replace(/[&<>"']/g, function(c) {{
+      return ({{"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"}})[c];
+    }});
+  }}
+
+  function rowsHtml(tenants, totals) {{
+    var out = "";
+    if (!tenants.length) {{
+      out += '<tr><td colspan="5" class="empty">No requests recorded yet.</td></tr>';
+    }} else {{
+      tenants.forEach(function(t) {{
+        out += "<tr>" +
+          "<td>" + esc(t.tenant) + "</td>" +
+          "<td>" + t.requests + "</td>" +
+          "<td>" + t.tokens_saved.toLocaleString("en-US") + "</td>" +
+          "<td>$" + t.dollars_saved.toFixed(4) + "</td>" +
+          "<td>" + t.pct_saved.toFixed(1) + "%</td>" +
+          "</tr>";
+      }});
+    }}
+    out += "<tr class='total-row'>" +
+      "<td><strong>TOTAL</strong></td>" +
+      "<td><strong>" + totals.requests + "</strong></td>" +
+      "<td><strong>" + totals.tokens_saved.toLocaleString("en-US") + "</strong></td>" +
+      "<td><strong>$" + totals.dollars_saved.toFixed(4) + "</strong></td>" +
+      "<td><strong>" + totals.pct_saved.toFixed(1) + "%</strong></td>" +
+      "</tr>";
+    return out;
+  }}
+
+  function renderCards(totals) {{
+    document.getElementById("c-requests").textContent = totals.requests;
+    document.getElementById("c-tokens").textContent = totals.tokens_saved.toLocaleString("en-US");
+    document.getElementById("c-dollars").textContent = "$" + totals.dollars_saved.toFixed(4);
+    document.getElementById("c-pct").textContent = totals.pct_saved.toFixed(1) + "%";
+  }}
+
+  function poll() {{
+    fetch("/distil/stats", {{cache: "no-store"}}).then(function(r) {{ return r.json(); }}).then(function(d) {{
+      renderCards(d.totals);
+      tbody.innerHTML = rowsHtml(d.tenants, d.totals);
+    }}).catch(function() {{}});
+  }}
+
+  function schedule() {{ timer = setInterval(poll, POLL_MS); }}
+
+  pauseBtn.addEventListener("click", function() {{
+    paused = !paused;
+    pauseBtn.textContent = paused ? "Resume" : "Pause";
+    pauseBtn.setAttribute("aria-pressed", paused ? "true" : "false");
+    note.textContent = paused ? "Updates paused • distil gateway" : "Updates every 5 s • distil gateway";
+    if (paused) {{
+      clearInterval(timer);
+    }} else {{
+      poll();
+      schedule();
+    }}
+  }});
+
+  schedule();
+}})();
+</script>
 </body>
 </html>"""
 

--- a/distil/webdash.py
+++ b/distil/webdash.py
@@ -107,10 +107,18 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
   .flash{animation:fl 1s ease-out}
   @keyframes fl{0%{box-shadow:0 0 0 1px var(--good),0 0 30px -6px var(--good)}100%{box-shadow:none}}
   @media (prefers-reduced-motion:reduce){.dot{animation:none}.odo .d{transition:none}}
+  body.paused .dot{animation-play-state:paused}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+    clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  .pause-btn{background:transparent;border:1px solid var(--line);color:var(--mut);
+    font:inherit;font-size:11px;padding:4px 10px;border-radius:6px;cursor:pointer}
+  .pause-btn:hover{background:rgba(255,255,255,.05)}
+  .pause-btn:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
 </style></head><body>
 <div class="card" id="card"><div class="top"></div><div class="in">
   <div class="lab"><span class="dot"></span> your tokens saved · live · this machine</div>
-  <div class="odo" id="odo"><span class="d">0</span></div>
+  <div class="odo" id="odo" aria-hidden="true"><span class="d">0</span></div>
+  <p id="live-status" class="sr-only" role="status"></p>
   <div class="sub" id="sub">reading your local ledger…</div>
   <div class="row">
     <div class="m"><div class="mv g" id="pct">–</div><div class="ml">smaller · overall</div></div>
@@ -118,12 +126,16 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
     <div class="m"><div class="mv a" id="eq">–</div><div class="ml">decision-equivalence</div></div>
     <div class="m"><div class="mv" id="runs">–</div><div class="ml">requests</div></div>
   </div>
-  <div class="foot"><span>◉ local only · nothing leaves this machine</span><span id="stamp"></span></div>
+  <div class="foot"><span>◉ local only · nothing leaves this machine</span>
+    <button type="button" id="pause-btn" class="pause-btn" aria-pressed="false">Pause</button>
+    <span id="stamp"></span></div>
 </div></div>
 <script>
 (function(){
   var reduced=matchMedia("(prefers-reduced-motion:reduce)").matches;
   var odo=document.getElementById("odo"),cells=[];
+  var liveEl=document.getElementById("live-status"),lastAnnounce=0;
+  var pauseBtn=document.getElementById("pause-btn"),paused=false,pollTimer=null,rafId=null;
   function commas(n){return Math.floor(n).toLocaleString("en-US");}
   function human(n){var u=[[1e12,"T"],[1e9,"B"],[1e6,"M"],[1e3,"k"]];for(var i=0;i<u.length;i++)if(n>=u[i][0])return (n/u[i][0]).toFixed(1)+u[i][1];return String(Math.round(n));}
   function render(str){
@@ -132,12 +144,13 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
   }
   var shown=null,target=0,from=0,t0=null;
   function loop(){
+    if(paused){rafId=null;return;}
     if(target!==shown){
       if(reduced||shown===null){shown=target;}
       else{if(t0===null){t0=Date.now();from=shown;}var k=Math.min(1,(Date.now()-t0)/900);k=1-Math.pow(1-k,3);shown=Math.round(from+(target-shown===0?0:(target-from))*k);if(k>=1){shown=target;t0=null;}}
       render(commas(shown));
     }
-    requestAnimationFrame(loop);
+    rafId=requestAnimationFrame(loop);
   }
   function set(id,v){var e=document.getElementById(id);if(e)e.textContent=v;}
   var last=null;
@@ -152,9 +165,27 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
       set("runs",commas(d.runs));
       document.getElementById("sub").innerHTML="The <b>exact</b> total from your ledger — "+human(d.baseline_tokens)+" → "+human(d.distil_tokens)+" tokens. It ticks up the instant a request books real savings. Equivalence over <b>"+commas(d.equivalence.shadowed)+"</b> shadowed requests.";
       set("stamp","updated "+new Date(d.ts*1000).toLocaleTimeString());
+      var now=Date.now();
+      if(now-lastAnnounce>=30000){
+        liveEl.textContent=human(d.tokens_saved)+" tokens saved, "+d.pct+"% smaller, "+commas(d.runs)+" requests.";
+        lastAnnounce=now;
+      }
     }).catch(function(){});
   }
-  requestAnimationFrame(loop);poll();setInterval(poll,1000);
+  function schedulePoll(){pollTimer=setInterval(poll,1000);}
+  pauseBtn.addEventListener("click",function(){
+    paused=!paused;
+    document.body.classList.toggle("paused",paused);
+    pauseBtn.textContent=paused?"Resume":"Pause";
+    pauseBtn.setAttribute("aria-pressed",paused?"true":"false");
+    if(paused){
+      clearInterval(pollTimer);
+    }else{
+      poll();schedulePoll();
+      if(rafId===null){rafId=requestAnimationFrame(loop);}
+    }
+  });
+  rafId=requestAnimationFrame(loop);poll();schedulePoll();
 })();
 </script></body></html>"""
 

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -23,7 +23,7 @@
     background:var(--acc2);box-shadow:0 0 12px 1px rgba(90,209,201,.7);flex:0 0 auto}
   .seyebrow.p::before{background:var(--acc);box-shadow:0 0 12px 1px rgba(139,123,255,.7)}
   .seyebrow.gr::before{background:var(--good);box-shadow:0 0 12px 1px rgba(90,209,154,.7)}
-  .seyebrow.live::before{animation:apulse 1.6s ease-in-out infinite}
+  .seyebrow.live::before{animation:apulse 1.6s ease-in-out 3}
   @keyframes apulse{50%{opacity:.35}}
 
   .astats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:22px 0 8px}
@@ -83,12 +83,12 @@
     linear-gradient(180deg,var(--panel2),var(--panel));padding:16px;overflow-x:auto;margin:16px 0 8px}
   .pipe svg{display:block;min-width:840px;width:100%;height:auto}
   .pipe .ln{stroke:#3d3d5c;stroke-width:1.6;fill:none;marker-end:url(#arr)}
-  .pipe .flow{stroke-dasharray:5 6;animation:aflow 1.6s linear infinite}
+  .pipe .flow{stroke-dasharray:5 6;animation:aflow 1.6s linear 3}
   @keyframes aflow{to{stroke-dashoffset:-22}}
   .pipe .bx{fill:#14141f;stroke:#23233a}
   .pipe .bx.hl{stroke:#2a2550}
   .pipe .bx.gr{stroke:#1f3a2c}
-  .pipe .breathe{animation:abreathe 2.6s ease-in-out infinite}
+  .pipe .breathe{animation:abreathe 2.6s ease-in-out 2}
   @keyframes abreathe{0%,100%{opacity:.65}50%{opacity:1}}
   .pipe .tt{fill:var(--ink);font:600 13px var(--mono)}
   .pipe .ss{fill:var(--mut);font:11px var(--mono)}
@@ -112,7 +112,7 @@
   .hero-in{position:relative;padding:26px 28px 22px;display:block}
   .hero-in>div{min-width:0}
   .hero-lab{font-family:var(--mono);font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--mut);display:flex;align-items:center;gap:9px}
-  .hero-lab .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 12px 2px rgba(90,209,154,.75);animation:apulse 1.4s ease-in-out infinite}
+  .hero-lab .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 12px 2px rgba(90,209,154,.75);animation:apulse 1.4s ease-in-out 4}
   /* odometer */
   .odo{display:flex;align-items:baseline;gap:1px;margin:10px 0 8px;font-family:var(--mono);font-weight:800;
     font-size:clamp(30px,5.1vw,60px);letter-spacing:-.02em;line-height:1;flex-wrap:wrap;
@@ -122,7 +122,7 @@
   .odo .d.tick{color:#7dffc4}
   .odo .unit{font-size:.34em;font-weight:700;color:var(--mut);letter-spacing:.04em;margin-left:.35em;text-shadow:none}
   .rate{font-family:var(--mono);font-size:13.5px;color:var(--good);display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-  .rate .up{display:inline-block;animation:arise 1.6s ease-in-out infinite}
+  .rate .up{display:inline-block;animation:arise 1.6s ease-in-out 3}
   @keyframes arise{0%,100%{transform:translateY(0);opacity:.7}50%{transform:translateY(-2px);opacity:1}}
   .rate .muted{color:var(--dim)}
   .hero-sub{color:var(--mut);font-size:13px;margin-top:12px;line-height:1.5}
@@ -153,6 +153,10 @@
   @media (prefers-reduced-motion:reduce){
     .hero-lab .dot,.rate .up{animation:none}
   }
+  .live-controls{display:flex;align-items:center;gap:10px;margin:8px 0 2px}
+  .pause-btn{background:transparent;border:1px solid var(--line);color:var(--mut);
+    font-family:var(--mono);font-size:11.5px;padding:4px 11px;border-radius:999px;cursor:pointer}
+  .pause-btn:hover{background:rgba(255,255,255,.05);color:var(--ink)}
 </style>
 </head>
 <body>
@@ -207,7 +211,10 @@
     <div class="hero">
       <div class="hero-in">
         <div>
-          <div class="hero-lab"><span class="dot"></span> Community tokens saved &middot; exact</div>
+          <div class="hero-lab"><span class="dot"></span> Community tokens saved &middot; <span id="hero-state">exact</span></div>
+          <div class="live-controls">
+            <button type="button" id="pause-btn" class="pause-btn" aria-pressed="false">Pause live updates</button>
+          </div>
           <div class="odo" id="odo" aria-live="off"><span class="d">0</span></div>
           <div class="rate">
             <b id="rate-sec">&mdash;</b>&nbsp;<span class="muted" id="rate-day"></span>
@@ -455,10 +462,14 @@
   //  new heartbeat or census), and correct downward only on a real re-baseline;
   //  between measurements they sit static, exact. `rate` is NEVER shown projected.
   var shownTokens = null, targetTokens = 0, liveBase = null; // liveBase:{total,rate}
+  // Pause/Resume (WCAG 2.2.2): a visible control suspends both polling
+  // intervals below and this rAF easing loop; nothing updates while paused.
+  var paused = false, pollTimer = null, liveTimer = null, rafId = null;
   function desiredTokens() {
     return liveBase ? liveBase.total : targetTokens;
   }
   function odoLoop() {
+    if (paused) { rafId = null; return; }
     var t = desiredTokens();
     if (shownTokens === null || reduced) { shownTokens = t; }
     else {
@@ -466,7 +477,7 @@
       if (Math.abs(t - shownTokens) < 1) shownTokens = t;
     }
     renderOdo(commas(shownTokens));
-    requestAnimationFrame(odoLoop);
+    rafId = requestAnimationFrame(odoLoop);
   }
 
   // Near-real-time community pulse (opt-in heartbeats → edge store). Polls fast;
@@ -494,8 +505,7 @@
         set("rate-day", act > 0
           ? "saving now · exact total, moves only when it truly rises"
           : "no machines active right now · exact total");
-        document.querySelector(".hero-lab").innerHTML =
-          '<span class="dot"></span> Community tokens saved &middot; ' + (act > 0 ? "live" : "exact");
+        set("hero-state", act > 0 ? "live" : "exact");
       } else {
         liveBase = null; // empty/unavailable store → census exact total
       }
@@ -584,12 +594,32 @@
       : '<div class="empty-note">billing &amp; agent mix appears as clients opt in</div>';
   }
 
-  requestAnimationFrame(odoLoop);
   function refresh() { fetchAggregates().then(paint).catch(function () { set("updated", "live data unavailable"); }); }
+  function schedule() {
+    pollTimer = setInterval(refresh, 45000); // census aggregates (versions, models, trust, downloads)
+    liveTimer = setInterval(pollLive, 3000); // near-real-time community pulse (heartbeat aggregate)
+  }
+  var pauseBtn = document.getElementById("pause-btn");
+  if (pauseBtn) {
+    pauseBtn.addEventListener("click", function () {
+      paused = !paused;
+      pauseBtn.textContent = paused ? "Resume live updates" : "Pause live updates";
+      pauseBtn.setAttribute("aria-pressed", paused ? "true" : "false");
+      if (paused) {
+        clearInterval(pollTimer);
+        clearInterval(liveTimer);
+      } else {
+        refresh();
+        pollLive();
+        schedule();
+        if (rafId === null) rafId = requestAnimationFrame(odoLoop);
+      }
+    });
+  }
+  rafId = requestAnimationFrame(odoLoop);
   refresh();
-  setInterval(refresh, 45000);   // census aggregates (versions, models, trust, downloads)
   pollLive();
-  setInterval(pollLive, 3000);   // near-real-time community pulse (heartbeat aggregate)
+  schedule();
 })();
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,7 @@
   .btn:hover{transform:translateY(-2px)}
   .btn.primary:hover{box-shadow:0 12px 36px -12px rgba(139,123,255,.6)}
   pre{box-shadow:var(--shadow)}
-  @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
+  @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}html{scroll-behavior:auto}}
   /* style the shared site.js .copy-btn here (this page uses inline CSS, not site.css) */
   pre{position:relative}
   .copy-btn{position:absolute;top:10px;right:10px;display:inline-flex;align-items:center;gap:5px;
@@ -205,7 +205,7 @@
     0 0 0 1px rgba(90,209,201,.14), 0 0 60px -20px rgba(90,209,154,.28)}
   .heroterm .bar{background:linear-gradient(180deg,rgba(90,209,201,.05),transparent)}
   .hc{display:inline-block;width:8px;height:15px;vertical-align:-2px;margin-left:2px;
-    background:var(--good);border-radius:1px;animation:blink 1.05s steps(1) infinite}
+    background:var(--good);border-radius:1px;animation:blink 1.05s steps(1) 5}
   @keyframes blink{50%{opacity:0}}
 
   /* ── section eyebrow rhythm on every section (compass/firstpass DNA) ── */
@@ -248,10 +248,10 @@
   .still{position:absolute;top:-120px;right:-150px;width:640px;height:860px;z-index:0;pointer-events:none;
     opacity:.9;-webkit-mask-image:radial-gradient(120% 90% at 74% 34%,#000 55%,transparent 100%);
             mask-image:radial-gradient(120% 90% at 74% 34%,#000 55%,transparent 100%)}
-  .still .stream{animation:fall 7s linear infinite}
-  .still .drop{transform-box:fill-box;transform-origin:center;animation:breathe 6.5s ease-in-out infinite}
-  .still .halo{transform-box:fill-box;transform-origin:center;animation:breathe 6.5s ease-in-out infinite}
-  .still .pulse{transform-box:fill-box;transform-origin:center;animation:certify 5.5s cubic-bezier(.25,.6,.3,1) infinite}
+  .still .stream{animation:fall 7s linear 1}
+  .still .drop{transform-box:fill-box;transform-origin:center;animation:breathe 6.5s ease-in-out 1}
+  .still .halo{transform-box:fill-box;transform-origin:center;animation:breathe 6.5s ease-in-out 1}
+  .still .pulse{transform-box:fill-box;transform-origin:center;animation:certify 5.5s cubic-bezier(.25,.6,.3,1) 1}
   .still .pulse.p2{animation-delay:2.75s}
   @keyframes fall{to{stroke-dashoffset:-260}}
   @keyframes breathe{0%,100%{opacity:.55}50%{opacity:1}}

--- a/docs/site.css
+++ b/docs/site.css
@@ -328,11 +328,11 @@ td code { font-size: 11.5px; }
 .archfig-hint b { color: var(--acc, #5ad1c9); font-weight: 600; }
 /* flow animation — lives in the page CSS (not the SVG file), so GitHub's
    SVG sanitizer never sees it; the standalone .svg stays static + safe. */
-.archfig .flow { stroke-dasharray: 5 9; animation: archdash 1.1s linear infinite; }
+.archfig .flow { stroke-dasharray: 5 9; animation: archdash 1.1s linear 5; }
 @keyframes archdash { to { stroke-dashoffset: -28; } }
-.archfig .rflow { stroke-dasharray: 0.1 9; stroke-linecap: round; animation: archrdash 2.2s linear infinite; }
+.archfig .rflow { stroke-dasharray: 0.1 9; stroke-linecap: round; animation: archrdash 2.2s linear 2; }
 @keyframes archrdash { to { stroke-dashoffset: -18; } }
-.archfig .pulse { animation: archpulse 2.4s ease-in-out infinite; }
+.archfig .pulse { animation: archpulse 2.4s ease-in-out 2; }
 @keyframes archpulse { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) {
   .archfig .flow, .archfig .rflow, .archfig .pulse { animation: none; }
@@ -372,6 +372,10 @@ hr { border: none; border-top: 1px solid var(--line); margin: 40px 0; }
 }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; scroll-behavior: auto; }
+  /* the universal selector above has lower specificity than `html { scroll-behavior:
+     smooth }` (site.css:46) and loses to it, so smooth scrolling stayed on for
+     reduced-motion users; this type-selector rule restores the override. */
+  html { scroll-behavior: auto; }
 }
 
 /* ── Copy-to-clipboard button on code blocks ───────────────────────── */

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -308,7 +308,9 @@ def test_dashboard_html_contains_dark_bg() -> None:
     assert "#06070a" in html, "dark bg colour missing from dashboard"
     assert "widget-co" in html, "tenant not rendered in dashboard"
     assert "$" in html, "dollar sign missing from dashboard"
-    assert 'content="5"' in html, "auto-refresh meta tag missing"
+    assert 'http-equiv="refresh"' not in html, "meta refresh should be gone (WCAG 2.2.1)"
+    assert 'fetch("/distil/stats"' in html, "in-place JSON polling missing"
+    assert 'id="pause-btn"' in html, "pause/resume control missing"
 
 
 def test_gateway_passthrough_non_compressible(gw_servers: Any) -> None:


### PR DESCRIPTION
This is the next installment in the accessibility series that started with #34. Where that one was about keyboard reachability and broken controls, this one is about time: several pages either reload themselves on a clock or update their content continuously, and until now there was no way to pause, stop, or extend any of it. That's a real problem for keyboard and screen reader users (their reading position gets yanked out from under them), and it's also just not great for anyone reading closely on a slow connection or a distracting monitor.

Nothing here changes what data is shown or how often it refreshes by default. It only adds a way to stop the clock when you want to.

## Gateway dashboard (`distil/gateway.py`)

**Before:** the dashboard reloaded the entire page every 5 seconds via a `<meta http-equiv="refresh">` tag. Full reloads reset scroll position, keyboard focus, and a screen reader's place in the table every single cycle, with no way to turn it off.

**Now:** the page polls the existing `/distil/stats` JSON endpoint and patches the headline cards and tenant table in place, no reload. A visible Pause/Resume button next to the refresh note lets you freeze it entirely. Same data, same 5-second default cadence, just no more forced reloads.

(WCAG 2.2.1 Timing Adjustable)

## Sessions portal (`distil/dissect.py`)

**Before:** same story, 15-second full-page reloads via meta refresh. On a portal whose whole job is letting you scan and click into a session, getting reloaded before you finish reading was a real problem.

**Now:** added a small `/sessions.json` endpoint and the page polls it every 15 seconds, updating existing table rows by session id instead of tearing down and rebuilding the table. I verified in a real browser that the same row element survives an automatic poll cycle, which is what keeps keyboard focus and reading position intact once a future PR makes rows keyboard-focusable. A Pause/Resume button is there too.

(WCAG 2.2.1 Timing Adjustable)

## Live savings dashboard (`distil/webdash.py`)

**Before:** this page polls every second and runs a permanent animation loop for the odometer, with no pause control anywhere, and no screen reader ever finds out the numbers changed, since nothing announced updates.

**Now:** a Pause/Resume button stops the poll, cancels the animation loop, and pauses the pulsing status dot. Separately, added a quiet status region that composes a plain sentence ("12,345 tokens saved, 40% smaller, 12 requests") and updates at most once every 30 seconds, so screen reader users get an occasional honest summary instead of either silence or a second-by-second flood. The fast-ticking odometer digits themselves are marked so they're not read aloud digit by digit.

(WCAG 2.2.2 Pause, Stop, Hide; WCAG 4.1.3 Status Messages)

## Adoption page (`docs/adoption.html`)

**Before:** polls a live endpoint every 3 seconds and the metrics branch every 45 seconds, with a permanent animation loop for its own odometer, no pause control.

**Now:** a "Pause live updates" button next to the odometer stops both polling intervals and the animation loop; clicking it again resumes everything immediately. Also had to fix a small bug this surfaced: the "live/exact" label was being rewritten with `innerHTML` in a way that would have wiped out the new button, so that update now targets a small child span instead.

(WCAG 2.2.2 Pause, Stop, Hide)

## Decorative motion (index.html, site.css, adoption.html)

Several purely decorative animations, the landing page's hero illustration, the blinking terminal cursor, the architecture diagram's flowing lines, and a few pulsing dots on the adoption page, played on an infinite loop with no way to stop them. All of these already respect `prefers-reduced-motion`, but that's an OS-level setting, not a page control, so anyone who finds the motion distracting without having set that preference had no recourse.

Rather than add another toggle, I capped each animation's iteration count so it plays for a few seconds and then settles, instead of running forever. Visually nothing changes except that the motion stops repeating after it's made its point.

(WCAG 2.2.2 Pause, Stop, Hide, a mitigated finding, not a hard failure, since reduced-motion already covers the strict case)

## Reduced-motion smooth scroll (site.css, index.html)

Small but worth calling out: the rule meant to turn off smooth scrolling for `prefers-reduced-motion` users was written as a universal selector (`*, *::before, *::after`), which loses a CSS specificity fight against the plain `html { scroll-behavior: smooth }` rule it was supposed to override. So smooth scrolling silently stayed on for exactly the users who'd asked for it to be off. Added a same-specificity `html` rule inside the existing reduced-motion media query so the override actually wins.

(WCAG 2.3.3 Animation from Interactions)

## Gates

- `uv run ruff check` on every Python file touched (`distil/gateway.py`, `distil/dissect.py`, `distil/webdash.py`): compared error counts against the unmodified file in place (not a copy elsewhere, since ruff's config resolution depends on being inside the repo). Zero new errors in any of the three files.
- `uv run pytest -q`: full suite passes, 1844 passed, 3 skipped (skips are pre-existing and unrelated), twice, once before the docs/CSS commits and once after the full branch was assembled.
- Grepped `tests/` for `meta http-equiv`, `refresh-note`, `poll`, `render_sessions_html`, and related strings. Only one test asserted the old meta-refresh markup (`test_dashboard_html_contains_dark_bg` in `tests/test_gateway.py`); updated it to assert the meta refresh is gone and the new polling/pause markup is present, without weakening the check.
- Browser verification (Playwright, shared instance, coordinated with the other parallel agents via a lock file):
  - Gateway dashboard: rendered with synthetic tenant data, served locally. Confirmed no `meta[http-equiv=refresh]`, zero console errors, and the Pause button toggles `aria-pressed` and the visible label, and the note text, correctly in both directions.
  - Sessions portal: rendered with two synthetic sessions, served locally with a working `/sessions.json`. Confirmed no meta refresh, zero console errors, rows keyed by `data-sid`, and, ran the server for a real 15-second poll cycle and confirmed the same table row DOM node was reused afterward (not rebuilt), which is what will keep focus and reading position stable once row links land in a later PR.
  - Webdash: served the real `build_server()` handler. Confirmed the odometer is `aria-hidden`, the `role="status"` region exists and holds a composed sentence, the Pause button toggles a `body.paused` class, and, by spying on `window.fetch`, confirmed zero poll requests fire while paused and polling resumes immediately on Resume.
  - Adoption page: served the real file. Confirmed the pause button toggles state correctly and, via the same fetch-spy technique, confirmed zero requests during a 3.2-second paused window versus multiple after resuming. One unrelated console error appeared ("Unexpected token '<'") from the page's `fetchAggregates()` hitting the real GitHub API from inside the test sandbox; it's inside code this PR never touches (the JSON-parsing fallback chain), and the "live" pulse label had in fact already updated successfully once before that, so it looks like an intermittent GitHub API response shape, not a regression.
  - Reduced-motion scroll override and the capped decorative animations: confirmed statically (grep/computed-style check) that the `html { scroll-behavior: auto }` rule exists in both files and that `.hero-lab .dot`'s computed `animation-iteration-count` is now `4`, not `infinite`.

## Deviations / out of scope

- C4 (session rows are `onclick`-only `<tr>`s with no keyboard path) is a separate finding in the audit and out of scope here; the sessions-portal rework was written so that once rows become real links, focus will naturally survive the row-diffing update, but that change itself belongs to whichever PR owns C4.
- Contrast fixes (the refresh-note color, `--dim`, etc.) are explicitly a sibling PR's responsibility; I only changed the refresh-note's text, never its color.
- M11 (adoption's `#updated` status text) and S13/S14/S15 (dissect tooltip accessibility) are separate findings and untouched here.
