### PR TITLE
release(1.34.0): count contributors, not consenters; one number for your savings

### DIFF
--- a/.github/workflows/sdlc-qa.yml
+++ b/.github/workflows/sdlc-qa.yml
@@ -44,6 +44,13 @@ jobs:
             ~/.cargo/git
           key: qa-deps-${{ runner.os }}-${{ hashFiles('**/go.sum', '**/package-lock.json', '**/pnpm-lock.yaml', '**/Cargo.lock', '**/requirements*.txt', '**/uv.lock', '**/poetry.lock') }}
           restore-keys: qa-deps-${{ runner.os }}-
+      # The generic runner ships no uv, but this repo's `make test` is `uv run
+      # pytest`, so the step below died with "make: uv: No such file or
+      # directory" before a single test ran. Install it when the repo declares
+      # it, so the auto-detected `make test` path actually works here.
+      - name: Set up uv
+        if: hashFiles('uv.lock', 'pyproject.toml') != ''
+        uses: astral-sh/setup-uv@v8.3.2
       - name: Run test suite
         id: test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [Unreleased] — say whose savings those are
+
+The counter fix in 1.33.1 stopped the community total moving backwards. This is
+the other half of the same problem: what that total actually *means*.
+
+**Consenting is not contributing.** The adoption page counted every machine that
+had turned the census on as a machine that was saving. On the real data that
+made "2 machines saving now" out of one machine with 1.6B tokens and one that
+had reported `tokens_saved: 0` twice and never run anything. The rollup now
+emits `contributing` (installs that have actually reported savings) alongside
+`instances`, and the page uses it: the headline reads "from 1 machine", the
+install tile reads "1 of 2 have reported savings · 1 opted in but idle", and
+below five contributors the hero carries an explicit small-sample notice —
+*this is one real ledger, not a community aggregate*. Aggregates written before
+the field existed make **no** claim rather than falling back to the consent
+count, which is the overstatement this removes.
+
+**Your savings, one number.** `distil dashboard --web` computed savings as
+lifetime-raw × *current* calibration factor, the exact method `census.py`
+documents as wrong: it restates every token already earned whenever calibration
+refines, so the number on screen can drop without a token being un-saved. It
+also disagreed with the census on the same machine — 1,522,590,876 against
+1,491,058,879. Both now read the count-time accrued total through
+`census.accrued_tokens()`, so your dashboard, your census payload, and the
+community rollup are the same figure.
+
+**Most users are never asked.** Consent is offered in exactly one place —
+inside `distil onboard`, at a TTY. Anyone who went from `uvx`/`pipx` straight to
+`distil wrap` was never asked at all, which is most of them. `distil stats` now
+mentions the census once, only to someone with real savings to contribute, only
+at a terminal, never twice, and silent under `DO_NOT_TRACK`. It does not send
+anything and does not grant consent — ignoring it leaves you un-asked.
+
 ## [1.33.1] — the zipapp can name itself
 
 `distil.pyz` — a release asset offered as the install path for anyone PyPI is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
-## [Unreleased] — say whose savings those are
+## [1.34.0] — say whose savings those are
 
 The counter fix in 1.33.1 stopped the community total moving backwards. This is
 the other half of the same problem: what that total actually *means*.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.33.1
+version: 1.34.0rc1
 date-released: 2026-07-26
 keywords:
   - llm

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.34.0rc1
+version: 1.34.0
 date-released: 2026-07-26
 keywords:
   - llm

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -24,6 +24,18 @@ It is **off until you say yes** — either `distil census on` or answering the
 one-time question in `distil onboard` (declining is recorded; you are never
 asked again; `--yes` does *not* consent for you).
 
+**Only an answer counts as an answer.** If you interrupt that question with
+Ctrl-C, or `onboard` runs with stdin piped, nothing is recorded — you stay
+un-asked and can decide later. (Until 1.33.x an interrupted prompt was stored
+as a refusal, which quietly spent the one chance to ask.)
+
+Because that question only appears inside `distil onboard`, and only at a
+terminal, most installs are never asked at all. So `distil stats` mentions the
+census **once**, and only if you have real savings to contribute. It prints a
+line and nothing else: it never sends anything, never grants consent, is silent
+when piped or when `DO_NOT_TRACK` is set, and is never shown twice. Ignoring it
+leaves you un-asked, exactly as before.
+
 ### Exactly what is sent
 
 At most **one JSON object per 24 hours**, fired from the proxy/wrap shutdown

--- a/distil/census.py
+++ b/distil/census.py
@@ -207,6 +207,46 @@ def _parse_savings(text: str) -> dict:
     return fresh
 
 
+def _invite_path() -> Path:
+    return _home() / "census-invite"
+
+
+def invite_seen() -> bool:
+    """Whether the one-time census invite has already been shown."""
+    return _invite_path().exists()
+
+
+def mark_invite_seen() -> None:
+    """Record that the invite was shown, so it is shown exactly once.
+
+    Deliberately separate from `consent`: seeing the invite is not answering it.
+    A user who ignores it stays un-asked (`consent() is None`) and can still opt
+    in later, but is never shown the same nudge twice.
+    """
+    try:
+        p = _invite_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("1", encoding="utf-8")
+    except OSError:
+        pass  # fail-open: worst case the invite prints once more
+
+
+def accrued_tokens() -> int | None:
+    """The count-time accrued token total, or None if nothing has accrued yet.
+
+    This is the figure the census and the heartbeat report: each delta banked at
+    the factor known when it was earned, so it never restates history. Local
+    surfaces ("your savings") read it through here so the number a user sees in
+    `distil dashboard` is the same one the community total is built from, rather
+    than lifetime×current-factor — which silently shrinks as calibration refines.
+
+    Read-only: never creates or advances state, so it is safe to call regardless
+    of consent (and returns None once `census off` has deleted the state).
+    """
+    saved = float(_load_savings().get("tokens", {}).get("saved") or 0.0)
+    return round(saved) if saved > 0 else None
+
+
 def _load_savings() -> dict:
     """Persisted accrual state. Each channel remembers the raw total already
     banked (`raw_seen`) and the frozen calibrated cumulative (`saved`, a float

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -304,7 +304,62 @@ def cmd_leaderboard(args: argparse.Namespace) -> int:
         "\n(local-first; export a page with --html, or share verifiably with "
         "`distil federated-leaderboard`.)"
     )
+    _census_invite(s)
     return 0
+
+
+# How much a user must have saved before the census is worth mentioning. Below
+# this the invite is noise; above it the number is worth contributing.
+INVITE_MIN_TOKENS = 100_000
+
+
+def _is_tty() -> bool:
+    """Whether stdout is a terminal — a seam so this stays testable.
+
+    pytest reinstalls its own captured `sys.stdout` for the call phase, and that
+    object is a TextIOWrapper, which accepts no instance attributes: `isatty`
+    can be patched neither on the instance nor on the type. One indirection is
+    cheaper than a test that cannot express "the user is at a terminal".
+    """
+    return sys.stdout.isatty()
+
+
+def _census_invite(s: Any) -> None:
+    """Mention the census once, to someone who has something to contribute.
+
+    Consent was only ever offered inside `distil onboard`, in a TTY. Anyone who
+    installed with `uvx`/`pipx` and went straight to `distil wrap` was never
+    asked at all — which is why the community total is built from a handful of
+    machines while the download count is orders of magnitude larger.
+
+    This does not weaken consent: it is opt-IN, printed once, never assumed, and
+    silent for anyone who has already answered, set a kill switch, or is being
+    piped somewhere. Declining is still a deliberate act; so is ignoring it.
+    """
+    try:
+        from . import census as _census
+
+        if (
+            not _is_tty()
+            or _census.consent() is not None
+            or _census.hard_disabled()
+            or s.total_tokens_saved < INVITE_MIN_TOKENS
+            or _census.invite_seen()
+        ):
+            return
+        import os as _os
+
+        color = _os.environ.get("NO_COLOR") is None
+
+        def c(code: str, t: str) -> str:
+            return f"\033[{code}m{t}\033[0m" if color else t
+
+        _census.mark_invite_seen()
+        print(c("90", "\nYour savings are local and stay local. If you'd like them counted in the"))
+        print(c("90", "public community total: ") + c("1", "distil census on"))
+        print(c("90", "  content-free, numbers only, one JSON/day · preview: distil census show"))
+    except Exception:  # noqa: BLE001 — an invite must never break `stats`
+        pass
 
 
 def cmd_prune(args: argparse.Namespace) -> int:

--- a/distil/onboard.py
+++ b/distil/onboard.py
@@ -145,6 +145,8 @@ def is_outdated(installed: str, latest: str | None) -> bool:
     """True if a newer *released* version than ``installed`` is available."""
     if not latest:
         return False
+    if installed == latest:
+        return False  # nothing is newer than itself, pre-release or not
     bi, pre_i = _ver_tuple(installed)
     bl, _pre_l = _ver_tuple(latest)
     if bi != bl:

--- a/distil/webdash.py
+++ b/distil/webdash.py
@@ -37,8 +37,16 @@ def _snapshot() -> dict:
     )
     eq = _equivalence()
     sub = _subscription()
+    # Prefer the count-time accrued total — the same monotonic figure the census
+    # reports — so "your savings" reads identically here, in the census, and in
+    # the community rollup. lifetime×current-factor (the fallback) restates every
+    # token already earned whenever calibration refines, so the number a user is
+    # watching can drop without a single token being un-saved.
+    from . import census as _census
+
+    accrued = _census.accrued_tokens()
     return {
-        "tokens_saved": round(tokens * f),
+        "tokens_saved": accrued if accrued is not None else round(tokens * f),
         "dollars_saved": round(dollars * f, 2),
         "pct": round(pct, 1),
         "runs": s.runs,

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -127,6 +127,11 @@
   .rate .muted{color:var(--dim)}
   .hero-sub{color:var(--mut);font-size:13px;margin-top:12px;line-height:1.5}
   .hero-sub b{color:var(--ink)}
+  /* Sample-size disclosure. A total summed from one machine is a real number
+     but it is not a community number, and the page has to say which it is
+     before the reader assumes. Shown only while the sample is small. */
+  .hero-caveat{margin-top:10px;padding:9px 12px;border-radius:9px;
+    border:1px solid #4a3a12;background:#161207;color:#e8b34b;font-size:12.5px;line-height:1.45}
   /* trust ring */
   .trust{display:flex;flex-wrap:wrap;align-items:center;gap:22px 30px;margin-top:18px;padding-top:18px;border-top:1px solid var(--line)}
   .ring-wrap{display:flex;align-items:center;gap:16px;flex:1 1 340px;min-width:0}
@@ -232,11 +237,13 @@
           </div>
           <div class="spark" id="spark"></div>
           <div class="hero-sub">
-            The community total from opted-in ledgers, calibration-corrected, never estimated. It's an
+            Summed from <b id="hero-machines">&mdash;</b> that opted in and have actually reported
+            savings, calibration-corrected, never estimated. It's an
             <b>exact cumulative</b>, summed fresh on every read — the digits move only when a real
             heartbeat or census (content-free, every ~5&nbsp;min) reports genuinely more saved, and
             <b>sit static while everyone idles</b>. No per-day projection, no invented growth. Worth
             <b id="hero-notional">&mdash;</b> at metered API rates.
+            <div id="hero-sample" class="hero-caveat" hidden></div>
           </div>
         </div>
         <div class="trust">
@@ -259,7 +266,7 @@
     </div>
 
     <div class="astats">
-      <div class="astat pu"><div class="n" id="t-active">–</div><div class="l">Active installs &middot; 30d</div><div class="foot">opt-in census &middot; one per machine &middot; bot-proof by construction</div></div>
+      <div class="astat pu"><div class="n" id="t-active">–</div><div class="l">Active installs &middot; 30d</div><div class="foot"><b id="t-contributing">–</b> reporting savings &middot; <span id="t-active-foot">opt-in census &middot; one per machine</span></div></div>
       <div class="astat hl"><div class="n" id="t-dollars-real">–</div><div class="l">Real $ saved &middot; metered</div><div class="foot">plus <b id="t-notional">–</b> notional API-rate value from flat-rate subscriptions</div></div>
       <div class="astat"><div class="n" id="t-real">–</div><div class="l">PyPI installs / month</div><div class="foot">bot-filtered <b>download events</b> (incl. CI &amp; upgrades) — not unique users; the census tile is the provable-users number</div></div>
       <div class="astat"><div class="n" id="t-shapes">–</div><div class="l">API shapes seen</div><div class="foot">distinct SDK wire formats across the fleet — Anthropic / OpenAI / Gemini</div></div>
@@ -513,11 +520,15 @@
         // No rate projection ("there is no honest amount of rate-projection"): a
         // per-interval heartbeat rate ×86400 is phantom "/day" growth from idle
         // machines. Show the honest live pulse — how many machines are saving now.
-        var act = d.active || 0;
+        // "saving now" must mean *saving*, not *consenting*. A heartbeat only
+        // fires when tokens actually grew, so d.active is already contributors
+        // only — but prefer an explicit count when the endpoint sends one, and
+        // never let the consent count stand in for it.
+        var act = (d.saving != null ? d.saving : d.active) || 0;
         set("rate-sec", act > 0 ? commas(act) + (act === 1 ? " machine" : " machines") : "exact");
         set("rate-day", act > 0
           ? "saving now · exact total, moves only when it truly rises"
-          : "no machines active right now · exact total");
+          : "no machines saving right now · exact total");
         set("hero-state", act > 0 ? "live" : "exact");
       } else {
         liveBase = null; // empty/unavailable store → census exact total
@@ -570,6 +581,42 @@
     set("ms-runs", commas(s.total_runs || 0));
     set("ms-avg", human(s.avg_per_run) || "—");
     set("t-active", human(a.installs.active_30d));
+
+    // Provenance of the headline total. `contributing` counts installs that have
+    // actually reported savings — consenting is not contributing, and one idle
+    // opt-in must never be counted into a "community" story. Aggregates written
+    // before that field existed simply do not know: say "machines" and make no
+    // claim about how many reported, rather than substituting the consent count
+    // (which is the very overstatement this exists to remove).
+    var contrib = s.contributing != null ? s.contributing : null;
+    var consented = a.installs.census_total || 0;
+    set("hero-machines", contrib == null
+      ? "the machines"
+      : (contrib === 1 ? "1 machine" : commas(contrib) + " machines"));
+    set("t-contributing", contrib == null ? "—" : commas(contrib));
+    var idle = contrib == null ? 0 : Math.max(0, consented - contrib);
+    set("t-active-foot", contrib == null
+      ? "opt-in census · one per machine"
+      : (commas(contrib) + " of " + commas(consented) + " have reported savings"
+         + (idle ? " · " + commas(idle) + " opted in but idle" : "")));
+    var caveat = document.getElementById("hero-sample");
+    if (caveat) {
+      if (contrib == null) {
+        caveat.hidden = true;  // unknown sample size — assert nothing
+      } else if (contrib <= 1) {
+        caveat.innerHTML = "<b>Small sample.</b> This total comes from a single opted-in machine, "
+          + "so read it as one real ledger — not a community aggregate. The number is exact; "
+          + "the sample is not yet representative.";
+        caveat.hidden = false;
+      } else if (contrib < 5) {
+        caveat.innerHTML = "<b>Small sample.</b> " + commas(contrib) + " machines reporting. "
+          + "Exact, but not yet representative of the wider fleet.";
+        caveat.hidden = false;
+      } else {
+        caveat.hidden = true;
+      }
+    }
+
     set("t-dollars-real", "$" + (human(s.dollars) || "0"));
     set("t-notional", "$" + human(s.dollars_notional));
     set("t-real", human(pd.real_os_30d));

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.33.1",
+  "version": "1.34.0rc1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.34.0rc1",
+  "version": "1.34.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.34.0rc1"
+version = "1.34.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.33.1"
+version = "1.34.0rc1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/scripts/census_rollup.py
+++ b/scripts/census_rollup.py
@@ -92,6 +92,20 @@ def rollup(metrics_dir: Path, now: float | None = None) -> dict:
     def active(days: int) -> int:
         return sum(1 for r in latest.values() if now - r["ts"] <= days * 86400)
 
+    def contributing(days: int) -> int:
+        """Installs that are active AND have actually saved something.
+
+        Consenting is not contributing: a machine can turn the census on and
+        never run anything, and two of those look identical in `active_30d`.
+        The page says "N machines saving" — that claim needs this number, not
+        the consent count, or one idle opt-in inflates the community story.
+        """
+        return sum(
+            1
+            for r in latest.values()
+            if now - r["ts"] <= days * 86400 and int(r.get("tokens_saved") or 0) > 0
+        )
+
     # MEASURED community savings rate: for each install with >=2 pings, the
     # token delta over the time delta between its two most recent censuses
     # (dropping resets where tokens went backwards), summed across installs.
@@ -201,6 +215,10 @@ def rollup(metrics_dir: Path, now: float | None = None) -> dict:
             "census_total": len(latest),
             "active_7d": active(7),
             "active_30d": active(30),
+            # Machines that actually saved something, not just consented. The
+            # savings tiles must never count an idle opt-in as a contributor.
+            "contributing_7d": contributing(7),
+            "contributing_30d": contributing(30),
             "by_version": dict(versions.most_common()),
         },
         "savings": {
@@ -208,6 +226,7 @@ def rollup(metrics_dir: Path, now: float | None = None) -> dict:
             "dollars": dollars_real,
             "dollars_notional": dollars_notional,
             "instances": len(latest),
+            "contributing": sum(1 for r in latest.values() if int(r.get("tokens_saved") or 0) > 0),
             # Live-projection inputs — all measured, none estimated:
             "as_of_ts": as_of_ts,  # the token total is exact as of this ts
             "rate_per_sec": round(rate_per_sec, 2),  # measured Δtokens/Δt

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.34.0rc1",
+  "version": "1.34.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.34.0rc1",
+      "version": "1.34.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.33.1",
+  "version": "1.34.0rc1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.33.1",
+      "version": "1.34.0rc1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -313,6 +313,95 @@ def test_concurrent_writers_never_lower_the_total(monkeypatch):
     assert on_disk > 0
 
 
+class _Sum:
+    def __init__(self, tokens):
+        self.total_tokens_saved = tokens
+
+
+@pytest.fixture
+def tty(monkeypatch):
+    """Claim stdout is a terminal. The invite is TTY-only so it never lands in a
+    pipe or a CI log, and pytest's captured stdout is not a TTY."""
+    from distil import cli
+
+    monkeypatch.setattr(cli, "_is_tty", lambda: True)
+
+
+def test_invite_offers_the_census_once_to_someone_with_savings(tty, capsys):
+    """Consent was only ever offered inside `distil onboard`, in a TTY — anyone
+    who went straight from `uvx`/`pipx` to `distil wrap` was never asked."""
+    from distil import cli
+
+    assert census.consent() is None
+    cli._census_invite(_Sum(5_000_000))
+    assert "distil census on" in capsys.readouterr().out
+    # Shown once. A second `distil stats` must be silent.
+    cli._census_invite(_Sum(5_000_000))
+    assert capsys.readouterr().out == ""
+
+
+def test_invite_never_grants_consent(tty, capsys):
+    """Seeing the invite is not answering it: the user stays un-asked and can
+    still opt in (or never) — the invite must not become a silent opt-in."""
+    from distil import cli
+
+    cli._census_invite(_Sum(5_000_000))
+    assert "distil census on" in capsys.readouterr().out
+    assert census.consent() is None
+    assert not census.enabled()
+
+
+def test_invite_is_silent_when_already_answered_or_disabled(tty, monkeypatch, capsys):
+    from distil import cli
+
+    census.opt_out()  # already answered
+    cli._census_invite(_Sum(5_000_000))
+    assert capsys.readouterr().out == ""
+
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    (census._home() / "census").unlink()  # back to un-asked
+    cli._census_invite(_Sum(5_000_000))
+    assert capsys.readouterr().out == "", "DO_NOT_TRACK must silence the invite too"
+
+
+def test_invite_is_silent_below_the_savings_threshold(tty, capsys):
+    from distil import cli
+
+    cli._census_invite(_Sum(cli.INVITE_MIN_TOKENS - 1))
+    assert capsys.readouterr().out == ""
+
+
+def test_stats_actually_shows_the_invite(tty, monkeypatch, capsys):
+    """Wiring test: the invite must reach the user through `distil stats`, not
+    just exist as a function nobody calls."""
+    import argparse
+
+    from distil import cli, ledger
+
+    summary = ledger.LedgerSummary(
+        runs=3,
+        total_dollars_saved=1.5,
+        total_tokens_saved=5_000_000,
+        by_trajectory={"live-proxy": 1.5},
+        total_baseline_tokens=10_000_000,
+        total_distil_tokens=5_000_000,
+        total_baseline_dollars=3.0,
+        total_distil_dollars=1.5,
+    )
+    monkeypatch.setattr(ledger, "summary", lambda *a, **k: summary)
+    args = argparse.Namespace(badge=False, html=None, json=False)
+    assert cli.cmd_leaderboard(args) == 0
+    assert "distil census on" in capsys.readouterr().out
+
+
+def test_invite_is_silent_without_a_tty(capsys):
+    """Piped into a file or a CI log, `distil stats` stays clean."""
+    from distil import cli
+
+    cli._census_invite(_Sum(5_000_000))
+    assert capsys.readouterr().out == ""
+
+
 def _seed_ledger(tmp_path, rows):
     """Write a savings.jsonl the census helpers read via ledger.default_path()."""
     import json as _json

--- a/tests/test_census_pipeline.py
+++ b/tests/test_census_pipeline.py
@@ -144,6 +144,29 @@ def test_rollup_active_windows(tmp_path):
     assert agg["installs"]["census_total"] == 3
 
 
+def test_rollup_separates_consenting_from_contributing(tmp_path):
+    """Consenting is not contributing. A machine can turn the census on and
+    never run anything — counting it as a machine that is "saving" is how one
+    idle opt-in turned a single real ledger into a two-machine community story.
+    """
+    now = int(time.time())
+    rows = [
+        _row(install_id="a" * 32, ts=now, tokens_saved=1_600_000_000),
+        _row(install_id="b" * 32, ts=now, tokens_saved=0, runs=0),  # opted in, idle
+        _row(install_id="c" * 32, ts=now - 86400 * 90, tokens_saved=500),  # stale
+    ]
+    agg = census_rollup.rollup(_write_metrics(tmp_path, rows, []), now=now)
+
+    assert agg["installs"]["census_total"] == 3
+    assert agg["installs"]["active_30d"] == 2  # a and b are recent…
+    assert agg["installs"]["contributing_30d"] == 1  # …but only a has saved anything
+    assert agg["installs"]["contributing_7d"] == 1
+    assert agg["savings"]["instances"] == 3
+    assert agg["savings"]["contributing"] == 2, "stale-but-nonzero still contributed"
+    # The headline total is unaffected — this changes what we CLAIM, not the sum.
+    assert agg["savings"]["tokens"] == 1_600_000_500
+
+
 def test_rollup_drops_invalid_rows_and_survives_corruption(tmp_path):
     now = int(time.time())
     valid = _row(install_id="a" * 32, ts=now)

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -128,6 +128,12 @@ def test_is_outdated_semantics() -> None:
         onboard.is_outdated("1.3.0.dev0", "1.3.0") is True
     )  # pre-release of the release → upgrade
     assert onboard.is_outdated("1.3.0", None) is False  # offline / check failed
+    # A pre-release compared to ITSELF is not outdated. Same base + "ours is a
+    # pre-release" used to short-circuit to True, so anyone running an rc that
+    # PyPI also reported as latest was nagged to upgrade to what they had.
+    assert onboard.is_outdated("1.34.0rc1", "1.34.0rc1") is False
+    assert onboard.is_outdated("1.34.0rc1", "1.34.0") is True  # …but the GA is newer
+    assert onboard.is_outdated("1.34.0rc1", "1.33.1") is False  # …and rc leads last stable
 
 
 def test_upgrade_command_per_method() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.33.1"
+version = "1.34.0rc1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.34.0rc1"
+version = "1.34.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Follows 1.33.1, which stopped the community total moving backwards. This is the other half of the same problem — what that total *means*, and whose it is.

## Consenting is not contributing

The adoption page counted every machine that had turned the census on as a machine that was *saving*. On the real data that produced **"2 machines saving now"** out of:

| install | pings | tokens saved | runs |
|---|---|---|---|
| `ccdd6de1` | 9 | 1,612,162,250 | 7,678 |
| `3867672e` | 2 | **0** | **0** |

One machine has ever saved a token. `census_rollup` now emits `contributing` (installs that have actually reported savings) beside `instances`, and the page uses it — verified in-browser against the real aggregate:

- hero: **"from 1 machine"**
- tile: `1` contributing / `2` active
- foot: **"1 of 2 have reported savings · 1 opted in but idle"**
- under five contributors, an explicit notice: *one real ledger, not a community aggregate*

Aggregates written before the field make **no** claim rather than falling back to the consent count — that fallback reproduced the exact overstatement being removed, and was caught mid-test.

## Your savings, one number

`webdash` computed savings as lifetime-raw × **current** calibration factor — the method `census.py:156` documents as wrong, because it restates every token already earned whenever calibration refines. It also disagreed with the census on the same machine: **1,522,590,876 vs 1,491,058,879**. Both now read the count-time accrued total via `census.accrued_tokens()`; verified they match to the token.

## Most users are never asked

Consent is offered in exactly one place — inside `distil onboard`, at a TTY. Anyone going `uvx`/`pipx` → `distil wrap` was never asked. `distil stats` now mentions the census **once**, only to someone with real savings, only at a terminal, never twice, silent under `DO_NOT_TRACK`. It sends nothing and grants nothing: ignoring it leaves you un-asked.

## Also fixed

`is_outdated(x, x)` returned **True** for a pre-release — anyone running an rc that PyPI also reported as latest was told to upgrade to what they already had. Surfaced by this very bump turning `test_updatecheck.py::test_silent_when_current` red.

## Verification

- `1902 passed, 2 skipped` · `GATE: PASS` · `FIDELITY: PASS` · lint clean at CI's pinned ruff
- Every new test verified to **fail** without its fix, including unwiring the invite from `stats`
- Page validated in a real browser against both aggregate shapes (with and without `contributing`)

`_is_tty()` exists as a seam because pytest reinstalls a `TextIOWrapper` for the call phase, which accepts no instance attributes — `isatty` can be patched neither on the instance nor the type, so the behaviour was otherwise untestable.

## Release note

Tagged `rc1` per `RELEASING.md`: this changes runtime behaviour (dashboard figure, `stats` output, census locking), so it soaks before GA. The CHANGELOG is headed `[1.34.0]` — the version the rc soaks for.