### PR TITLE
fix(a11y): real navigation, table, and page structure for assistive technology

### DIFF
--- a/distil/benchmark.py
+++ b/distil/benchmark.py
@@ -432,13 +432,18 @@ th,td{{padding:10px 13px;border-bottom:1px solid #1b2030;text-align:left}}
 th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 td.r{{text-align:right;font-variant-numeric:tabular-nums}} td.d{{color:#9aa1b3}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:20px}}
+caption.sr-only{{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+ clip:rect(0,0,0,0);white-space:nowrap;border:0}}
 </style></head><body><div class="wrap">
 <h1>Compression <span class="g">benchmark</span></h1>
 <p class="sub">model {report.model} · runner {report.runner} · every technique through the same
 decision-equivalence + non-inferiority gate and cache-aware cost model.</p>
-<table><thead><tr><th>technique</th><th>family</th><th style="text-align:right">tok save</th>
-<th style="text-align:right">$ save</th><th style="text-align:right">equiv</th><th>verdict</th>
-<th>fidelity</th></tr></thead><tbody>{body}</tbody></table>
+<table><caption class="sr-only">Compression technique standings</caption>
+<thead><tr><th scope="col">technique</th><th scope="col">family</th>
+<th scope="col" style="text-align:right">tok save</th>
+<th scope="col" style="text-align:right">$ save</th>
+<th scope="col" style="text-align:right">equiv</th><th scope="col">verdict</th>
+<th scope="col">fidelity</th></tr></thead><tbody>{body}</tbody></table>
 <p class="foot">{verdict} Raw token savings that fail the gate are disqualified — savings that
 change the answer aren't savings. Reproduce offline: <code>distil benchmark</code>; verify a real
 tool: <code>distil benchmark --external module:function</code>.</p>

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -1212,8 +1212,11 @@ def _timeline_table(requests: list[dict[str, Any]]) -> str:
     )
     return (
         "<details><summary class='muted'>data table</summary>"
-        "<table><tr><th>#</th><th>model</th><th>overhead</th><th>sent</th>"
-        f"<th>saved</th><th>billed in</th><th>ms</th></tr>{rows}</table></details>"
+        "<table><caption class='sr-only'>Per-request token timeline</caption>"
+        "<tr><th scope='col'>#</th><th scope='col'>model</th><th scope='col'>overhead</th>"
+        "<th scope='col'>sent</th>"
+        f"<th scope='col'>saved</th><th scope='col'>billed in</th><th scope='col'>ms</th></tr>"
+        f"{rows}</table></details>"
     )
 
 
@@ -1476,12 +1479,18 @@ the wire. Hover a bar for exact numbers.</p>
 kind:size — e.g. <code>log:l</code> is a large log, <code>prose:m</code> a medium block of
 text. Only these labels are stored, never the content.</p>
 {kind_chart}
-<table><tr><th>kind</th><th>blocks</th><th>tokens</th></tr>{kind_rows}</table>
+<table><caption class="sr-only">Folded block kinds</caption>
+<tr><th scope="col">kind</th><th scope="col">blocks</th><th scope="col">tokens</th></tr>
+{kind_rows}</table>
 <h2>Largest folds</h2>
 <p class="desc">The biggest single blocks distil summarized. The handle is the short ID the
 model can use to ask for the original back; “recoverable” means those original bytes are
 still on this machine.</p>
-<table><tr><th>handle</th><th>kind</th><th>tokens</th><th title="how many requests carried this block">seen</th><th title="is the original still on disk (restore/)?">restore</th></tr>{top_rows}</table>"""
+<table><caption class="sr-only">Largest folded blocks</caption>
+<tr><th scope="col">handle</th><th scope="col">kind</th><th scope="col">tokens</th>
+<th scope="col" title="how many requests carried this block">seen</th>
+<th scope="col" title="is the original still on disk (restore/)?">restore</th></tr>
+{top_rows}</table>"""
     else:
         detail_body = (
             "<h2>Request detail</h2><p class='muted'>Not recorded — per-request detail needs a "
@@ -1528,10 +1537,14 @@ each of your prompts cost.</p>
 {unused}
 {refetch_html}
 <h3>Largest folds, named</h3>
-<table><tr><th>source</th><th>under turn</th><th>tokens</th><th>folds</th><th>results seen in</th></tr>
+<table><caption class="sr-only">Largest folds by source</caption>
+<tr><th scope="col">source</th><th scope="col">under turn</th><th scope="col">tokens</th>
+<th scope="col">folds</th><th scope="col">results seen in</th></tr>
 {fold_rows or "<tr><td class='muted' colspan='5'>no blocks could be attributed</td></tr>"}</table>
 <h3>Costliest turns</h3>
-<table><tr><th>#</th><th>your prompt</th><th>req</th><th>baseline</th><th>saved</th></tr>
+<table><caption class="sr-only">Token usage by turn</caption>
+<tr><th scope="col">#</th><th scope="col">your prompt</th><th scope="col">req</th>
+<th scope="col">baseline</th><th scope="col">saved</th></tr>
 {turn_rows or "<tr><td class='muted' colspan='5'>no turns matched</td></tr>"}</table>"""
     heads = d.headlines()
     story = (
@@ -1595,6 +1608,8 @@ ul.warn{{margin:8px 0 0;padding-left:20px}} ul.warn li{{color:#e8b34b;margin:6px
 ul.notes{{margin:14px 0 0;padding-left:20px}} ul.notes li{{color:#9aa1b3;margin:8px 0}}
 details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:26px}}
+caption.sr-only{{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+ clip:rect(0,0,0,0);white-space:nowrap;border:0}}
 </style></head><body><div class="wrap">
 <h1>Session <span class="g">dissected</span></h1>
 <p class="sub">{e(d.sid)} — {e(man.get("tool") or "unknown tool")},
@@ -1610,7 +1625,9 @@ details{{margin:10px 0}} details summary{{cursor:pointer;color:#5b6177}}
 <h2>Per model</h2>
 <p class="desc">Who talked and what it cost: baseline is what each model <em>would</em> have
 received unwrapped; distil is what was actually sent after compression.</p>
-<table><tr><th>model</th><th>req</th><th>baseline</th><th>distil</th><th>saved</th></tr>{model_rows}</table>
+<table><caption class="sr-only">Token usage by model</caption>
+<tr><th scope="col">model</th><th scope="col">req</th><th scope="col">baseline</th>
+<th scope="col">distil</th><th scope="col">saved</th></tr>{model_rows}</table>
 {detail_body}
 {corr_html}
 <h2>Quality loops</h2>
@@ -1697,11 +1714,15 @@ td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}}
 tbody tr{{cursor:pointer}} tbody tr:hover td{{background:#10131d}}
 code{{color:#8b7bff}} .muted{{color:#5b6177}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+caption.sr-only{{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+ clip:rect(0,0,0,0);white-space:nowrap;border:0}}
 </style></head><body><div class="wrap">
 <h1>Distil <span class="g">sessions</span></h1>
 <p class="sub">Pick a session to dissect — newest activity first. This page refreshes itself.</p>
-<table><thead><tr><th>session</th><th>tool</th><th>started</th><th>last</th><th>reqs</th>
-<th>saved</th><th>status</th></tr></thead><tbody>{rows}</tbody></table>
+<table><caption class="sr-only">Recorded sessions</caption>
+<thead><tr><th scope="col">session</th><th scope="col">tool</th><th scope="col">started</th>
+<th scope="col">last</th><th scope="col">reqs</th>
+<th scope="col">saved</th><th scope="col">status</th></tr></thead><tbody>{rows}</tbody></table>
 <p class="foot">Local-first: served from this machine's ~/.distil only. Reports are per-session;
 JSON at /json/&lt;session&gt;.</p>
 </div></body></html>"""

--- a/distil/gateway.py
+++ b/distil/gateway.py
@@ -383,7 +383,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
 
     totals_row = (
         f"<tr class='total-row'>"
-        f"<td><strong>TOTAL</strong></td>"
+        f"<th scope='row'><strong>TOTAL</strong></th>"
         f"<td><strong>{totals['requests']}</strong></td>"
         f"<td><strong>{totals['tokens_saved']:,}</strong></td>"
         f"<td><strong>${totals['dollars_saved']:.4f}</strong></td>"
@@ -468,7 +468,7 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     border-bottom: 1px solid #13161f;
     transition: background 0.12s;
   }}
-  tbody tr:hover {{ background: #0d1020; }}
+  tbody tr:hover, tfoot tr:hover {{ background: #0d1020; }}
   tbody td {{
     padding: 0.75rem 1rem;
     font-variant-numeric: tabular-nums;
@@ -478,15 +478,21 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
     color: #8b7bff;
     font-size: 0.82rem;
   }}
-  .total-row td {{
+  .total-row td, .total-row th {{
     border-top: 2px solid #1e2130;
     color: #5ad1c9;
     padding: 0.75rem 1rem;
     font-variant-numeric: tabular-nums;
+    text-align: left;
+    font-weight: 400;
   }}
-  .total-row td:first-child {{
+  .total-row td:first-child, .total-row th:first-child {{
     font-family: 'JetBrains Mono', 'Fira Code', monospace;
     font-size: 0.82rem;
+  }}
+  caption.sr-only {{
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
   }}
   .empty {{
     color: #4b5563;
@@ -533,19 +539,22 @@ def _dashboard_html(snap: dict[str, Any]) -> str:
 
 <div class="table-wrap">
 <table>
+  <caption class="sr-only">Per-tenant token compression leaderboard</caption>
   <thead>
     <tr>
-      <th>Tenant</th>
-      <th>Requests</th>
-      <th>Tokens Saved</th>
-      <th>$ Saved</th>
-      <th>% Saved</th>
+      <th scope="col">Tenant</th>
+      <th scope="col">Requests</th>
+      <th scope="col">Tokens Saved</th>
+      <th scope="col">$ Saved</th>
+      <th scope="col">% Saved</th>
     </tr>
   </thead>
   <tbody>
     {rows}
-    {totals_row}
   </tbody>
+  <tfoot>
+    {totals_row}
+  </tfoot>
 </table>
 </div>
 <p class="refresh-note">Auto-refresh every 5 s &bull; distil gateway</p>

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -400,6 +400,8 @@ th,td{{padding:11px 14px;border-bottom:1px solid #1b2030;text-align:left}}
 th{{color:#5b6177;font-size:11px;text-transform:uppercase;letter-spacing:.07em}}
 td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{{color:#5b6177}}
 .foot{{color:#5b6177;font-size:12.5px;margin-top:22px}}
+caption.sr-only{{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+ clip:rect(0,0,0,0);white-space:nowrap;border:0}}
 </style></head><body><div class="wrap">
 <h1>Your <span class="g">savings</span></h1>
 <p class="sub">Genuine, local-first — measured from your own runs and proxy traffic. No content leaves your machine.</p>
@@ -410,7 +412,10 @@ td.r{{text-align:right;color:#5ad1c9;font-variant-numeric:tabular-nums}} .muted{
  <div class="card"><div class="l">Runs</div><div class="v">{s.runs:,}</div></div>
  {_eq_card(change_rate, samples)}{_session_card(session)}
 </div>
-<table><thead><tr><th>source</th><th style="text-align:right">{col_hdr}</th></tr></thead><tbody>{rows}</tbody></table>
+<table><caption class="sr-only">Savings by source</caption>
+<thead><tr><th scope="col">source</th>
+<th scope="col" style="text-align:right">{col_hdr}</th></tr></thead>
+<tbody>{rows}</tbody></table>
 <p class="foot">{note} Share verifiably across instances with <code>distil federated-leaderboard</code>.</p>
 </div></body></html>"""
 

--- a/distil/telemetry.py
+++ b/distil/telemetry.py
@@ -242,6 +242,8 @@ def render_leaderboard_html(lb: Leaderboard) -> str:
           color:#8b7bff;font-size:.7rem;padding:.1rem .4rem;border-radius:.25rem;
           margin-left:.5rem;vertical-align:middle}}
   .rejected{{font-size:.8rem;color:#8b8ea8;margin-top:1rem}}
+  caption.sr-only{{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+      clip:rect(0,0,0,0);white-space:nowrap;border:0}}
 </style>
 </head>
 <body>
@@ -258,10 +260,13 @@ def render_leaderboard_html(lb: Leaderboard) -> str:
     <div class="value">{t.get("instances", 0):,}</div></div>
 </div>
 <table>
+<caption class="sr-only">Per-instance verified savings leaderboard</caption>
 <thead><tr>
-  <th>#</th><th>Instance</th><th style="text-align:right">Tokens saved</th>
-  <th style="text-align:right">Dollars saved</th><th style="text-align:right">Runs</th>
-  <th>Certified</th>
+  <th scope="col">#</th><th scope="col">Instance</th>
+  <th scope="col" style="text-align:right">Tokens saved</th>
+  <th scope="col" style="text-align:right">Dollars saved</th>
+  <th scope="col" style="text-align:right">Runs</th>
+  <th scope="col">Certified</th>
 </tr></thead>
 <tbody>
 {rows_html}</tbody>

--- a/distil/webdash.py
+++ b/distil/webdash.py
@@ -87,7 +87,7 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
     background:linear-gradient(180deg,var(--panel2),var(--panel));box-shadow:0 40px 120px -50px #000}
   .top{height:3px;background:linear-gradient(90deg,var(--acc),var(--tl))}
   .in{padding:30px 32px 28px}
-  .lab{font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--mut);display:flex;align-items:center;gap:9px}
+  .lab{margin:0;font-weight:400;font-size:11.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--mut);display:flex;align-items:center;gap:9px}
   .dot{width:8px;height:8px;border-radius:50%;background:var(--good);box-shadow:0 0 12px 2px rgba(90,209,154,.75);animation:p 1.4s ease-in-out infinite}
   @keyframes p{50%{opacity:.35}}
   .odo{display:flex;align-items:baseline;gap:1px;margin:14px 0 8px;font-weight:800;font-size:clamp(34px,7vw,68px);line-height:1;letter-spacing:-.02em;flex-wrap:wrap;text-shadow:0 0 30px rgba(90,209,154,.25)}
@@ -108,18 +108,20 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
   @keyframes fl{0%{box-shadow:0 0 0 1px var(--good),0 0 30px -6px var(--good)}100%{box-shadow:none}}
   @media (prefers-reduced-motion:reduce){.dot{animation:none}.odo .d{transition:none}}
 </style></head><body>
+<main>
 <div class="card" id="card"><div class="top"></div><div class="in">
-  <div class="lab"><span class="dot"></span> your tokens saved · live · this machine</div>
+  <h1 class="lab"><span class="dot"></span> your tokens saved · live · this machine</h1>
   <div class="odo" id="odo"><span class="d">0</span></div>
   <div class="sub" id="sub">reading your local ledger…</div>
   <div class="row">
-    <div class="m"><div class="mv g" id="pct">–</div><div class="ml">smaller · overall</div></div>
-    <div class="m"><div class="mv" id="dollars">–</div><div class="ml" id="dollarslab">$ saved</div></div>
-    <div class="m"><div class="mv a" id="eq">–</div><div class="ml">decision-equivalence</div></div>
-    <div class="m"><div class="mv" id="runs">–</div><div class="ml">requests</div></div>
+    <div class="m"><div class="mv g" id="pct" aria-labelledby="pctlab">–</div><div class="ml" id="pctlab">smaller · overall</div></div>
+    <div class="m"><div class="mv" id="dollars" aria-labelledby="dollarslab">–</div><div class="ml" id="dollarslab">$ saved</div></div>
+    <div class="m"><div class="mv a" id="eq" aria-labelledby="eqlab">–</div><div class="ml" id="eqlab">decision-equivalence</div></div>
+    <div class="m"><div class="mv" id="runs" aria-labelledby="runslab">–</div><div class="ml" id="runslab">requests</div></div>
   </div>
   <div class="foot"><span>◉ local only · nothing leaves this machine</span><span id="stamp"></span></div>
 </div></div>
+</main>
 <script>
 (function(){
   var reduced=matchMedia("(prefers-reduced-motion:reduce)").matches;

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html" class="active" aria-current="page">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html" class="active">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -169,31 +169,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html" class="active" aria-current="page">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html" class="active">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&larr; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&larr; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html" class="active">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html" class="active" aria-current="page">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/benchmark.html
+++ b/docs/benchmark.html
@@ -33,30 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
-    <a href="benchmark.html" class="active">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html" class="active" aria-current="page">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">
@@ -79,19 +89,19 @@
 
     <table>
       <thead>
-        <tr><th>Method</th><th style="text-align:right">Token&nbsp;savings</th><th style="text-align:right">Live&nbsp;decision-change</th><th>Certifies&nbsp;≤5%@95%?</th><th style="text-align:right">Latency/turn</th></tr>
+        <tr><th scope="col">Method</th><th scope="col" style="text-align:right">Token&nbsp;savings</th><th scope="col" style="text-align:right">Live&nbsp;decision-change</th><th scope="col">Certifies&nbsp;≤5%@95%?</th><th scope="col" style="text-align:right">Latency/turn</th></tr>
       </thead>
       <tbody>
         <tr style="background:rgba(90,209,154,.10)">
-          <td><strong>Distil</strong> <span style="color:#5b6177">(causal-prune + lossless)</span></td>
+          <th scope="row"><strong>Distil</strong> <span style="color:#5b6177">(causal-prune + lossless)</span></th>
           <td style="text-align:right"><strong>83.2%</strong></td><td style="text-align:right"><strong>0.0%</strong></td>
           <td><span class="badge-pass">✔ certified — leader</span></td><td style="text-align:right"><strong>0.026&nbsp;ms</strong></td></tr>
         <tr>
-          <td>LLMLingua-2 <span style="color:#5b6177">(<code>llmlingua</code>, real)</span></td>
+          <th scope="row">LLMLingua-2 <span style="color:#5b6177">(<code>llmlingua</code>, real)</span></th>
           <td style="text-align:right">53.1%</td><td style="text-align:right">12.5%</td>
           <td><span class="badge-fail">✘ fails gate</span></td><td style="text-align:right">~1,480&nbsp;ms</td></tr>
         <tr>
-          <td>Headroom <span style="color:#5b6177">(<code>headroom-ai</code>, real)</span></td>
+          <th scope="row">Headroom <span style="color:#5b6177">(<code>headroom-ai</code>, real)</span></th>
           <td style="text-align:right">39.7%</td><td style="text-align:right">0.0%</td>
           <td><span class="badge-pass">✔ certified</span></td><td style="text-align:right">26&nbsp;ms</td></tr>
       </tbody>
@@ -145,14 +155,14 @@ It's not how many tokens you cut — it's which ones.</pre>
     <p>A second, <strong>messages-level</strong> benchmark targets the coding-agent hot path (<code>benchmarks/codebench.py</code>: 16 sessions / 256 turns of read → edit → <strong>re-read</strong>), scoring <strong>cache-aware real dollars</strong> against the <em>real</em> installed packages. Each method is a pure, deterministic, <strong>cache-monotonic</strong> function of the cumulative conversation — the same standard distil holds itself to. The competitors are driven the way they actually deploy: LLMLingua-2 over every tool result (memoised); Headroom via its whole-conversation router with <code>optimize=True</code>.</p>
     <img src="assets/cache-delta.svg" alt="Cache-delta: read, edit, re-read — distil sends a reference + diff" class="svg-embed"/>
     <table>
-      <thead><tr><th>method</th><th style="text-align:right">token savings</th><th style="text-align:right">$ savings (cache-aware)</th><th style="text-align:right">latency / turn</th><th>fidelity</th></tr></thead>
+      <thead><tr><th scope="col">method</th><th scope="col" style="text-align:right">token savings</th><th scope="col" style="text-align:right">$ savings (cache-aware)</th><th scope="col" style="text-align:right">latency / turn</th><th scope="col">fidelity</th></tr></thead>
       <tbody>
-        <tr style="background:rgba(139,123,255,.07)"><td><b>distil</b> (PAYG digest)</td><td class="r">91.5%</td><td class="r">91.1%</td><td class="r">0.08 ms</td><td>reversible</td></tr>
-        <tr><td>distil + cache-delta</td><td class="r">89.6%</td><td class="r">89.0%</td><td class="r">12.9 ms</td><td>reversible</td></tr>
-        <tr><td>LLMLingua-2 (<code>llmlingua</code> 0.2.2, real)</td><td class="r">56.8%</td><td class="r">57.2%</td><td class="r">274 ms</td><td>lossy</td></tr>
-        <tr><td>distil-verbatim + cache-delta</td><td class="r">34.9%</td><td class="r">43.8%</td><td class="r">13.8 ms</td><td>reversible</td></tr>
-        <tr><td>distil-verbatim (Tier-0 only)</td><td class="r">0.0%</td><td class="r">0.0%</td><td class="r">0.6 ms</td><td>reversible</td></tr>
-        <tr><td>Headroom (<code>headroom-ai</code> 0.27.0, real, default)</td><td class="r">22.4%</td><td class="r">&minus;16.8%</td><td class="r">5.3 ms</td><td>lossy</td></tr>
+        <tr style="background:rgba(139,123,255,.07)"><th scope="row"><b>distil</b> (PAYG digest)</th><td class="r">91.5%</td><td class="r">91.1%</td><td class="r">0.08 ms</td><td>reversible</td></tr>
+        <tr><th scope="row">distil + cache-delta</th><td class="r">89.6%</td><td class="r">89.0%</td><td class="r">12.9 ms</td><td>reversible</td></tr>
+        <tr><th scope="row">LLMLingua-2 (<code>llmlingua</code> 0.2.2, real)</th><td class="r">56.8%</td><td class="r">57.2%</td><td class="r">274 ms</td><td>lossy</td></tr>
+        <tr><th scope="row">distil-verbatim + cache-delta</th><td class="r">34.9%</td><td class="r">43.8%</td><td class="r">13.8 ms</td><td>reversible</td></tr>
+        <tr><th scope="row">distil-verbatim (Tier-0 only)</th><td class="r">0.0%</td><td class="r">0.0%</td><td class="r">0.6 ms</td><td>reversible</td></tr>
+        <tr><th scope="row">Headroom (<code>headroom-ai</code> 0.27.0, real, default)</th><td class="r">22.4%</td><td class="r">&minus;16.8%</td><td class="r">5.3 ms</td><td>lossy</td></tr>
       </tbody>
     </table>
     <div class="callout">
@@ -166,43 +176,43 @@ It's not how many tokens you cut — it's which ones.</pre>
 
     <table>
       <thead>
-        <tr><th>Technique</th><th>Family</th><th style="text-align:right">Tokens&nbsp;saved</th><th style="text-align:right">$&nbsp;saved</th><th style="text-align:right">Decision&nbsp;equiv.</th><th>Verdict</th><th>Fidelity</th></tr>
+        <tr><th scope="col">Technique</th><th scope="col">Family</th><th scope="col" style="text-align:right">Tokens&nbsp;saved</th><th scope="col" style="text-align:right">$&nbsp;saved</th><th scope="col" style="text-align:right">Decision&nbsp;equiv.</th><th scope="col">Verdict</th><th scope="col">Fidelity</th></tr>
       </thead>
       <tbody>
         <tr style="background:rgba(139,123,255,.08)">
-          <td><strong>distil-causal</strong></td><td>cache-aware + causal pruning</td>
+          <th scope="row"><strong>distil-causal</strong></th><td>cache-aware + causal pruning</td>
           <td style="text-align:right">80.5%</td><td style="text-align:right"><strong>81.5%</strong></td>
           <td style="text-align:right">100%</td><td><span class="badge-pass">✔ certified · leader</span></td><td>lossy*</td></tr>
         <tr>
-          <td>truncate-tail <span style="color:#5b6177">(structural baseline)</span></td><td>sliding-window / truncation</td>
+          <th scope="row">truncate-tail <span style="color:#5b6177">(structural baseline)</span></th><td>sliding-window / truncation</td>
           <td style="text-align:right">78.7%</td><td style="text-align:right">79.6%</td>
           <td style="text-align:right">14%</td><td><span class="badge-fail">✘ fails gate</span></td><td>lossy</td></tr>
         <tr>
-          <td><strong>distil-stream</strong></td><td>lossless + cross-turn dedup (fully reversible)</td>
+          <th scope="row"><strong>distil-stream</strong></th><td>lossless + cross-turn dedup (fully reversible)</td>
           <td style="text-align:right">61.0%</td><td style="text-align:right">61.7%</td>
           <td style="text-align:right">100%</td><td><span class="badge-pass">✔ certified</span></td><td>reversible</td></tr>
         <tr>
-          <td><strong>distil-lossless</strong></td><td>cache-aware lossless + structured fold + template mining</td>
+          <th scope="row"><strong>distil-lossless</strong></th><td>cache-aware lossless + structured fold + template mining</td>
           <td style="text-align:right">57.4%</td><td style="text-align:right">58.1%</td>
           <td style="text-align:right">100%</td><td><span class="badge-pass">✔ certified</span></td><td>byte-exact</td></tr>
         <tr>
-          <td>summarize <span style="color:#5b6177">(structural baseline)</span></td><td>abstractive / rolling summary</td>
+          <th scope="row">summarize <span style="color:#5b6177">(structural baseline)</span></th><td>abstractive / rolling summary</td>
           <td style="text-align:right">56.5%</td><td style="text-align:right">57.2%</td>
           <td style="text-align:right">39%</td><td><span class="badge-fail">✘ fails gate</span></td><td>lossy</td></tr>
         <tr>
-          <td><strong>LLMLingua-2</strong> <span style="color:#5b6177">(real pkg)</span></td><td><code>llmlingua</code> 0.2.2, per tool-result</td>
+          <th scope="row"><strong>LLMLingua-2</strong> <span style="color:#5b6177">(real pkg)</span></th><td><code>llmlingua</code> 0.2.2, per tool-result</td>
           <td style="text-align:right">54.9%</td><td style="text-align:right">54.8%</td>
           <td style="text-align:right">0%</td><td><span class="badge-fail">✘ fails gate</span></td><td>lossy</td></tr>
         <tr>
-          <td><strong>Headroom</strong> <span style="color:#5b6177">(real pkg)</span></td><td><code>headroom-ai</code> 0.27.0, whole-conversation <code>optimize=True</code></td>
+          <th scope="row"><strong>Headroom</strong> <span style="color:#5b6177">(real pkg)</span></th><td><code>headroom-ai</code> 0.27.0, whole-conversation <code>optimize=True</code></td>
           <td style="text-align:right">43.5%</td><td style="text-align:right">44.0%</td>
           <td style="text-align:right">61%</td><td><span class="badge-fail">✘ fails gate</span></td><td>lossy</td></tr>
         <tr>
-          <td>extractive-prune <span style="color:#5b6177">(structural baseline)</span></td><td>extractive importance (LLMLingua technique family)</td>
+          <th scope="row">extractive-prune <span style="color:#5b6177">(structural baseline)</span></th><td>extractive importance (LLMLingua technique family)</td>
           <td style="text-align:right">18.2%</td><td style="text-align:right">18.4%</td>
           <td style="text-align:right">77%</td><td><span class="badge-fail">✘ fails gate</span></td><td>lossy</td></tr>
         <tr>
-          <td>minify-all</td><td>lossless minification</td>
+          <th scope="row">minify-all</th><td>lossless minification</td>
           <td style="text-align:right">0.1%</td><td style="text-align:right">0.1%</td>
           <td style="text-align:right">100%</td><td><span class="badge-pass">✔ certified</span></td><td>byte-exact</td></tr>
       </tbody>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&larr; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&larr; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -88,15 +88,15 @@
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--tokenizer</code></td><td><code>heuristic</code></td><td><code>heuristic</code> (offline, zero deps) or <code>anthropic</code> (billing-grade <code>count_tokens</code>)</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model pricing to use (see pricing catalog)</td></tr>
-        <tr><td><code>--margin</code></td><td><code>0.02</code></td><td>TOST indifference margin (max tolerable mean score drop)</td></tr>
-        <tr><td><code>--alpha</code></td><td><code>0.05</code></td><td>Significance level for the non-inferiority test</td></tr>
-        <tr><td><code>--record</code></td><td>off</td><td>Append corpus-aggregate savings to the local savings ledger</td></tr>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Run on a custom corpus dir (e.g. from <code>distil ingest</code>)</td></tr>
-        <tr><td><code>--savings-only</code></td><td>off</td><td>Report token savings only; skip the decision-equivalence gate (for real-trace corpora without DECISION labels)</td></tr>
+        <tr><th scope="row"><code>--tokenizer</code></th><td><code>heuristic</code></td><td><code>heuristic</code> (offline, zero deps) or <code>anthropic</code> (billing-grade <code>count_tokens</code>)</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model pricing to use (see pricing catalog)</td></tr>
+        <tr><th scope="row"><code>--margin</code></th><td><code>0.02</code></td><td>TOST indifference margin (max tolerable mean score drop)</td></tr>
+        <tr><th scope="row"><code>--alpha</code></th><td><code>0.05</code></td><td>Significance level for the non-inferiority test</td></tr>
+        <tr><th scope="row"><code>--record</code></th><td>off</td><td>Append corpus-aggregate savings to the local savings ledger</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Run on a custom corpus dir (e.g. from <code>distil ingest</code>)</td></tr>
+        <tr><th scope="row"><code>--savings-only</code></th><td>off</td><td>Report token savings only; skip the decision-equivalence gate (for real-trace corpora without DECISION labels)</td></tr>
       </tbody>
     </table>
 
@@ -125,13 +125,13 @@ GATE: <span class="g">PASS</span> — every trajectory certified non-inferior; a
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--trajectory, -t</code></td><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
-        <tr><td><code>--tokenizer</code></td><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code> (billing-grade)</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model pricing to use</td></tr>
-        <tr><td><code>--output-tokens-per-turn</code></td><td><code>0</code></td><td>Assumed output tokens per turn (for output cost accounting)</td></tr>
-        <tr><td><code>--record</code></td><td>off</td><td>Append this run to the local savings ledger</td></tr>
+        <tr><th scope="row"><code>--trajectory, -t</code></th><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
+        <tr><th scope="row"><code>--tokenizer</code></th><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code> (billing-grade)</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model pricing to use</td></tr>
+        <tr><th scope="row"><code>--output-tokens-per-turn</code></th><td><code>0</code></td><td>Assumed output tokens per turn (for output cost accounting)</td></tr>
+        <tr><th scope="row"><code>--record</code></th><td>off</td><td>Append this run to the local savings ledger</td></tr>
       </tbody>
     </table>
 
@@ -157,13 +157,13 @@ note: naive compression costs $0.01691 — <span class="w">66% MORE</span> than 
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--trajectory, -t</code></td><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
-        <tr><td><code>--strategy</code></td><td><code>distil</code></td><td>Strategy to certify: <code>distil</code>, <code>aggressive</code>, <code>naive</code>, <code>none</code></td></tr>
-        <tr><td><code>--runner</code></td><td><code>deterministic</code></td><td><code>deterministic</code> (offline, uses ground-truth markers) or <code>anthropic</code> (live model, requires key)</td></tr>
-        <tr><td><code>--margin</code></td><td><code>0.02</code></td><td>TOST indifference margin</td></tr>
-        <tr><td><code>--alpha</code></td><td><code>0.05</code></td><td>Significance level</td></tr>
+        <tr><th scope="row"><code>--trajectory, -t</code></th><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
+        <tr><th scope="row"><code>--strategy</code></th><td><code>distil</code></td><td>Strategy to certify: <code>distil</code>, <code>aggressive</code>, <code>naive</code>, <code>none</code></td></tr>
+        <tr><th scope="row"><code>--runner</code></th><td><code>deterministic</code></td><td><code>deterministic</code> (offline, uses ground-truth markers) or <code>anthropic</code> (live model, requires key)</td></tr>
+        <tr><th scope="row"><code>--margin</code></th><td><code>0.02</code></td><td>TOST indifference margin</td></tr>
+        <tr><th scope="row"><code>--alpha</code></th><td><code>0.05</code></td><td>Significance level</td></tr>
       </tbody>
     </table>
 
@@ -203,9 +203,9 @@ VERDICT: <span class="w">FAIL</span>  (NOT certified — would degrade quality)<
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--trajectory, -t</code></td><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
+        <tr><th scope="row"><code>--trajectory, -t</code></th><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
       </tbody>
     </table>
 
@@ -229,10 +229,10 @@ tokens provably free to drop: 615 across 2 block(s).</pre>
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--trajectory, -t</code></td><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
-        <tr><td><code>--tokenizer</code></td><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code></td></tr>
+        <tr><th scope="row"><code>--trajectory, -t</code></th><td>bundled sample</td><td>Path to a trajectory JSON file</td></tr>
+        <tr><th scope="row"><code>--tokenizer</code></th><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code></td></tr>
       </tbody>
     </table>
 
@@ -296,11 +296,11 @@ VALIDATE: <span class="g">PASS</span> — 60/60 checks across 12 adversarial cas
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--tokenizer</code></td><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code></td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model pricing to use</td></tr>
-        <tr><td><code>--control-fraction</code></td><td><code>0.2</code></td><td>Fraction of corpus held out as control group</td></tr>
+        <tr><th scope="row"><code>--tokenizer</code></th><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code></td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model pricing to use</td></tr>
+        <tr><th scope="row"><code>--control-fraction</code></th><td><code>0.2</code></td><td>Fraction of corpus held out as control group</td></tr>
       </tbody>
     </table>
 
@@ -334,10 +334,10 @@ fresh start: all new records use post-1.10 accounting (booked only after upstrea
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--html</code></td><td>off</td><td>Render your savings ledger as a self-contained HTML page at this path</td></tr>
-        <tr><td><code>--json</code></td><td>off</td><td>Machine-readable output: the full savings summary plus decision-equivalence/shadow-sample counts when shadow data exists</td></tr>
+        <tr><th scope="row"><code>--html</code></th><td>off</td><td>Render your savings ledger as a self-contained HTML page at this path</td></tr>
+        <tr><th scope="row"><code>--json</code></th><td>off</td><td>Machine-readable output: the full savings summary plus decision-equivalence/shadow-sample counts when shadow data exists</td></tr>
       </tbody>
     </table>
 
@@ -368,20 +368,20 @@ by trajectory:
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--host</code></td><td><code>127.0.0.1</code></td><td>Interface to bind on</td></tr>
-        <tr><td><code>--port</code></td><td><code>8788</code></td><td>Port to listen on</td></tr>
-        <tr><td><code>--upstream</code></td><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL to forward to</td></tr>
-        <tr><td><code>--lossless-only</code></td><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
-        <tr><td><code>--verbatim</code></td><td>off</td><td>Skip the Tier-1 digest; Tier-0 only (JSON minify + collapse exact-duplicate runs). Interactive-safe, lower savings. Use where <code>distil_expand</code> recovery is unavailable.</td></tr>
-        <tr><td><code>--shape-output</code></td><td>off</td><td>Enable generation-side verbosity shaping: <code>light</code> (conservative) or <code>aggressive</code>. Injects a <code>role:"system"</code> directive before the request. Gated by <code>--lossless-only</code>: shaping is skipped when <code>--lossless-only</code> is set. No subscription key detection.</td></tr>
-        <tr><td><code>--expand</code></td><td>off</td><td>Inject the <code>distil_expand</code> tool so the model can pull digested blocks back on demand</td></tr>
-        <tr><td><code>--shadow</code></td><td>off (direct use; <code>distil wrap</code> defaults to 0.02)</td><td>Shadow-mode sampling rate (0–1): re-run a fraction of requests uncompressed to measure live decision-equivalence. <code>--shadow 0</code> disables; <code>--shadow 1.0</code> = full-sampling validation (~3× tokens — prove equivalence in minutes, then drop back).</td></tr>
-        <tr><td><code>--session-delta</code></td><td>off</td><td>Enable cross-turn cache-delta encoding (deduplicates repeated stable blocks across the session)</td></tr>
-        <tr><td><code>--async</code></td><td>off</td><td>Use the async aiohttp backend (<code>distil/aproxy.py</code>) for high-concurrency streaming. Requires <code>pip install 'distil-llm[async]'</code>. Async event loop handles thousands of concurrent sessions. Note: the async backend supports lossless / verbatim / output-shaping, but not <code>--expand</code>, <code>--session-delta</code>, or <code>--shadow</code> yet — pass those on the standard (sync) proxy, which handles typical agent concurrency. Combining them with <code>--async</code> prints a notice and ignores them.</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model used to price the genuine dollar savings recorded to the ledger</td></tr>
-        <tr><td><code>--no-record</code></td><td>off</td><td>Do not record genuine savings to the local ledger</td></tr>
+        <tr><th scope="row"><code>--host</code></th><td><code>127.0.0.1</code></td><td>Interface to bind on</td></tr>
+        <tr><th scope="row"><code>--port</code></th><td><code>8788</code></td><td>Port to listen on</td></tr>
+        <tr><th scope="row"><code>--upstream</code></th><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL to forward to</td></tr>
+        <tr><th scope="row"><code>--lossless-only</code></th><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
+        <tr><th scope="row"><code>--verbatim</code></th><td>off</td><td>Skip the Tier-1 digest; Tier-0 only (JSON minify + collapse exact-duplicate runs). Interactive-safe, lower savings. Use where <code>distil_expand</code> recovery is unavailable.</td></tr>
+        <tr><th scope="row"><code>--shape-output</code></th><td>off</td><td>Enable generation-side verbosity shaping: <code>light</code> (conservative) or <code>aggressive</code>. Injects a <code>role:"system"</code> directive before the request. Gated by <code>--lossless-only</code>: shaping is skipped when <code>--lossless-only</code> is set. No subscription key detection.</td></tr>
+        <tr><th scope="row"><code>--expand</code></th><td>off</td><td>Inject the <code>distil_expand</code> tool so the model can pull digested blocks back on demand</td></tr>
+        <tr><th scope="row"><code>--shadow</code></th><td>off (direct use; <code>distil wrap</code> defaults to 0.02)</td><td>Shadow-mode sampling rate (0–1): re-run a fraction of requests uncompressed to measure live decision-equivalence. <code>--shadow 0</code> disables; <code>--shadow 1.0</code> = full-sampling validation (~3× tokens — prove equivalence in minutes, then drop back).</td></tr>
+        <tr><th scope="row"><code>--session-delta</code></th><td>off</td><td>Enable cross-turn cache-delta encoding (deduplicates repeated stable blocks across the session)</td></tr>
+        <tr><th scope="row"><code>--async</code></th><td>off</td><td>Use the async aiohttp backend (<code>distil/aproxy.py</code>) for high-concurrency streaming. Requires <code>pip install 'distil-llm[async]'</code>. Async event loop handles thousands of concurrent sessions. Note: the async backend supports lossless / verbatim / output-shaping, but not <code>--expand</code>, <code>--session-delta</code>, or <code>--shadow</code> yet — pass those on the standard (sync) proxy, which handles typical agent concurrency. Combining them with <code>--async</code> prints a notice and ignores them.</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model used to price the genuine dollar savings recorded to the ledger</td></tr>
+        <tr><th scope="row"><code>--no-record</code></th><td>off</td><td>Do not record genuine savings to the local ledger</td></tr>
       </tbody>
     </table>
 
@@ -442,19 +442,19 @@ $ distil <span class="c">wrap</span> --env-var MY_BASE_URL --upstream https://ap
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--host</code></td><td><code>127.0.0.1</code></td><td>Bind address for the ephemeral proxy</td></tr>
-        <tr><td><code>--upstream</code></td><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL to forward to</td></tr>
-        <tr><td><code>--env-var</code></td><td><code>ANTHROPIC_BASE_URL</code></td><td>Environment variable to point at the proxy in the child process</td></tr>
-        <tr><td><code>--lossless-only</code></td><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
-        <tr><td><code>--verbatim</code></td><td>off</td><td>Skip the Tier-1 digest; Tier-0 only. Interactive-safe, lower savings.</td></tr>
-        <tr><td><code>--shape-output</code></td><td>off</td><td>Generation-side verbosity shaping (gated by <code>--lossless-only</code>)</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model used to price genuine dollar savings recorded to the ledger</td></tr>
-        <tr><td><code>--no-record</code></td><td>off</td><td>Do not record genuine savings to the local ledger</td></tr>
-        <tr><td><code>--expand</code></td><td>off</td><td>Inject the <code>distil_expand</code> tool so the model can pull digested blocks back on demand</td></tr>
-        <tr><td><code>--shadow</code></td><td>0.02 (2%, opt-out)</td><td>Fraction of requests re-issued uncompressed to measure live decision-equivalence. <code>--shadow 0</code> disables; <code>--shadow 1.0</code> = full-sampling validation (~3× tokens — proves equivalence fast, use then drop back). See <a href="#statusline">status line</a> for how to read the <code>de</code> segment.</td></tr>
-        <tr><td><code>--session-delta</code></td><td>off</td><td>Enable cross-turn cache-delta encoding</td></tr>
+        <tr><th scope="row"><code>--host</code></th><td><code>127.0.0.1</code></td><td>Bind address for the ephemeral proxy</td></tr>
+        <tr><th scope="row"><code>--upstream</code></th><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL to forward to</td></tr>
+        <tr><th scope="row"><code>--env-var</code></th><td><code>ANTHROPIC_BASE_URL</code></td><td>Environment variable to point at the proxy in the child process</td></tr>
+        <tr><th scope="row"><code>--lossless-only</code></th><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
+        <tr><th scope="row"><code>--verbatim</code></th><td>off</td><td>Skip the Tier-1 digest; Tier-0 only. Interactive-safe, lower savings.</td></tr>
+        <tr><th scope="row"><code>--shape-output</code></th><td>off</td><td>Generation-side verbosity shaping (gated by <code>--lossless-only</code>)</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model used to price genuine dollar savings recorded to the ledger</td></tr>
+        <tr><th scope="row"><code>--no-record</code></th><td>off</td><td>Do not record genuine savings to the local ledger</td></tr>
+        <tr><th scope="row"><code>--expand</code></th><td>off</td><td>Inject the <code>distil_expand</code> tool so the model can pull digested blocks back on demand</td></tr>
+        <tr><th scope="row"><code>--shadow</code></th><td>0.02 (2%, opt-out)</td><td>Fraction of requests re-issued uncompressed to measure live decision-equivalence. <code>--shadow 0</code> disables; <code>--shadow 1.0</code> = full-sampling validation (~3× tokens — proves equivalence fast, use then drop back). See <a href="#statusline">status line</a> for how to read the <code>de</code> segment.</td></tr>
+        <tr><th scope="row"><code>--session-delta</code></th><td>off</td><td>Enable cross-turn cache-delta encoding</td></tr>
       </tbody>
     </table>
 
@@ -478,9 +478,9 @@ $ distil <span class="c">wrap</span> --env-var MY_BASE_URL --upstream https://ap
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--input</code></td><td>bundled fixture</td><td>Path to a JSONL file of <code>{"baseline": ..., "shaped": ...}</code> pairs</td></tr>
+        <tr><th scope="row"><code>--input</code></th><td>bundled fixture</td><td>Path to a JSONL file of <code>{"baseline": ..., "shaped": ...}</code> pairs</td></tr>
       </tbody>
     </table>
 
@@ -501,12 +501,12 @@ output-token A/B — n=8 turns
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--input</code></td><td>required</td><td>Path to the JSONL log file (Anthropic or OpenAI request format)</td></tr>
-        <tr><td><code>--out</code></td><td><code>./ingested-corpus</code></td><td>Output directory where the trajectory will be written</td></tr>
-        <tr><td><code>--provider</code></td><td><code>anthropic</code></td><td><code>anthropic</code> or <code>openai</code> — selects the input format</td></tr>
-        <tr><td><code>--model</code></td><td><code>claude-opus-4-8</code></td><td>Model name to tag the trajectory with (must be in the pricing catalog)</td></tr>
+        <tr><th scope="row"><code>--input</code></th><td>required</td><td>Path to the JSONL log file (Anthropic or OpenAI request format)</td></tr>
+        <tr><th scope="row"><code>--out</code></th><td><code>./ingested-corpus</code></td><td>Output directory where the trajectory will be written</td></tr>
+        <tr><th scope="row"><code>--provider</code></th><td><code>anthropic</code></td><td><code>anthropic</code> or <code>openai</code> — selects the input format</td></tr>
+        <tr><th scope="row"><code>--model</code></th><td><code>claude-opus-4-8</code></td><td>Model name to tag the trajectory with (must be in the pricing catalog)</td></tr>
       </tbody>
     </table>
 
@@ -529,9 +529,9 @@ corpus gate — savings-only (no DECISION labels)
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--iterations</code></td><td><code>200</code></td><td>Number of compression iterations to run</td></tr>
+        <tr><th scope="row"><code>--iterations</code></th><td><code>200</code></td><td>Number of compression iterations to run</td></tr>
       </tbody>
     </table>
 
@@ -553,16 +553,16 @@ distil performance benchmark
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--host</code></td><td><code>127.0.0.1</code></td><td>Interface to bind on. Pass <code>0.0.0.0</code> for network-accessible deployments.</td></tr>
-        <tr><td><code>--port</code></td><td><code>8789</code></td><td>Port to listen on.</td></tr>
-        <tr><td><code>--upstream</code></td><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL (set once at startup, cannot be overridden per-request).</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model pricing key for per-tenant dollar accounting.</td></tr>
-        <tr><td><code>--lossless-only</code></td><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
-        <tr><td><code>--verbatim</code></td><td>off</td><td>Skip the Tier-1 digest; Tier-0 only. Interactive-safe, lower savings.</td></tr>
-        <tr><td><code>--admin-token</code></td><td>unset (env <code>DISTIL_GATEWAY_TOKEN</code>)</td><td>Bearer token required for <code>/distil/stats</code> and <code>/distil/dashboard</code>. Mandatory for those routes on non-loopback binds — without it, <code>/distil/*</code> is disabled entirely rather than left open.</td></tr>
-        <tr><td><code>--trust-tenant-header</code></td><td>off</td><td>Honor the client-supplied <code>x-distil-tenant</code> header for accounting. Off by default: tenant identity is derived from the credential hash, never a client-writable header, so no caller can book its traffic under another tenant's line.</td></tr>
+        <tr><th scope="row"><code>--host</code></th><td><code>127.0.0.1</code></td><td>Interface to bind on. Pass <code>0.0.0.0</code> for network-accessible deployments.</td></tr>
+        <tr><th scope="row"><code>--port</code></th><td><code>8789</code></td><td>Port to listen on.</td></tr>
+        <tr><th scope="row"><code>--upstream</code></th><td><code>https://api.anthropic.com</code></td><td>Real LLM API base URL (set once at startup, cannot be overridden per-request).</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model pricing key for per-tenant dollar accounting.</td></tr>
+        <tr><th scope="row"><code>--lossless-only</code></th><td>off</td><td>Policy mode: Tier-0 verbatim only — no lossy output-shaping, no tool injection (<code>--expand</code>), no Tier-1 digest stubs. Folds directly into verbatim (no separate <code>--verbatim</code> needed). Use for subscription / OAuth sessions.</td></tr>
+        <tr><th scope="row"><code>--verbatim</code></th><td>off</td><td>Skip the Tier-1 digest; Tier-0 only. Interactive-safe, lower savings.</td></tr>
+        <tr><th scope="row"><code>--admin-token</code></th><td>unset (env <code>DISTIL_GATEWAY_TOKEN</code>)</td><td>Bearer token required for <code>/distil/stats</code> and <code>/distil/dashboard</code>. Mandatory for those routes on non-loopback binds — without it, <code>/distil/*</code> is disabled entirely rather than left open.</td></tr>
+        <tr><th scope="row"><code>--trust-tenant-header</code></th><td>off</td><td>Honor the client-supplied <code>x-distil-tenant</code> header for accounting. Off by default: tenant identity is derived from the credential hash, never a client-writable header, so no caller can book its traffic under another tenant's line.</td></tr>
       </tbody>
     </table>
 
@@ -619,13 +619,13 @@ $ distil gateway --tenant-rpm 60 --tenant-daily-tokens 1000000 \
 
     <h4>gateway keys flags</h4>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>gateway --require-keys</code></td><td>off</td><td>Force key auth even before any keys are issued.</td></tr>
-        <tr><td><code>gateway --tenant-rpm</code></td><td>0 (unlimited)</td><td>Gateway-wide requests-per-minute cap per tenant.</td></tr>
-        <tr><td><code>gateway --tenant-daily-tokens</code></td><td>0 (unlimited)</td><td>Gateway-wide daily input-token cap per tenant.</td></tr>
-        <tr><td><code>keys issue --tenant &lt;name&gt;</code></td><td>required</td><td>Tenant label to associate with the new key.</td></tr>
-        <tr><td><code>keys revoke &lt;prefix&gt;</code></td><td>required</td><td>First hex characters of the key to revoke (as shown by <code>keys list</code>).</td></tr>
+        <tr><th scope="row"><code>gateway --require-keys</code></th><td>off</td><td>Force key auth even before any keys are issued.</td></tr>
+        <tr><th scope="row"><code>gateway --tenant-rpm</code></th><td>0 (unlimited)</td><td>Gateway-wide requests-per-minute cap per tenant.</td></tr>
+        <tr><th scope="row"><code>gateway --tenant-daily-tokens</code></th><td>0 (unlimited)</td><td>Gateway-wide daily input-token cap per tenant.</td></tr>
+        <tr><th scope="row"><code>keys issue --tenant &lt;name&gt;</code></th><td>required</td><td>Tenant label to associate with the new key.</td></tr>
+        <tr><th scope="row"><code>keys revoke &lt;prefix&gt;</code></th><td>required</td><td>First hex characters of the key to revoke (as shown by <code>keys list</code>).</td></tr>
       </tbody>
     </table>
 
@@ -641,11 +641,11 @@ $ distil gateway --tenant-rpm 60 --tenant-daily-tokens 1000000 \
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--out</code></td><td><code>distil-keep-transformer</code></td><td>Output directory. Receives <code>model.onnx</code>, tokenizer files, and <code>metrics.json</code>.</td></tr>
-        <tr><td><code>--base-model</code></td><td><code>google/bert_uncased_L-2_H-128_A-2</code></td><td>HuggingFace model ID to fine-tune. Swap for <code>distilbert-base-uncased</code> for higher accuracy at larger size.</td></tr>
-        <tr><td><code>--epochs</code></td><td><code>3</code></td><td>Number of training epochs.</td></tr>
+        <tr><th scope="row"><code>--out</code></th><td><code>distil-keep-transformer</code></td><td>Output directory. Receives <code>model.onnx</code>, tokenizer files, and <code>metrics.json</code>.</td></tr>
+        <tr><th scope="row"><code>--base-model</code></th><td><code>google/bert_uncased_L-2_H-128_A-2</code></td><td>HuggingFace model ID to fine-tune. Swap for <code>distilbert-base-uncased</code> for higher accuracy at larger size.</td></tr>
+        <tr><th scope="row"><code>--epochs</code></th><td><code>3</code></td><td>Number of training epochs.</td></tr>
       </tbody>
     </table>
 
@@ -676,11 +676,11 @@ Load with: TransformerKeepModel.from_pretrained('./my-keep-model/model.onnx', '.
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Custom corpus dir (e.g. from <code>distil ingest</code> on benchmark traces)</td></tr>
-        <tr><td><code>--runner</code></td><td><code>deterministic</code></td><td><code>deterministic</code> (offline, structural equivalence) or <code>anthropic</code> (live model, requires API key)</td></tr>
-        <tr><td><code>--out</code></td><td>off</td><td>Write the raw curve as a timestamped JSONL file to this directory</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Custom corpus dir (e.g. from <code>distil ingest</code> on benchmark traces)</td></tr>
+        <tr><th scope="row"><code>--runner</code></th><td><code>deterministic</code></td><td><code>deterministic</code> (offline, structural equivalence) or <code>anthropic</code> (live model, requires API key)</td></tr>
+        <tr><th scope="row"><code>--out</code></th><td>off</td><td>Write the raw curve as a timestamped JSONL file to this directory</td></tr>
       </tbody>
     </table>
 
@@ -708,16 +708,16 @@ certified ceiling: 8.4% savings (beyond this, lossy compression drops decisions 
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--external</code></td><td>—</td><td><code>module:function[:Name]</code> — register a real compressor (<code>list[str]→list[str]</code> over per-turn block texts), measured on the identical axes. Repeatable.</td></tr>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Custom corpus dir (e.g. ingested benchmark traces)</td></tr>
-        <tr><td><code>--runner</code></td><td><code>deterministic</code></td><td><code>deterministic</code> (offline) or <code>anthropic</code> (live model)</td></tr>
-        <tr><td><code>--pricing</code></td><td><code>claude-opus-4-8</code></td><td>Model pricing for the cache-aware cost model</td></tr>
-        <tr><td><code>--tokenizer</code></td><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code> (billing-grade)</td></tr>
-        <tr><td><code>--margin</code></td><td><code>0.02</code></td><td>TOST non-inferiority margin</td></tr>
-        <tr><td><code>--alpha</code></td><td><code>0.05</code></td><td>Significance level for the non-inferiority test</td></tr>
-        <tr><td><code>--html</code> / <code>--out</code></td><td>off</td><td>Render the standings as HTML / write raw results JSONL</td></tr>
+        <tr><th scope="row"><code>--external</code></th><td>—</td><td><code>module:function[:Name]</code> — register a real compressor (<code>list[str]→list[str]</code> over per-turn block texts), measured on the identical axes. Repeatable.</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Custom corpus dir (e.g. ingested benchmark traces)</td></tr>
+        <tr><th scope="row"><code>--runner</code></th><td><code>deterministic</code></td><td><code>deterministic</code> (offline) or <code>anthropic</code> (live model)</td></tr>
+        <tr><th scope="row"><code>--pricing</code></th><td><code>claude-opus-4-8</code></td><td>Model pricing for the cache-aware cost model</td></tr>
+        <tr><th scope="row"><code>--tokenizer</code></th><td><code>heuristic</code></td><td><code>heuristic</code> or <code>anthropic</code> (billing-grade)</td></tr>
+        <tr><th scope="row"><code>--margin</code></th><td><code>0.02</code></td><td>TOST non-inferiority margin</td></tr>
+        <tr><th scope="row"><code>--alpha</code></th><td><code>0.05</code></td><td>Significance level for the non-inferiority test</td></tr>
+        <tr><th scope="row"><code>--html</code> / <code>--out</code></th><td>off</td><td>Render the standings as HTML / write raw results JSONL</td></tr>
       </tbody>
     </table>
 
@@ -743,12 +743,12 @@ LEADER (certified $ savings): distil-causal — 37.4% cheaper, 100% decision-equ
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--targets</code></td><td><code>1.0,0.97,0.95,0.90,0.80</code></td><td>Comma-separated equivalence targets in (0,1]</td></tr>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Custom corpus dir</td></tr>
-        <tr><td><code>--runner</code></td><td><code>deterministic</code></td><td><code>deterministic</code> or <code>anthropic</code> (live model)</td></tr>
-        <tr><td><code>--samples</code></td><td><code>3</code></td><td>Majority-vote samples for the anthropic runner</td></tr>
+        <tr><th scope="row"><code>--targets</code></th><td><code>1.0,0.97,0.95,0.90,0.80</code></td><td>Comma-separated equivalence targets in (0,1]</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Custom corpus dir</td></tr>
+        <tr><th scope="row"><code>--runner</code></th><td><code>deterministic</code></td><td><code>deterministic</code> or <code>anthropic</code> (live model)</td></tr>
+        <tr><th scope="row"><code>--samples</code></th><td><code>3</code></td><td>Majority-vote samples for the anthropic runner</td></tr>
       </tbody>
     </table>
 
@@ -770,14 +770,14 @@ savings-vs-equivalence dial  (runner=deterministic)
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--alpha</code></td><td><code>0.05</code></td><td>Risk target: max tolerable decision-change rate</td></tr>
-        <tr><td><code>--delta</code></td><td><code>0.05</code></td><td>LTT failure probability; confidence is 1&minus;&delta; (ignored by CRC)</td></tr>
-        <tr><td><code>--method</code></td><td><code>ltt</code></td><td><code>ltt</code> (high-probability bound) or <code>crc</code> (expected-rate bound)</td></tr>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Calibration corpus dir (use your own traffic via <code>distil ingest</code>)</td></tr>
-        <tr><td><code>--runner</code></td><td><code>deterministic</code></td><td><code>deterministic</code> or <code>anthropic</code> (live model)</td></tr>
-        <tr><td><code>--samples</code></td><td><code>3</code></td><td>Majority-vote samples for the anthropic runner</td></tr>
+        <tr><th scope="row"><code>--alpha</code></th><td><code>0.05</code></td><td>Risk target: max tolerable decision-change rate</td></tr>
+        <tr><th scope="row"><code>--delta</code></th><td><code>0.05</code></td><td>LTT failure probability; confidence is 1&minus;&delta; (ignored by CRC)</td></tr>
+        <tr><th scope="row"><code>--method</code></th><td><code>ltt</code></td><td><code>ltt</code> (high-probability bound) or <code>crc</code> (expected-rate bound)</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Calibration corpus dir (use your own traffic via <code>distil ingest</code>)</td></tr>
+        <tr><th scope="row"><code>--runner</code></th><td><code>deterministic</code></td><td><code>deterministic</code> or <code>anthropic</code> (live model)</td></tr>
+        <tr><th scope="row"><code>--samples</code></th><td><code>3</code></td><td>Majority-vote samples for the anthropic runner</td></tr>
       </tbody>
     </table>
 
@@ -799,10 +799,10 @@ Decision-Equivalence Risk Certificate (DERC)
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--corpus</code></td><td>bundled corpus</td><td>Corpus dir of traffic to learn from. Use <code>distil ingest</code> to convert real logs first.</td></tr>
-        <tr><td><code>--promote-to</code></td><td>off (dry run)</td><td>If certified, write the new weights as a <code>LogisticKeepModel</code>-compatible JSON file to this path.</td></tr>
+        <tr><th scope="row"><code>--corpus</code></th><td>bundled corpus</td><td>Corpus dir of traffic to learn from. Use <code>distil ingest</code> to convert real logs first.</td></tr>
+        <tr><th scope="row"><code>--promote-to</code></th><td>off (dry run)</td><td>If certified, write the new weights as a <code>LogisticKeepModel</code>-compatible JSON file to this path.</td></tr>
       </tbody>
     </table>
 
@@ -825,9 +825,9 @@ self-distilling round — keep-model learns from causal labels, gated by non-inf
     <p>The model is <strong>additive-only</strong> (it can only widen the keep set, so reversibility and the decision-equivalence certificate are untouched) and <strong>gated</strong>: weights are promoted only if held-out recall beats the phase-1 lexical baseline at a precision floor. With no promoted weights, behavior is exactly phase&nbsp;1. Collection runs automatically under <code>distil wrap --expand</code>; it stores only numeric feature vectors and expand outcomes — never a prompt, a line, or a query term.</p>
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--min-samples</code></td><td>200</td><td>Minimum accumulated flywheel labels before a candidate is eligible for promotion.</td></tr>
+        <tr><th scope="row"><code>--min-samples</code></th><td>200</td><td>Minimum accumulated flywheel labels before a candidate is eligible for promotion.</td></tr>
       </tbody>
     </table>
     <pre class="term"><span class="d">$ distil query-relevance</span>
@@ -845,11 +845,11 @@ flywheel; promote only if it beats the phase-1 lexical baseline (additive-only, 
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--dir</code></td><td>required</td><td>Directory containing <code>submissions.jsonl</code> (one signed aggregate per line)</td></tr>
-        <tr><td><code>--keys</code></td><td>off</td><td>Path to a JSON file mapping <code>instance_id</code> &rarr; HMAC key. Submissions with no matching key are rejected.</td></tr>
-        <tr><td><code>--html</code></td><td>off</td><td>Write a self-contained leaderboard HTML page to this path</td></tr>
+        <tr><th scope="row"><code>--dir</code></th><td>required</td><td>Directory containing <code>submissions.jsonl</code> (one signed aggregate per line)</td></tr>
+        <tr><th scope="row"><code>--keys</code></th><td>off</td><td>Path to a JSON file mapping <code>instance_id</code> &rarr; HMAC key. Submissions with no matching key are rejected.</td></tr>
+        <tr><th scope="row"><code>--html</code></th><td>off</td><td>Write a self-contained leaderboard HTML page to this path</td></tr>
       </tbody>
     </table>
 
@@ -872,12 +872,12 @@ verifiable savings — 3 verified instance(s), 0 rejected
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>outcomes</code></td><td>required</td><td>Path to a JSONL file of matched runs, one object per line: <code>{"task_id": ..., "full_success": bool, "compressed_success": bool}</code></td></tr>
-        <tr><td><code>--alpha</code></td><td><code>0.05</code></td><td>Maximum end-to-end degradation risk to certify</td></tr>
-        <tr><td><code>--delta</code></td><td><code>0.05</code></td><td>Confidence budget — certificate holds at confidence 1&minus;&delta;</td></tr>
-        <tr><td><code>--json</code></td><td>off</td><td>Machine-readable output: the full certificate fields plus <code>statement</code></td></tr>
+        <tr><th scope="row"><code>outcomes</code></th><td>required</td><td>Path to a JSONL file of matched runs, one object per line: <code>{"task_id": ..., "full_success": bool, "compressed_success": bool}</code></td></tr>
+        <tr><th scope="row"><code>--alpha</code></th><td><code>0.05</code></td><td>Maximum end-to-end degradation risk to certify</td></tr>
+        <tr><th scope="row"><code>--delta</code></th><td><code>0.05</code></td><td>Confidence budget — certificate holds at confidence 1&minus;&delta;</td></tr>
+        <tr><th scope="row"><code>--json</code></th><td>off</td><td>Machine-readable output: the full certificate fields plus <code>statement</code></td></tr>
       </tbody>
     </table>
 
@@ -936,9 +936,9 @@ distil &middot; &Sigma;27.0M saved &minus;50% $96.10</pre>
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--json</code></td><td>off</td><td>Machine-readable output: <code>samples</code>, <code>changes</code>, <code>decision_change_rate</code>, <code>decision_equivalence</code></td></tr>
+        <tr><th scope="row"><code>--json</code></th><td>off</td><td>Machine-readable output: <code>samples</code>, <code>changes</code>, <code>decision_change_rate</code>, <code>decision_equivalence</code></td></tr>
       </tbody>
     </table>
 
@@ -949,10 +949,10 @@ distil &middot; &Sigma;27.0M saved &minus;50% $96.10</pre>
 
     <h3>Flags</h3>
     <table>
-      <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+      <thead><tr><th scope="col">Flag</th><th scope="col">Default</th><th scope="col">Description</th></tr></thead>
       <tbody>
-        <tr><td><code>--no-color</code></td><td>off</td><td>Disable ANSI colors in the check list</td></tr>
-        <tr><td><code>--json</code></td><td>off</td><td>Machine-readable output (CI-gateable): <code>{"checks": [...], "ok": bool}</code>, one object per check with <code>name</code>/<code>status</code>/<code>detail</code>/<code>hint</code></td></tr>
+        <tr><th scope="row"><code>--no-color</code></th><td>off</td><td>Disable ANSI colors in the check list</td></tr>
+        <tr><th scope="row"><code>--json</code></th><td>off</td><td>Machine-readable output (CI-gateable): <code>{"checks": [...], "ok": bool}</code>, one object per check with <code>name</code>/<code>status</code>/<code>detail</code>/<code>hint</code></td></tr>
       </tbody>
     </table>
 

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html" class="active" aria-current="page">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html" class="active">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/compare.html
+++ b/docs/compare.html
@@ -33,29 +33,39 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html" class="active">Compare</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html" class="active" aria-current="page">Compare</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">
@@ -70,11 +80,11 @@
 
     <table>
       <thead>
-        <tr><th>Capability</th><th>Distil</th><th>Headroom</th><th>rtk</th><th>LLMLingua-2</th><th>Provider caching</th></tr>
+        <tr><th scope="col">Capability</th><th scope="col">Distil</th><th scope="col">Headroom</th><th scope="col">rtk</th><th scope="col">LLMLingua-2</th><th scope="col">Provider caching</th></tr>
       </thead>
       <tbody>
         <tr>
-          <td>Per-step statistical certificate</td>
+          <th scope="row">Per-step statistical certificate</th>
           <td><span class="badge-pass">✔</span> DERC (Learn-Then-Test / CRC)</td>
           <td><span class="badge-fail">✘</span> none published</td>
           <td><span class="badge-fail">✘</span> none published</td>
@@ -82,7 +92,7 @@
           <td>— not a compressor</td>
         </tr>
         <tr>
-          <td>Trajectory-level (task-outcome) certificate</td>
+          <th scope="row">Trajectory-level (task-outcome) certificate</th>
           <td><span class="badge-pass">✔</span> <code>distil certify-trajectories</code></td>
           <td><span class="badge-fail">✘</span></td>
           <td><span class="badge-fail">✘</span></td>
@@ -90,7 +100,7 @@
           <td>— not a compressor</td>
         </tr>
         <tr>
-          <td>Reversible (bytes recoverable on demand)</td>
+          <th scope="row">Reversible (bytes recoverable on demand)</th>
           <td><span class="badge-pass">✔</span> Tier-1 digest + handle, <code>distil_expand</code></td>
           <td><span class="badge-pass">✔</span> documents a local store + <code>headroom_retrieve</code>; the compression itself is lossy in-context (the configuration benchmarked in E8)</td>
           <td><span class="badge-fail">✘</span> lossy filtering (strips boilerplate; keeps raw logs on failure)</td>
@@ -98,7 +108,7 @@
           <td><span class="badge-pass">✔</span> trivially — nothing is removed</td>
         </tr>
         <tr>
-          <td>Live shadow decision-equivalence on real traffic</td>
+          <th scope="row">Live shadow decision-equivalence on real traffic</th>
           <td><span class="badge-pass">✔</span> <code>--shadow</code> / <code>shadow-stats</code></td>
           <td>not published</td>
           <td>not published</td>
@@ -106,7 +116,7 @@
           <td>— no decision risk to measure</td>
         </tr>
         <tr>
-          <td>SSE streaming pass-through (TTFT preserved)</td>
+          <th scope="row">SSE streaming pass-through (TTFT preserved)</th>
           <td><span class="badge-pass">✔</span> chunk-by-chunk relay</td>
           <td>n/a — library, not an HTTP relay</td>
           <td>n/a — CLI output proxy, not an LLM API relay</td>
@@ -114,7 +124,7 @@
           <td>n/a — no proxy layer in the path</td>
         </tr>
         <tr>
-          <td>Savings ledger + status line</td>
+          <th scope="row">Savings ledger + status line</th>
           <td><span class="badge-pass">✔</span> local ledger, <code>leaderboard</code>/<code>statusline</code></td>
           <td>not published</td>
           <td>not published</td>
@@ -122,7 +132,7 @@
           <td>— provider billing dashboard covers this natively</td>
         </tr>
         <tr>
-          <td>Multi-tenant gateway (per-tenant accounting)</td>
+          <th scope="row">Multi-tenant gateway (per-tenant accounting)</th>
           <td><span class="badge-pass">✔</span> <code>distil gateway</code></td>
           <td>not published</td>
           <td>not published</td>
@@ -146,34 +156,34 @@
     <p>Capability tables can't settle whether any of this holds up on a real, long-horizon coding agent. <a href="research.html#e8">E8</a> runs six conditions of the identical ReAct agent (only the compressor differs) end-to-end on the <strong>full 500-instance SWE-bench Verified set</strong>, scored by the <strong>official <code>swebench</code> harness</strong> (hidden tests, per-instance Docker) — not a proxy metric.</p>
 
     <table>
-      <thead><tr><th>Condition</th><th style="text-align:center">Task success</th><th style="text-align:center">Tied with full context?</th><th style="text-align:center">Reversible + certified?</th></tr></thead>
+      <thead><tr><th scope="col">Condition</th><th scope="col" style="text-align:center">Task success</th><th scope="col" style="text-align:center">Tied with full context?</th><th scope="col" style="text-align:center">Reversible + certified?</th></tr></thead>
       <tbody>
         <tr style="background:rgba(90,209,154,.16)">
-          <td><strong>Distil</strong> (gated + surprise digest, v1.7)</td>
+          <th scope="row"><strong>Distil</strong> (gated + surprise digest, v1.7)</th>
           <td style="text-align:center"><strong>42.0%</strong></td>
           <td style="text-align:center"><span class="badge-pass">✔ tied with full</span> <small>(paired CI &minus;0.6..+6.2pp)</small></td>
           <td style="text-align:center"><span class="badge-pass">✔</span></td>
         </tr>
         <tr style="background:rgba(90,209,154,.10)">
-          <td><strong>Distil</strong> (relevance-gated, E8)</td>
+          <th scope="row"><strong>Distil</strong> (relevance-gated, E8)</th>
           <td style="text-align:center"><strong>36.8%</strong></td>
           <td style="text-align:center"><span class="badge-pass">✔</span></td>
           <td style="text-align:center"><span class="badge-pass">✔</span></td>
         </tr>
         <tr>
-          <td>Headroom <span style="color:#5b6177">(lossy)</span></td>
+          <th scope="row">Headroom <span style="color:#5b6177">(lossy)</span></th>
           <td style="text-align:center">32.6%</td>
           <td style="text-align:center"><span class="badge-fail">✘ &minus;6.6&nbsp;pp</span></td>
           <td style="text-align:center"><span class="badge-fail">✘</span></td>
         </tr>
         <tr>
-          <td>LLMLingua-2 <span style="color:#5b6177">(lossy)</span></td>
+          <th scope="row">LLMLingua-2 <span style="color:#5b6177">(lossy)</span></th>
           <td style="text-align:center">2.4%</td>
           <td style="text-align:center"><span class="badge-fail">✘ &minus;36.8&nbsp;pp</span></td>
           <td style="text-align:center"><span class="badge-fail">✘</span></td>
         </tr>
         <tr>
-          <td>No compression <span style="color:#5b6177">(full)</span></td>
+          <th scope="row">No compression <span style="color:#5b6177">(full)</span></th>
           <td style="text-align:center">39.2%</td>
           <td style="text-align:center">&mdash;</td>
           <td style="text-align:center">&mdash;</td>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html" class="active">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html" class="active" aria-current="page">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/corpus.html
+++ b/docs/corpus.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html" class="active" aria-current="page">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html" class="active">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/deploy-security.html
+++ b/docs/deploy-security.html
@@ -36,31 +36,40 @@
 
   <!-- Sidebar -->
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html" class="active">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html" class="active" aria-current="page">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <!-- Main content -->
@@ -78,17 +87,17 @@
     <div class="tiers">
       <div class="tier">
         <div class="k">Topology 1</div>
-        <h4>Local dev sidecar</h4>
+        <h3>Local dev sidecar</h3>
         <p>Run <code>distil proxy</code> on your laptop alongside your application. Default bind is <code>127.0.0.1:8788</code> — not reachable from the network. Zero infra overhead.</p>
       </div>
       <div class="tier">
         <div class="k">Topology 2</div>
-        <h4>Container sidecar</h4>
+        <h3>Container sidecar</h3>
         <p>Add the proxy as a sidecar container in the same Pod or Compose stack. Your app container calls <code>http://localhost:8788</code>; only the sidecar egresses to the upstream API.</p>
       </div>
       <div class="tier">
         <div class="k">Topology 3</div>
-        <h4>Shared gateway</h4>
+        <h3>Shared gateway</h3>
         <p>Run one proxy instance accessible to multiple services on a private network. Bind to an internal interface (<code>--host 0.0.0.0</code>), keep it behind a firewall or service mesh, never expose it to the public internet.</p>
       </div>
     </div>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html" class="active">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html" class="active" aria-current="page">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -36,31 +36,40 @@
 
   <!-- Sidebar -->
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html" class="active">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html" class="active" aria-current="page">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <!-- Main content -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,8 @@
   table{width:100%;border-collapse:collapse;font-size:14px;margin-top:8px}
   th,td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line)}
   th{color:var(--dim);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.06em}
+  /* Row-header th cells (M3) carry scope="row" for AT but must render like the td they replace. */
+  th[scope="row"]{color:var(--ink);font-weight:400;font-size:inherit;text-transform:none;letter-spacing:normal}
   td .new{color:var(--acc);font-weight:700}
   .callout{background:linear-gradient(180deg,#0f1326,#0b0d16);border:1px solid #23284a;border-radius:16px;
     padding:22px;margin-top:8px}
@@ -106,7 +108,8 @@
   .tiers{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
   .tier{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:20px}
   .tier .k{font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--acc2)}
-  .tier h4{margin:8px 0 6px;font-size:16px}
+  /* N2: promoted from h4 (was a skipped level under the h2 above) to h3; kept visually identical. */
+  .tier h3{font-family:inherit;margin:8px 0 6px;font-size:16px;font-weight:700}
   .tier p{color:var(--mut);font-size:13px;margin:0}
   footer{padding:48px 0 70px;color:var(--dim);font-size:13px;border-top:1px solid var(--line)}
   .muted{color:var(--dim)}
@@ -441,6 +444,7 @@
   </script>
 </div></header>
 
+<main>
 <section id="why"><div class="wrap">
   <div class="seyebrow p">The difference</div>
   <h2 style="margin-top:0">Every other compressor <b class="w">trusts</b>.<br>Distil <b class="g">proves</b>.</h2>
@@ -567,11 +571,11 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <h2>Risk-graded tiers<a class="hlink" href="#tiers" aria-label="Link to this section">#</a></h2>
   <p class="lead">Apply the provably-safe ones everywhere; gate the rest on evidence.</p>
   <div class="tiers">
-    <div class="tier"><div class="k">Tier 0</div><h4>Provably lossless</h4>
+    <div class="tier"><div class="k">Tier 0</div><h3>Provably lossless</h3>
       <p>Reconstructable transforms — JSON minify, reversible run-length encoding. Always on.</p></div>
-    <div class="tier"><div class="k">Tier 1</div><h4>Reversible digest</h4>
+    <div class="tier"><div class="k">Tier 1</div><h3>Reversible digest</h3>
       <p>Decision-aware digest + a handle; the full original stays local and re-expands on demand.</p></div>
-    <div class="tier"><div class="k">Certified</div><h4>Lossy, but gated</h4>
+    <div class="tier"><div class="k">Certified</div><h3>Lossy, but gated</h3>
       <p>Pruning &amp; summarization allowed only at ratios the non-inferiority gate certifies.</p></div>
   </div>
 </div></section>
@@ -580,21 +584,25 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <div class="seyebrow">The cost stack</div>
   <h2>Capabilities <span class="g">— every layer of the cost stack</span><a class="hlink" href="#bestof" aria-label="Link to this section">#</a></h2>
   <table>
-    <tr><th>Capability</th><th>What it does</th><th>Loss profile</th></tr>
-    <tr><td>Priced cache-aware engine</td><td>Models the multi-turn loop and proves naive recompression busts the cache</td><td>—</td></tr>
-    <tr><td>Schema canonicalization</td><td>Recursively key-sorts JSON/tool payloads so the prefix is byte-stable</td><td>lossless</td></tr>
-    <tr><td>Volatile-field extraction</td><td>Lifts dates/UUIDs/JWTs out of the cached prefix so it stops churning</td><td>lossless · reversible</td></tr>
-    <tr><td>Reversible digest + handles</td><td>Originals stay local and re-expand on demand</td><td>reversible</td></tr>
-    <tr><td>Reject-if-bigger invariant</td><td>Never emits a block larger than its original</td><td>safety</td></tr>
-    <tr><td>Adversarial validation gate</td><td><code>distil validate</code> — drives the real compressor against hostile inputs and asserts reversibility, recency-exactness, fail-open, and content-free telemetry hold</td><td><span class="new">CI gate</span></td></tr>
-    <tr><td>Causal / counterfactual pruning</td><td>Ablation discovers context that never changes a decision</td><td><span class="new">certified</span></td></tr>
-    <tr><td>TOST non-inferiority gate (DERC)</td><td>Per-step: a strategy ships only if it passes the quality contract</td><td><span class="new">the moat</span></td></tr>
-    <tr><td>Trajectory-level certificate</td><td>Task-level: <code>distil certify-trajectories</code> bounds end-to-end degradation on matched full/compressed runs</td><td><span class="new">the differentiator</span></td></tr>
-    <tr><td>Savings ledger + leaderboard</td><td>Local-first, privacy-preserving cumulative savings</td><td>opt-in</td></tr>
-    <tr><td>Content-type keep policy</td><td>Pins each kind's load-bearing lines — a log's pass/fail verdict, a traceback's frames, a diff's hunk headers</td><td><span class="new">1.15</span></td></tr>
-    <tr><td>Query-aware salience</td><td>Sees the agent's intent in the same request and pins the line it's asking about — lexically (a grep hit, a SHA), and now <em>semantically</em>: a learned model keeps the line that <em>answers</em> the query with no shared word ("retry limit" → <code>max_attempts = 5</code>)</td><td><span class="new">1.16</span></td></tr>
-    <tr><td>Columnar fold</td><td>Re-encodes JSON record arrays into a compact self-describing table — real token savings even on a flat-rate plan</td><td>lossless</td></tr>
-    <tr><td>Session dissect</td><td><code>distil dissect</code> — per-session deep-dive with an anomaly list that catches silent failures automatically</td><td><span class="new">1.15</span></td></tr>
+    <thead>
+    <tr><th scope="col">Capability</th><th scope="col">What it does</th><th scope="col">Loss profile</th></tr>
+    </thead>
+    <tbody>
+    <tr><th scope="row">Priced cache-aware engine</th><td>Models the multi-turn loop and proves naive recompression busts the cache</td><td>—</td></tr>
+    <tr><th scope="row">Schema canonicalization</th><td>Recursively key-sorts JSON/tool payloads so the prefix is byte-stable</td><td>lossless</td></tr>
+    <tr><th scope="row">Volatile-field extraction</th><td>Lifts dates/UUIDs/JWTs out of the cached prefix so it stops churning</td><td>lossless · reversible</td></tr>
+    <tr><th scope="row">Reversible digest + handles</th><td>Originals stay local and re-expand on demand</td><td>reversible</td></tr>
+    <tr><th scope="row">Reject-if-bigger invariant</th><td>Never emits a block larger than its original</td><td>safety</td></tr>
+    <tr><th scope="row">Adversarial validation gate</th><td><code>distil validate</code> — drives the real compressor against hostile inputs and asserts reversibility, recency-exactness, fail-open, and content-free telemetry hold</td><td><span class="new">CI gate</span></td></tr>
+    <tr><th scope="row">Causal / counterfactual pruning</th><td>Ablation discovers context that never changes a decision</td><td><span class="new">certified</span></td></tr>
+    <tr><th scope="row">TOST non-inferiority gate (DERC)</th><td>Per-step: a strategy ships only if it passes the quality contract</td><td><span class="new">the moat</span></td></tr>
+    <tr><th scope="row">Trajectory-level certificate</th><td>Task-level: <code>distil certify-trajectories</code> bounds end-to-end degradation on matched full/compressed runs</td><td><span class="new">the differentiator</span></td></tr>
+    <tr><th scope="row">Savings ledger + leaderboard</th><td>Local-first, privacy-preserving cumulative savings</td><td>opt-in</td></tr>
+    <tr><th scope="row">Content-type keep policy</th><td>Pins each kind's load-bearing lines — a log's pass/fail verdict, a traceback's frames, a diff's hunk headers</td><td><span class="new">1.15</span></td></tr>
+    <tr><th scope="row">Query-aware salience</th><td>Sees the agent's intent in the same request and pins the line it's asking about — lexically (a grep hit, a SHA), and now <em>semantically</em>: a learned model keeps the line that <em>answers</em> the query with no shared word ("retry limit" → <code>max_attempts = 5</code>)</td><td><span class="new">1.16</span></td></tr>
+    <tr><th scope="row">Columnar fold</th><td>Re-encodes JSON record arrays into a compact self-describing table — real token savings even on a flat-rate plan</td><td>lossless</td></tr>
+    <tr><th scope="row">Session dissect</th><td><code>distil dissect</code> — per-session deep-dive with an anomaly list that catches silent failures automatically</td><td><span class="new">1.15</span></td></tr>
+    </tbody>
   </table>
 </div></section>
 
@@ -671,6 +679,7 @@ client = wrap(anthropic.Anthropic())  <span class="d"># compresses + keeps the c
     <a class="btn ghost" href="https://github.com/dshakes/distil">View on GitHub →</a>
   </div>
 </div></section>
+</main>
 
 <footer><div class="wrap">
   Distil · compression with a quality contract · stdlib-only core ·

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -36,31 +36,40 @@
 
   <!-- Sidebar -->
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html" class="active">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html" class="active" aria-current="page">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <!-- Main content -->

--- a/docs/learn-compression.html
+++ b/docs/learn-compression.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html" class="active">Token Economics</a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html" class="active" aria-current="page">Token Economics</a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/learn-distil.html
+++ b/docs/learn-distil.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html" class="active">Token Economics</a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html" class="active" aria-current="page">Token Economics</a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/learn-tokens.html
+++ b/docs/learn-tokens.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html" class="active">Token Economics</a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html" class="active" aria-current="page">Token Economics</a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/output.html
+++ b/docs/output.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html" class="active" aria-current="page">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html" class="active">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/research.html
+++ b/docs/research.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html" class="active">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html" class="active" aria-current="page">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">

--- a/docs/site.css
+++ b/docs/site.css
@@ -111,10 +111,15 @@ a { color: inherit; text-decoration: none; }
   backdrop-filter: blur(8px);
 }
 .sidebar-section {
-  font-size: 10px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase;
-  color: var(--dim); padding: 20px 12px 8px;
+  font-family: inherit; font-size: 10px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--dim); margin: 0; padding: 20px 12px 8px;
 }
+.sidebar-section::before { content: none; }
 .sidebar-section:first-child { padding-top: 4px; }
+/* The sidebar's link groups are real <ul>/<li> lists now (M2/N10); undo the
+   shared prose list styles so the visual result matches the old bare <a>s. */
+.sidebar ul { list-style: none; padding-left: 0; margin: 0; color: inherit; }
+.sidebar li { margin: 0; }
 .sidebar a {
   position: relative; display: block;
   padding: 7px 12px; margin: 1px 0; font-size: 13px;

--- a/docs/site.css
+++ b/docs/site.css
@@ -248,6 +248,15 @@ th {
 }
 td { padding: 11px 14px; border-bottom: 1px solid var(--line); color: var(--mut); vertical-align: top; }
 tr:last-child td { border-bottom: none; }
+/* Matrix-table row headers (M3): a th[scope=row] carries the same semantics
+   as a column th but must keep rendering like the plain td it replaces. */
+th[scope="row"] {
+  padding: 11px 14px; border-bottom: 1px solid var(--line); color: var(--mut); vertical-align: top;
+  background: transparent; font-weight: 400; font-size: inherit; text-transform: none; letter-spacing: normal;
+}
+th[scope="row"] strong, th[scope="row"] b { color: var(--ink); }
+th[scope="row"] code { font-size: 11.5px; }
+tr:last-child th[scope="row"] { border-bottom: none; }
 tbody tr { transition: background .12s; }
 tbody tr:hover { background: rgba(139,123,255,.04); }
 td strong, td b { color: var(--ink); }
@@ -275,7 +284,9 @@ td code { font-size: 11.5px; }
 }
 .tier:hover { transform: translateY(-3px); border-color: #2f3a5a; }
 .tier .k { font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--acc2); font-weight: 700; margin-bottom: 6px; }
-.tier h4 { font-size: 15px; margin: 6px 0 5px; color: var(--ink); }
+/* N2: these tier-card headings were <h4> straight under an <h2> (a skipped
+   level); promoted to <h3> in markup, kept visually identical here. */
+.tier h3 { font-family: inherit; font-size: 15px; font-weight: 700; margin: 6px 0 5px; color: var(--ink); }
 .tier p { color: var(--mut); font-size: 13px; }
 
 /* ── Stat boxes ────────────────────────────────────────────────────── */

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html" class="active">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html">Token Economics <span class="nav-badge">Start here</span></a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html" class="active" aria-current="page">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">← Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">← Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">
@@ -201,7 +210,7 @@ tokens provably free to drop: 615 across 2 block(s).</pre>
     <div class="tiers">
       <div class="tier">
         <div class="k">Tier 0</div>
-        <h4>Provably lossless</h4>
+        <h3>Provably lossless</h3>
         <p>Reconstructable transforms with no assumptions about content semantics. Applied unconditionally.</p>
         <ul style="margin-top:10px;font-size:13px;color:var(--mut)">
           <li>JSON minification</li>
@@ -212,7 +221,7 @@ tokens provably free to drop: 615 across 2 block(s).</pre>
       </div>
       <div class="tier">
         <div class="k">Tier 1</div>
-        <h4>Reversible digest</h4>
+        <h3>Reversible digest</h3>
         <p>Decision-aware digest: the compressed form embeds an 8-hex handle; the original is kept locally and re-expands on demand.</p>
         <ul style="margin-top:10px;font-size:13px;color:var(--mut)">
           <li>Large tool results (≥ 6 lines) digested</li>
@@ -223,7 +232,7 @@ tokens provably free to drop: 615 across 2 block(s).</pre>
       </div>
       <div class="tier">
         <div class="k">Certified</div>
-        <h4>Lossy, gated</h4>
+        <h3>Lossy, gated</h3>
         <p>Pruning applied only at ratios the non-inferiority gate certifies. Never ships without a TOST PASS.</p>
         <ul style="margin-top:10px;font-size:13px;color:var(--mut)">
           <li>Causal pruning (ablation-discovered)</li>

--- a/docs/token-economics.html
+++ b/docs/token-economics.html
@@ -33,31 +33,40 @@
 
 <div class="shell">
   <aside class="sidebar" id="sidebar">
-    <div class="sidebar-section">Getting started</div>
-    <a href="getting-started.html">Install &amp; Quickstart</a>
+    <nav aria-label="Documentation">
+      <h2 class="sidebar-section">Getting started</h2>
+      <ul>
+        <li><a href="getting-started.html">Install &amp; Quickstart</a></li>
+      </ul>
 
-    <div class="sidebar-section">Learn</div>
-    <a href="token-economics.html" class="active">Token Economics</a>
-    <a href="concepts.html">Concepts</a>
-    <a href="techniques.html">Techniques</a>
-    <a href="architecture.html">Architecture</a>
-    <a href="research.html">Research &amp; Frontier</a>
+      <h2 class="sidebar-section">Learn</h2>
+      <ul>
+        <li><a href="token-economics.html" class="active" aria-current="page">Token Economics</a></li>
+        <li><a href="concepts.html">Concepts</a></li>
+        <li><a href="techniques.html">Techniques</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="research.html">Research &amp; Frontier</a></li>
+        <li><a href="benchmark.html">Benchmark</a></li>
+        <li><a href="compare.html">Compare</a></li>
+        <li><a href="adoption.html">Adoption <span class="nav-badge">Live</span></a></li>
+      </ul>
 
-    <a href="benchmark.html">Benchmark</a>
-    <a href="compare.html">Compare</a>
-    <a href="adoption.html">Adoption <span class="nav-badge">Live</span></a>
+      <h2 class="sidebar-section">Reference</h2>
+      <ul>
+        <li><a href="cli.html">CLI Reference</a></li>
+        <li><a href="adapters.html">Adapters</a></li>
+        <li><a href="corpus.html">Corpus</a></li>
+        <li><a href="output.html">Output &amp; I/O</a></li>
+      </ul>
 
-    <div class="sidebar-section">Reference</div>
-    <a href="cli.html">CLI Reference</a>
-    <a href="adapters.html">Adapters</a>
-    <a href="corpus.html">Corpus</a>
-    <a href="output.html">Output &amp; I/O</a>
-
-    <div class="sidebar-section">More</div>
-    <a href="faq.html">FAQ</a>
-    <a href="integrations.html">Integrations</a>
-    <a href="deploy-security.html">Deploy &amp; Security</a>
-    <a href="index.html">&#8592; Landing page</a>
+      <h2 class="sidebar-section">More</h2>
+      <ul>
+        <li><a href="faq.html">FAQ</a></li>
+        <li><a href="integrations.html">Integrations</a></li>
+        <li><a href="deploy-security.html">Deploy &amp; Security</a></li>
+        <li><a href="index.html">&#8592; Landing page</a></li>
+      </ul>
+    </nav>
   </aside>
 
   <main class="content">


### PR DESCRIPTION
Hey team. This is the next installment in the accessibility series that started with #34. Like the earlier PRs, it's about structure, not looks: nothing here should look any different to a sighted user. If you spot a pixel out of place, that's a bug, please flag it.

## The why, in plain terms

Sighted users navigate a page by its visual layout: a sidebar on the left, section headings in bold, a table row lining up under its column header. Screen reader users get none of that for free. They rely on the page's underlying HTML to tell them "this is navigation," "this is a heading," "this cell belongs to this row and this column." When that structure is missing, the page still *looks* fine, but it becomes a maze for anyone not looking at it.

Two concrete examples from this codebase before this PR:

- The docs sidebar (all 20 pages) was just a box of links with no `<nav>` element and no lists. A screen reader announced it as generic "complementary" content, the same way it would announce a random sidebar ad. There was no way to jump straight to it, and the "Getting started / Learn / Reference / More" grouping you can see at a glance was invisible.
- The capability matrix on the Compare page, the flag tables in the CLI reference, and every table our Python modules generate (session reports, the gateway dashboard, the savings ledger) marked every cell as generic data. A screen reader landing on a checkmark in the "rtk" column had no idea it was answering "does rtk support per-step certificates" versus any other row. It just said "checkmark."

This PR fixes both of those, plus a few smaller structural gaps in the same family: two pages had heading levels that jumped from h2 straight to h4 (screen readers use headings the way sighted users use font size to skim a page), the landing page had no `<main>` landmark for "skip to the content," and the live savings dashboard (`webdash.py`) had no heading at all and no link between a metric's number and its label.

## What changed

1. **Docs sidebar** (all 20 pages that have it): the `<aside class="sidebar" id="sidebar">` wrapper is untouched (the mobile toggle and shared CSS depend on that exact id and class), but its contents are now `<nav aria-label="Documentation">` with real `<ul>`/`<li>` lists, and the section labels ("Getting started," "Learn," etc.) are headings instead of styled divs. The active page's link gets `aria-current="page"`.
2. **Table headers**: every matrix-style table (Compare's two comparison tables, the landing page's capabilities table, Benchmark's three standings tables, and all 25 flag-reference tables in the CLI docs) now marks its row label as `<th scope="row">` and its column headers as `<th scope="col">`. A small CSS rule makes sure the row-header cell still looks exactly like the plain cell it replaced, not like a bold little column heading.
3. **Generated report tables** (`dissect.py`, `gateway.py`, `telemetry.py`, `benchmark.py`, `ledger.py`): every table gets `scope="col"` headers and a short caption naming the table (visually hidden, since a visible one would change the design). The gateway dashboard's TOTAL row moves from a bold row in the middle of the data into a proper `<tfoot>` with `th scope="row"`.
4. **Heading levels**: `deploy-security.html`, `techniques.html`, and the landing page had teaser cards using `<h4>` directly under an `<h2>`, skipping `<h3>` entirely. Promoted to `<h3>` with a matching CSS rule so they render identically.
5. **Landmarks**: the landing page's main content is now wrapped in `<main>`, matching every other docs page.
6. **webdash.py**: the page label is now a real `<h1>`, the card is wrapped in `<main>`, and each metric tile's value is linked to its label with `aria-labelledby`.

## Zero visual changes

This is the part I want to be most upfront about, since it's easy to say and harder to prove. For every markup change here, I added or adjusted CSS so nothing shifts: the sidebar's link groups are `list-style: none` with the same padding and margins as before, promoted headings get font-family/size/weight overrides so they render identically to the old tags, and the new table row-headers get their column-header styling stripped back down to plain-cell styling. I checked this in a real browser (screenshots, computed styles at both desktop and mobile widths) rather than just eyeballing the diff, and I caught and fixed one real bug in the process: my first pass hardcoded a font size on the new row-header cells that didn't track the mobile breakpoint's smaller table font, which would have made row labels look slightly larger than the data next to them on narrow screens. Fixed before landing.

One small, known side effect: promoting those teaser-card headings to real `<h3>` means the shared "on this page" table-of-contents script now picks them up (it only scans `h2`/`h3`), so on `deploy-security.html` the TOC gets a duplicate "Local dev sidecar" entry (the teaser card and the full section below share that title). This is a pre-existing site-wide issue with duplicate heading IDs (the TOC script doesn't de-duplicate slugs yet, cli.html already has this same problem with 24 "Flags" headings): not something this PR introduces, but worth knowing it now touches one more page. (#35 in this series fixes the underlying slug de-duplication, so once both land, the two entries at least get unique ids and correct scroll targets.)

## Gates

- **Lint** (`uvx ruff check distil tests`): 428 errors both before and after this branch. All pre-existing; nothing new. I ran `ruff check` on every Python file I touched individually and confirmed the count matches its own baseline.
- **Tests** (`uv run pytest -q`): 1844 passed, 3 skipped, both before my changes and after. No test assertions on table markup existed to update; I grepped `tests/` for `th`, `caption`, and `scope=` first to confirm.
- **Browser verification**: held the shared Playwright lock, served my worktree's `docs/` on port 8648, and checked: sidebar renders pixel-identical (screenshot + computed styles for list-style, margins, font-family, the accent-bar pseudo-element), the `nav` landmark and `aria-current="page"` are present in the accessibility tree, the mobile sidebar toggle still opens/closes correctly, `compare.html`'s row headers announce as `rowheader`/`columnheader` in the accessibility tree, `index.html` renders unchanged with its new `main` and `thead`, and the tier-card promotions on three pages render with identical font metrics. For the Python templates, rendered all five modules with real fixture data to files and confirmed captions, `scope`, and the gateway `tfoot` are all present and correctly structured.
- **Deviations**: none from the assigned findings. Two things worth flagging for the reviewer: the row-header font-size bug mentioned above (fixed), and the duplicate-TOC-entry side effect (pre-existing, unfixed, out of this PR's scope).

Branch: `fix/a11y-semantics`. Four commits, one per logical group of findings.
