### PR TITLE
fix(release): restore the publishing pipeline; stop the npm version drifting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,154 +1,215 @@
 name: release
 
-# One-click release: tag → publish GitHub Release (notes from CHANGELOG) → open the
-# Homebrew formula-bump PR. Runs on GitHub's runners, which have the ref-write access a
-# local/sandboxed clone may not — so "cut a release" becomes a single tap from the
-# Actions tab or GitHub Mobile (Run workflow), no terminal required.
-#
-# The formula bump lands as a PR (main is branch-protected) — merge it to point
-# `brew install` at the new tag. Mirrors scripts/release.sh; idempotent (safe to re-run).
-
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release, e.g. v0.10.1. Leave blank to use the newest [X.Y.Z] heading in CHANGELOG.md."
-        required: false
-        default: ""
+  push:
+    tags: ["v*"]
+  # Manual release: lets a maintainer (or CI) cut the release for the version in
+  # pyproject without pushing a tag from a restricted environment. The job creates
+  # the matching tag + GitHub release and publishes to PyPI.
+  workflow_dispatch: {}
 
 permissions:
-  contents: write          # create + push the tag, publish the Release
-  pull-requests: write     # open the Homebrew formula-bump PR
-
-concurrency:
-  group: release
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
-          fetch-depth: 0     # full history so the tag + CHANGELOG parsing work
-
-      - name: Resolve version
+          python-version: "3.12"
+      - name: Resolve version from pyproject
         id: ver
-        env:
-          IN: ${{ inputs.version }}
+        # sed (not `cut -d'"'`, which mis-parsed the quote and yielded an empty
+        # version → a release literally named "v"). Fail loudly if empty so a
+        # bad version can never silently create/clobber the wrong release.
         run: |
-          set -euo pipefail
-          v="$IN"
-          if [ -z "$v" ]; then
-            v="v$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | tr -dc '0-9.')"
-          fi
-          case "$v" in v*) ;; *) v="v$v" ;; esac
-          [ "$v" != "v" ] || { echo "could not resolve a version (pass one, or add a [X.Y.Z] heading)"; exit 1; }
-          echo "version=$v"      >> "$GITHUB_OUTPUT"
-          echo "num=${v#v}"      >> "$GITHUB_OUTPUT"
-          echo "Releasing $v"
-
-      - name: Extract release notes from CHANGELOG
-        id: notes
-        env:
-          NUM: ${{ steps.ver.outputs.num }}
+          V=$(grep -m1 '^version' pyproject.toml | sed -E 's/^version *= *"([^"]+)".*/\1/')
+          echo "Resolved version: '$V'"
+          test -n "$V" || { echo "::error::could not resolve version from pyproject.toml"; exit 1; }
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+      - name: Gate before release
         run: |
-          set -euo pipefail
-          {
-            echo 'body<<RELEASE_NOTES_EOF'
-            awk -v v="$NUM" '$0 ~ ("^## \\[" v "\\]"){f=1;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md
-            echo 'RELEASE_NOTES_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Create and push the tag (idempotent)
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
-            echo "tag $VERSION already on origin — skipping"
-          else
-            # Runners have no git identity; annotated tags need one (empty-ident fatal).
-            git config user.name  "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a "$VERSION" -m "compass $VERSION"
-            git push origin "refs/tags/$VERSION"
-          fi
-
-      - name: Publish the GitHub Release (idempotent, marks Latest)
+          uv run --with pytest python -m pytest -q
+          uv run distil bench
+          uv run distil verify
+      - name: Build wheel + sdist
+        run: uv build
+      - name: Build single-file executable
+        run: bash scripts/build_pyz.sh
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/distil.cyclonedx.json
+          upload-release-assets: false # this workflow attaches assets itself below, not via a `release` event
+      - name: Create the GitHub release (+ tag v<version>) and attach artifacts
+        # `gh release create` reliably creates the tag + release + uploads assets on
+        # ANY trigger (including manual workflow_dispatch), unlike action-gh-release
+        # which can no-op on a non-tag ref. Idempotent: if the release already exists,
+        # upload/clobber the assets instead of failing.
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.ver.outputs.version }}
-          NOTES: ${{ steps.notes.outputs.body }}
         run: |
-          set -euo pipefail
-          if gh release view "$VERSION" >/dev/null 2>&1; then
-            printf '%s' "$NOTES" | gh release edit "$VERSION" --notes-file -
+          V="v${{ steps.ver.outputs.version }}"
+          # rc tags are soak candidates (see RELEASING.md): marked prerelease so
+          # nobody installs one by accident from the releases page.
+          PRE=""
+          case "$V" in *rc*) PRE="--prerelease" ;; esac
+          if gh release view "$V" >/dev/null 2>&1; then
+            gh release upload "$V" dist/*.whl dist/*.tar.gz dist/distil.pyz dist/distil.cyclonedx.json --clobber
           else
-            printf '%s' "$NOTES" | gh release create "$VERSION" --latest --title "$VERSION — compass" --notes-file -
+            gh release create "$V" dist/*.whl dist/*.tar.gz dist/distil.pyz dist/distil.cyclonedx.json \
+              --target "${{ github.sha }}" --title "$V" $PRE \
+              --notes "Release $V — see CHANGELOG.md. Install: pipx install distil-llm (PyPI), or download the wheel/distil.pyz below if PyPI is blocked."
           fi
+      - name: Stage PyPI artifacts (wheel + sdist only)
+        run: |
+          mkdir -p pypi-dist
+          cp dist/*.whl dist/*.tar.gz pypi-dist/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pypi-dist
+          path: pypi-dist/
 
-      - name: Open the Homebrew formula-bump PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.ver.outputs.version }}
-          REPO: ${{ github.repository }}
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    # Enable once the PyPI trusted publisher is configured (see below), by setting
+    # repo variable PUBLISH_TO_PYPI=true. Until then the release still ships GitHub artifacts.
+    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/distil-llm
+    permissions:
+      id-token: write   # OIDC — trusted publishing, no API token/secret needed
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: pypi-dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # tolerate re-running a release for a version already on PyPI (e.g. when
+          # re-cutting only to (re)create the GitHub release) — don't fail the run.
+          skip-existing: true
+          # PEP 740 Sigstore attestations. Recent action versions default this on, but
+          # 1.30.0 published with attestations=NO and provenance=none, so the default
+          # cannot be relied on — request it explicitly and verify it below.
+          attestations: true
+
+      # The README claims releases carry PEP 740 attestations. Claiming a security
+      # property without checking it is exactly the failure this project exists to
+      # criticise, so the claim is enforced here: if PyPI does not report attestations
+      # for the version just published, the release job fails.
+      - name: Verify PyPI recorded the attestations
         run: |
           set -euo pipefail
-          # Optional + generic: only repos that ship a Homebrew tap formula get this PR.
-          formula="$(ls Formula/*.rb 2>/dev/null | head -1 || true)"
-          [ -n "$formula" ] || { echo "no Homebrew formula in this repo — skipping formula PR"; exit 0; }
-          url="https://github.com/$REPO/archive/refs/tags/$VERSION.tar.gz"
-          sha="$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)"
-          [ -n "$sha" ] || { echo "could not compute tarball sha"; exit 1; }
-          tmp="$(mktemp)"
-          sed -E -e "s#archive/refs/tags/v[0-9.]+\.tar\.gz#archive/refs/tags/$VERSION.tar.gz#" \
-                 -e "s/^([[:space:]]*sha256 )\"[a-f0-9]*\"/\1\"$sha\"/" "$formula" >"$tmp" && mv "$tmp" "$formula"
-          if git diff --quiet -- "$formula"; then echo "formula already at $VERSION — no PR needed"; exit 0; fi
-          branch="release/formula-$VERSION"
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git commit -aqm "chore(release): pin $VERSION + tarball sha in the Homebrew formula"
-          git push -f origin "$branch"
-          gh pr create --base main --head "$branch" \
-            --title "chore(release): Homebrew formula -> $VERSION" \
-            --body "Automated formula bump for **$VERSION** (url + tarball \`sha256 $sha\`). Auto-merges once checks pass, so \`brew install\` never lags a release." \
-            || gh pr edit "$branch" --body "Automated formula bump for $VERSION (sha256 $sha)." || true
-          # Close the loop: land the bump automatically once required checks pass, so a
-          # forgotten manual merge can't leave brew on a stale release (the reason we
-          # were pinned to v0.20.0). Tolerant — if the repo hasn't enabled auto-merge,
-          # the CI drift guard on main still flags the staleness loudly.
-          # NOTE: if branch protection requires the `ci` check, that check must be able
-          # to run on this bot-authored PR — pushes made with the default GITHUB_TOKEN
-          # don't trigger `on: pull_request`, so use a PAT (secrets.RELEASE_PAT) for the
-          # push above if auto-merge stalls waiting on checks.
-          gh pr merge --auto --squash "$branch" \
-            || echo "::warning::could not enable auto-merge — enable 'Allow auto-merge' in repo settings (+ required checks), or merge the formula PR by hand"
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "checking attestations for distil-llm ${VERSION}"
+          # Ask the integrity API, not the JSON API. PyPI does NOT populate an
+          # "attestations" field on /pypi/<pkg>/<ver>/json — checking it there reports a
+          # false negative even when the bundle exists, which failed the 1.31.0 release
+          # that had in fact attested correctly.
+          FILES="import json,sys; print(' '.join(u['filename'] for u in json.load(sys.stdin)['urls']))"
+          COUNT="import json,sys; print(len(json.load(sys.stdin).get('attestation_bundles') or []))"
+          for attempt in 1 2 3 4 5; do
+            sleep $((attempt * 10))   # PyPI indexes attestations a moment after upload
+            RESP="$(curl -fsSL "https://pypi.org/pypi/distil-llm/${VERSION}/json")" || continue
+            MISSING=""
+            for FN in $(printf '%s' "$RESP" | python3 -c "$FILES"); do
+              N="$(curl -fsSL "https://pypi.org/integrity/distil-llm/${VERSION}/${FN}/provenance" 2>/dev/null | python3 -c "$COUNT" 2>/dev/null || echo 0)"
+              [ "${N:-0}" -ge 1 ] || MISSING="$MISSING $FN"
+            done
+            if [ -z "$MISSING" ]; then
+              echo "✓ all artifacts carry attestations"
+              exit 0
+            fi
+            echo "attempt ${attempt}: still missing on — ${MISSING}"
+          done
+          echo "::error::PyPI reports no PEP 740 attestations for ${VERSION}, but README.md claims them. Either the publish step failed to attest, or the README claim must be removed."
+          exit 1
 
-      - name: Sync formula into the shared tap (dshakes/homebrew-tap)
+# ── PyPI trusted publishing setup (one-time, on pypi.org) ──────────────────────
+# 1. Create the project owner account, then add a *pending publisher*:
+#    PyPI → Your projects → Publishing → Add a new pending publisher
+#      PyPI Project Name : distil-llm
+#      Owner             : dshakes
+#      Repository        : distil
+#      Workflow name     : release.yml
+#      Environment       : pypi
+# 2. In this repo: Settings → Secrets and variables → Actions → Variables →
+#    add PUBLISH_TO_PYPI = true
+# 3. Push a tag (vX.Y.Z). No API token is ever stored — auth is OIDC.
+
+  # GA container image → GitHub Container Registry, on the same v* tag.
+  # ghcr.io needs no extra secrets (GITHUB_TOKEN with packages:write).
+  publish-image:
+    runs-on: ubuntu-latest
+    needs: [build]
+    # No image for rc soak tags: `1.X.Yrc1` isn't valid semver for the tagger,
+    # and an rc must never move `latest` — rc soakers install the wheel/pipx.
+    if: ${{ !contains(github.ref_name, 'rc') }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Keep the Homebrew tap in lockstep with the release — no more manual formula
+  # bumps. Needs a TAP_TOKEN secret (PAT with contents:write on the tap repo);
+  # no-ops with a notice if absent, so it never blocks a release.
+  bump-homebrew:
+    runs-on: ubuntu-latest
+    needs: [build]
+    # Never point the tap at an rc — brew users get finals only.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+    steps:
+      - name: Update tap formula
         env:
-          TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
-          VERSION: ${{ steps.ver.outputs.version }}
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
         run: |
-          set -euo pipefail
-          # Users install via `brew install dshakes/tap/compass`, which reads the shared
-          # tap repo — so each release must push the bumped formula there too. Cross-repo
-          # write needs a PAT (the default GITHUB_TOKEN is scoped to this repo only).
-          formula="$(ls Formula/*.rb 2>/dev/null | head -1 || true)"
-          [ -n "$formula" ] || exit 0
-          if [ -z "${TAP_PAT:-}" ]; then
-            echo "::warning::HOMEBREW_TAP_PAT not set — skipping tap sync. Add a fine-grained PAT with contents:write on dshakes/homebrew-tap so the tap tracks releases automatically."
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::notice::TAP_TOKEN not set — skipping Homebrew tap bump."
             exit 0
           fi
-          tmp="$(mktemp -d)"
-          git clone --depth 1 "https://x-access-token:${TAP_PAT}@github.com/dshakes/homebrew-tap.git" "$tmp/tap" 2>/dev/null
-          mkdir -p "$tmp/tap/Formula"
-          cp "$formula" "$tmp/tap/Formula/compass.rb"
-          cd "$tmp/tap"
-          if git diff --quiet; then echo "tap already current for $VERSION"; exit 0; fi
+          VER="${GITHUB_REF_NAME#v}"
+          SHA="$(curl -sL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/dshakes/homebrew-tap" tap
+          cd tap
+          python3 - "$VER" "$SHA" <<'PY'
+          import re, sys
+          ver, sha = sys.argv[1], sys.argv[2]
+          fp = "Formula/distil.rb"; s = open(fp).read()
+          s = re.sub(r'v\d+\.\d+\.\d+', f'v{ver}', s)
+          s = re.sub(r'sha256 "[a-f0-9]{64}"', f'sha256 "{sha}"', s)
+          s = re.sub(r'version "\d+\.\d+\.\d+"', f'version "{ver}"', s)
+          open(fp, "w").write(s)
+          PY
           git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -aqm "compass $VERSION"
-          git push
-          echo "synced compass $VERSION into dshakes/homebrew-tap"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "distil ${VER}" && git -c push.default=current push || echo "tap already current"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.12"
       - name: Resolve version from pyproject
@@ -52,7 +52,7 @@ jobs:
       - name: Build single-file executable
         run: bash scripts/build_pyz.sh
       - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@v0.24.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: cyclonedx-json
@@ -82,7 +82,7 @@ jobs:
         run: |
           mkdir -p pypi-dist
           cp dist/*.whl dist/*.tar.gz pypi-dist/
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pypi-dist
           path: pypi-dist/
@@ -99,11 +99,11 @@ jobs:
     permissions:
       id-token: write   # OIDC — trusted publishing, no API token/secret needed
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pypi-dist
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           # tolerate re-running a release for a version already on PyPI (e.g. when
           # re-cutting only to (re)create the GitHub release) — don't fail the run.
@@ -183,8 +183,8 @@ jobs:
       # workflow-level default (contents: write) does not include it.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -221,21 +221,21 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,13 +241,20 @@ jobs:
       - name: Update tap formula
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          if [ -z "$TAP_TOKEN" ]; then
+          set -euo pipefail
+          if [ -z "${TAP_TOKEN:-}" ]; then
             echo "::notice::TAP_TOKEN not set — skipping Homebrew tap bump."
             exit 0
           fi
-          VER="${RELEASE_VERSION}"   # see above: GITHUB_REF_NAME is the branch on dispatch
-          SHA="$(curl -sL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
+          # see publish-pypi: GITHUB_REF_NAME is the branch on workflow_dispatch
+          VER="${RELEASE_VERSION:-}"
+          # Never write a formula from an empty version: it would rewrite the tap's
+          # url/sha to "v" and break `brew install` for everyone.
+          [ -n "$VER" ] || { echo "::error::RELEASE_VERSION is empty — refusing to touch the tap"; exit 1; }
+          SHA="$(curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
+          [ -n "$SHA" ] || { echo "::error::could not hash the v${VER} tarball"; exit 1; }
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/dshakes/homebrew-tap" tap
           cd tap
           python3 - "$VER" "$SHA" <<'PY'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,4 +274,15 @@ jobs:
           PY
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "distil ${VER}" && git -c push.default=current push || echo "tap already current"
+          # `commit && push || echo` swallowed a FAILED PUSH as "already current":
+          # an auth or non-fast-forward error printed the happy-path message and the
+          # job went green with brew still on the old version. Nothing-to-commit and
+          # push-failed are different outcomes, so separate them — under
+          # `set -euo pipefail` a real push failure now fails the release.
+          if git diff --quiet -- Formula/distil.rb; then
+            echo "tap already at ${VER} — nothing to push"
+          else
+            git commit -qam "distil ${VER}"
+            git -c push.default=current push
+            echo "tap updated to ${VER}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.build.outputs.version, 'rc') }}
+    permissions:
+      contents: read
+      # `npm publish --provenance` signs via OIDC, exactly like publish-pypi's
+      # trusted publishing — without this the publish fails outright. The
+      # workflow-level default (contents: write) does not include it.
+      id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,44 @@ jobs:
 #    add PUBLISH_TO_PYPI = true
 # 3. Push a tag (vX.Y.Z). No API token is ever stored — auth is OIDC.
 
+  # The npm wrapper — the README carries an npm version badge, but nothing ever
+  # published it after the first manual push: the registry served 1.25.0 while
+  # the repo said 1.27.0 and PyPI was on 1.33.1. A badge that advertises a build
+  # nine releases old is worse than no badge.
+  #
+  # Dormant until an NPM_TOKEN secret exists (an automation token from
+  # npmjs.com → Access Tokens). Until then the release is unaffected and the
+  # version can no longer drift silently: tests/test_packaging_smoke.py and the
+  # release.sh preflight both pin packaging/npm/package.json to pyproject.
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.build.outputs.version, 'rc') }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::warning::NPM_TOKEN not set — skipping npm publish. The README's npm"
+            echo "::warning::badge will keep showing the last published version."
+            exit 0
+          fi
+          cd packaging/npm
+          V="$(node -p "require('./package.json').version")"
+          # Re-running a release for a version already on npm must not fail the run.
+          if npm view "distil-llm@$V" version >/dev/null 2>&1; then
+            echo "distil-llm@$V already on npm — nothing to do"
+            exit 0
+          fi
+          npm publish --provenance --access public
+
   # GA container image → GitHub Container Registry, on the same v* tag.
   # ghcr.io needs no extra secrets (GITHUB_TOKEN with packages:write).
   publish-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,17 @@ jobs:
           V=$(grep -m1 '^version' pyproject.toml | sed -E 's/^version *= *"([^"]+)".*/\1/')
           echo "Resolved version: '$V'"
           test -n "$V" || { echo "::error::could not resolve version from pyproject.toml"; exit 1; }
+          # Every job keys off pyproject, so a tag that disagrees with it would build
+          # and publish the OTHER version: push v1.35.0 with pyproject on 1.34.0 and
+          # the run uploads assets onto the existing v1.34.0 release and re-publishes
+          # 1.34.0, while the tag you pushed stays empty. Refuse instead.
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            TAG_V="${GITHUB_REF_NAME#v}"
+            [ "$TAG_V" = "$V" ] || {
+              echo "::error::tag ${GITHUB_REF_NAME} does not match pyproject version ${V} — bump pyproject or retag"
+              exit 1
+            }
+          fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
       - name: Gate before release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,15 @@ jobs:
       # criticise, so the claim is enforced here: if PyPI does not report attestations
       # for the version just published, the release job fails.
       - name: Verify PyPI recorded the attestations
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          # NOT GITHUB_REF_NAME: on workflow_dispatch that is the branch ("main"),
+          # so this queried /pypi/distil-llm/main/json and failed the release with a
+          # false negative AFTER a successful publish. The build job already resolved
+          # the version from pyproject — use that on every trigger.
+          VERSION="${RELEASE_VERSION}"
           echo "checking attestations for distil-llm ${VERSION}"
           # Ask the integrity API, not the JSON API. PyPI does NOT populate an
           # "attestations" field on /pypi/<pkg>/<ver>/json — checking it there reports a
@@ -191,7 +197,9 @@ jobs:
     needs: [build]
     # No image for rc soak tags: `1.X.Yrc1` isn't valid semver for the tagger,
     # and an rc must never move `latest` — rc soakers install the wheel/pipx.
-    if: ${{ !contains(github.ref_name, 'rc') }}
+    # Version-derived, not ref-derived: on workflow_dispatch github.ref_name is the
+    # branch, so an rc dispatched by hand would still publish a GA image.
+    if: ${{ !contains(needs.build.outputs.version, 'rc') }}
     permissions:
       contents: read
       packages: write
@@ -224,8 +232,11 @@ jobs:
   bump-homebrew:
     runs-on: ubuntu-latest
     needs: [build]
-    # Never point the tap at an rc — brew users get finals only.
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'rc')
+    # Never point the tap at an rc — brew users get finals only. Keyed on the
+    # resolved version, not the ref: the tag-only guard skipped this job on
+    # every workflow_dispatch release, which RELEASING.md documents as supported,
+    # so brew silently stayed on the previous version.
+    if: ${{ !contains(needs.build.outputs.version, 'rc') }}
     steps:
       - name: Update tap formula
         env:
@@ -235,7 +246,7 @@ jobs:
             echo "::notice::TAP_TOKEN not set — skipping Homebrew tap bump."
             exit 0
           fi
-          VER="${GITHUB_REF_NAME#v}"
+          VER="${RELEASE_VERSION}"   # see above: GITHUB_REF_NAME is the branch on dispatch
           SHA="$(curl -sL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/dshakes/homebrew-tap" tap
           cd tap

--- a/README.md
+++ b/README.md
@@ -170,15 +170,15 @@ To be precise about what each layer proves: the **per-commit** gates grade decis
 ```
 domain            trajectory                $ saved   distil   aggr  pruned
 ---------------------------------------------------------------------------
-ops/sre           sre-disk-incident           33.1%     PASS   FAIL     615
-coding            coding-bugfix               28.7%     PASS   FAIL     736
+ops/sre           sre-disk-incident           32.8%     PASS   FAIL     615
+coding            coding-bugfix               25.5%     PASS   FAIL     736
 support           support-refund              32.6%     PASS   FAIL     765
 research          research-synthesis          25.7%     PASS   FAIL     809
 data-analysis     data-analysis-sql           18.1%     PASS   FAIL     965
-devops            devops-rollback             25.0%     PASS   FAIL     857
-finance           finance-reconcile           29.1%     PASS   FAIL    1014
+devops            devops-rollback             22.8%     PASS   FAIL     857
+finance           finance-reconcile           24.9%     PASS   FAIL    1014
 ---------------------------------------------------------------------------
-aggregate: distil cuts $0.14212 -> $0.10402 (26.8% cheaper) reversibly; 5761 tokens causally prunable.
+aggregate: distil cuts $0.14212 -> $0.10610 (25.3% cheaper) reversibly; 5761 tokens causally prunable.
 GATE: PASS — every trajectory certified non-inferior; aggressive rejected on all.
 ```
 

--- a/docs/assets/cache-aware.svg
+++ b/docs/assets/cache-aware.svg
@@ -59,14 +59,14 @@
     <rect class="cbar c2" x="300" y="180" width="502" height="30" rx="10" fill="url(#bar1)" stroke="#2e3758" stroke-width="1"/>
     <text x="816" y="201" fill="#8b91a3">$0.01115  ·  −27%</text>
 
-    <!-- naive 0.01691 -->
+    <!-- naive 0.01696 -->
     <text x="40" y="251" fill="#ff8a6b">naive compress</text>
     <text x="40" y="267" font-size="10" fill="#5b6177">busts the prefix cache</text>
     <text x="1055" y="226" font-size="10.5" text-anchor="end" fill="#ff8a6b">▲ costs MORE than baseline</text>
     <rect class="cbar c3" x="300" y="236" width="761" height="30" rx="10" fill="#2e1a20" stroke="#ff8a6b" stroke-width="1.5" stroke-opacity="0.7"/>
-    <text x="1075" y="256" fill="#ff8a6b">$0.01691</text>
+    <text x="1075" y="256" fill="#ff8a6b">$0.01696</text>
 
-    <!-- distil 0.01019 -->
+    <!-- distil 0.01023 -->
     <text x="40" y="307" fill="#5ad1c9">distil</text>
     <text x="40" y="323" font-size="10" fill="#5b6177">cache-aware lossless</text>
     <!-- glow layer behind distil bar -->
@@ -74,6 +74,6 @@
     <!-- actual distil bar -->
     <rect class="cbar cwin" x="300" y="292" width="459" height="30" rx="10" fill="url(#g)"/>
     <g clip-path="url(#cwclip)"><rect class="cshim" x="230" y="292" width="70" height="30" fill="url(#cshimg)"/></g>
-    <text x="773" y="313" font-weight="700" fill="#f2f3f7">$0.01019  ·  −33%</text>
+    <text x="773" y="313" font-weight="700" fill="#f2f3f7">$0.01023  ·  −33%</text>
   </g>
 </svg>

--- a/docs/assets/domains.svg
+++ b/docs/assets/domains.svg
@@ -40,12 +40,12 @@
   <!-- rows: bar columns[160..520] | % @540 | PASS @600 | FAIL @730 | tokens @910 -->
   <g transform="translate(40,116)">
 
-    <!-- ops/sre 33.1 615 -->
+    <!-- ops/sre 32.8 615 -->
     <g transform="translate(0,38)">
       <rect class="dbar dr1" x="160" y="-9" width="360" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
       <rect class="dbar dr1" x="160" y="-9" width="360" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">ops/sre</text>
-      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">33.1%</text>
+      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">32.8%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
       <text x="634" y="9" text-anchor="middle" font-size="11" font-weight="700" fill="#5ad19a">&#x2714; PASS</text>
       <rect x="726" y="-4" width="68" height="18" rx="9" fill="#2e1a1a" stroke="#4a2525"/>
@@ -54,12 +54,12 @@
       <line x1="0" y1="19" x2="1120" y2="19" stroke="#1a1f2e" stroke-width="1" opacity="0.7"/>
     </g>
 
-    <!-- coding 28.7 736 -->
+    <!-- coding 25.5 736 -->
     <g transform="translate(0,76)">
-      <rect class="dbar dr2" x="160" y="-9" width="312" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr2" x="160" y="-9" width="312" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr2" x="160" y="-9" width="280" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr2" x="160" y="-9" width="280" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">coding</text>
-      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">28.7%</text>
+      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">25.5%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
       <text x="634" y="9" text-anchor="middle" font-size="11" font-weight="700" fill="#5ad19a">&#x2714; PASS</text>
       <rect x="726" y="-4" width="68" height="18" rx="9" fill="#2e1a1a" stroke="#4a2525"/>
@@ -70,8 +70,8 @@
 
     <!-- support 32.6 765 -->
     <g transform="translate(0,114)">
-      <rect class="dbar dr3" x="160" y="-9" width="355" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr3" x="160" y="-9" width="355" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr3" x="160" y="-9" width="358" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr3" x="160" y="-9" width="358" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">support</text>
       <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">32.6%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
@@ -84,8 +84,8 @@
 
     <!-- research 25.7 809 -->
     <g transform="translate(0,152)">
-      <rect class="dbar dr4" x="160" y="-9" width="280" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr4" x="160" y="-9" width="280" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr4" x="160" y="-9" width="282" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr4" x="160" y="-9" width="282" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">research</text>
       <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">25.7%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
@@ -98,8 +98,8 @@
 
     <!-- data-analysis 18.1 965 -->
     <g transform="translate(0,190)">
-      <rect class="dbar dr5" x="160" y="-9" width="197" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr5" x="160" y="-9" width="197" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr5" x="160" y="-9" width="199" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr5" x="160" y="-9" width="199" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">data-analysis</text>
       <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">18.1%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
@@ -110,12 +110,12 @@
       <line x1="0" y1="19" x2="1120" y2="19" stroke="#1a1f2e" stroke-width="1" opacity="0.7"/>
     </g>
 
-    <!-- devops 25.0 857 -->
+    <!-- devops 22.8 857 -->
     <g transform="translate(0,228)">
-      <rect class="dbar dr6" x="160" y="-9" width="272" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr6" x="160" y="-9" width="272" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr6" x="160" y="-9" width="250" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr6" x="160" y="-9" width="250" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">devops</text>
-      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">25.0%</text>
+      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">22.8%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
       <text x="634" y="9" text-anchor="middle" font-size="11" font-weight="700" fill="#5ad19a">&#x2714; PASS</text>
       <rect x="726" y="-4" width="68" height="18" rx="9" fill="#2e1a1a" stroke="#4a2525"/>
@@ -124,12 +124,12 @@
       <line x1="0" y1="19" x2="1120" y2="19" stroke="#1a1f2e" stroke-width="1" opacity="0.7"/>
     </g>
 
-    <!-- finance 29.1 1014 -->
+    <!-- finance 24.9 1014 -->
     <g transform="translate(0,266)">
-      <rect class="dbar dr7" x="160" y="-9" width="317" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
-      <rect class="dbar dr7" x="160" y="-9" width="317" height="20" rx="6" fill="url(#g)"/>
+      <rect class="dbar dr7" x="160" y="-9" width="273" height="20" rx="6" fill="url(#g)" opacity="0.2" filter="url(#glow)"/>
+      <rect class="dbar dr7" x="160" y="-9" width="273" height="20" rx="6" fill="url(#g)"/>
       <text x="0" y="5" font-size="13" fill="#f2f3f7">finance</text>
-      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">29.1%</text>
+      <text x="540" y="5" font-size="13" font-weight="700" fill="#f2f3f7">24.9%</text>
       <rect x="596" y="-4" width="76" height="18" rx="9" fill="#0d3028" stroke="#1a5040"/>
       <text x="634" y="9" text-anchor="middle" font-size="11" font-weight="700" fill="#5ad19a">&#x2714; PASS</text>
       <rect x="726" y="-4" width="68" height="18" rx="9" fill="#2e1a1a" stroke="#4a2525"/>
@@ -141,5 +141,5 @@
   </g>
 
   <line x1="40" y1="402" x2="1160" y2="402" stroke="#252c3e" stroke-width="1"/>
-  <text x="40" y="424" font-size="13" fill="#8b91a3">aggregate: <tspan fill="#5ad1c9" font-weight="700">26.8% cheaper</tspan>, losslessly &#xB7; <tspan fill="#f2f3f7">5,761 tokens</tspan> causally prunable &#xB7; <tspan fill="#5ad19a">GATE: PASS</tspan></text>
+  <text x="40" y="424" font-size="13" fill="#8b91a3">aggregate: <tspan fill="#5ad1c9" font-weight="700">25.3% cheaper</tspan>, reversibly &#xB7; <tspan fill="#f2f3f7">5,761 tokens</tspan> causally prunable &#xB7; <tspan fill="#5ad19a">GATE: PASS</tspan></text>
 </svg>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -107,15 +107,15 @@ corpus gate — 7 trajectories | model claude-opus-4-8 | tokenizer=heuristic
 
 domain            trajectory               $ saved   distil   aggr  pruned
 ---------------------------------------------------------------------------
-ops/sre           sre-disk-incident          33.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>     615
-coding            coding-bugfix              28.7%     <span class="g">PASS</span>   <span class="w">FAIL</span>     736
+ops/sre           sre-disk-incident          32.8%     <span class="g">PASS</span>   <span class="w">FAIL</span>     615
+coding            coding-bugfix              25.5%     <span class="g">PASS</span>   <span class="w">FAIL</span>     736
 support           support-refund             32.6%     <span class="g">PASS</span>   <span class="w">FAIL</span>     765
 research          research-synthesis         25.7%     <span class="g">PASS</span>   <span class="w">FAIL</span>     809
 data-analysis     data-analysis-sql          18.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>     965
-devops            devops-rollback            25.0%     <span class="g">PASS</span>   <span class="w">FAIL</span>     857
-finance           finance-reconcile          29.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>    1014
+devops            devops-rollback            22.8%     <span class="g">PASS</span>   <span class="w">FAIL</span>     857
+finance           finance-reconcile          24.9%     <span class="g">PASS</span>   <span class="w">FAIL</span>    1014
 ---------------------------------------------------------------------------
-aggregate: distil cuts $0.14212 -> $0.10402 (26.8% cheaper) losslessly; 5761 tokens prunable.
+aggregate: distil cuts $0.14212 -> $0.10610 (25.3% cheaper) losslessly; 5761 tokens prunable.
 
 GATE: <span class="g">PASS</span> — every trajectory certified non-inferior; aggressive rejected on all.</pre>
 
@@ -144,11 +144,11 @@ strategy                               $ / run   vs baseline  cache hits
 ------------------------------------------------------------------------
 baseline (no cache, no compress)       0.01524          0.0%           0
 cache only                             0.01115         26.8%       1,028
-naive compress + cache                 0.01691        <span class="w">-11.0%</span>           0
-distil (cache-aware lossless)          0.01019         <span class="g">33.1%</span>       1,028
+naive compress + cache                 0.01696        <span class="w">-11.3%</span>           0
+distil (cache-aware lossless)          0.01023         <span class="g">32.8%</span>       1,028
 ------------------------------------------------------------------------
-distil cuts $0.01524 -> $0.01019 per run (33.1% cheaper), losslessly.
-note: naive compression costs $0.01691 — <span class="w">66% MORE</span> than distil despite fewer tokens,
+distil cuts $0.01524 -> $0.01023 per run (32.8% cheaper), reversibly.
+note: naive compression costs $0.01696 — <span class="w">66% MORE</span> than distil despite fewer tokens,
       because it busts the prefix cache.</pre>
 
     <hr/>

--- a/docs/corpus.html
+++ b/docs/corpus.html
@@ -76,7 +76,7 @@
     <h1>The <span class="g">Corpus</span></h1>
     <p class="lead">The asset that makes certification meaningful — 7 real, captured-style agent trajectories across 7 domains. Every strategy must pass the gate on every one of them.</p>
 
-    <img src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 33.1%, coding 28.7%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 25.0%, finance 29.1%; aggregate 26.8% cheaper losslessly across 5,761 prunable tokens; figures repeated in the table below" class="svg-embed"/>
+    <img src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 32.8%, coding 25.5%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 22.8%, finance 24.9%; aggregate 25.3% cheaper reversibly across 5,761 prunable tokens; figures repeated in the table below" class="svg-embed"/>
 
     <hr/>
 
@@ -107,7 +107,7 @@
         <tr>
           <td><strong>ops/sre</strong></td>
           <td><code>sre-disk-incident</code></td>
-          <td>33.1%</td>
+          <td>32.8%</td>
           <td><span class="badge-pass">PASS</span></td>
           <td><span class="badge-fail">FAIL</span></td>
           <td>615</td>
@@ -115,7 +115,7 @@
         <tr>
           <td><strong>coding</strong></td>
           <td><code>coding-bugfix</code></td>
-          <td>28.7%</td>
+          <td>25.5%</td>
           <td><span class="badge-pass">PASS</span></td>
           <td><span class="badge-fail">FAIL</span></td>
           <td>736</td>
@@ -147,7 +147,7 @@
         <tr>
           <td><strong>devops</strong></td>
           <td><code>devops-rollback</code></td>
-          <td>25.0%</td>
+          <td>22.8%</td>
           <td><span class="badge-pass">PASS</span></td>
           <td><span class="badge-fail">FAIL</span></td>
           <td>857</td>
@@ -155,7 +155,7 @@
         <tr>
           <td><strong>finance</strong></td>
           <td><code>finance-reconcile</code></td>
-          <td>29.1%</td>
+          <td>24.9%</td>
           <td><span class="badge-pass">PASS</span></td>
           <td><span class="badge-fail">FAIL</span></td>
           <td>1014</td>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -261,15 +261,15 @@ corpus gate — 7 trajectories | model claude-opus-4-8 | tokenizer=heuristic
 
 domain            trajectory               $ saved   distil   aggr  pruned
 ---------------------------------------------------------------------------
-ops/sre           sre-disk-incident          33.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>     615
-coding            coding-bugfix              28.7%     <span class="g">PASS</span>   <span class="w">FAIL</span>     736
+ops/sre           sre-disk-incident          32.8%     <span class="g">PASS</span>   <span class="w">FAIL</span>     615
+coding            coding-bugfix              25.5%     <span class="g">PASS</span>   <span class="w">FAIL</span>     736
 support           support-refund             32.6%     <span class="g">PASS</span>   <span class="w">FAIL</span>     765
 research          research-synthesis         25.7%     <span class="g">PASS</span>   <span class="w">FAIL</span>     809
 data-analysis     data-analysis-sql          18.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>     965
-devops            devops-rollback            25.0%     <span class="g">PASS</span>   <span class="w">FAIL</span>     857
-finance           finance-reconcile          29.1%     <span class="g">PASS</span>   <span class="w">FAIL</span>    1014
+devops            devops-rollback            22.8%     <span class="g">PASS</span>   <span class="w">FAIL</span>     857
+finance           finance-reconcile          24.9%     <span class="g">PASS</span>   <span class="w">FAIL</span>    1014
 ---------------------------------------------------------------------------
-aggregate: distil cuts $0.14212 -> $0.10402 (26.8% cheaper) reversibly; 5761 tokens causally prunable.
+aggregate: distil cuts $0.14212 -> $0.10610 (25.3% cheaper) reversibly; 5761 tokens causally prunable.
 
 GATE: <span class="g">PASS</span> — every trajectory certified non-inferior; aggressive rejected on all.</pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -557,8 +557,8 @@ strategy                               $ / run   vs baseline  cache hits
 ------------------------------------------------------------------------
 baseline (no cache, no compress)       0.01524          0.0%           0
 cache only                             0.01115         26.8%       1,028
-naive compress + cache                 0.01691        <span class="w">-11.0%</span>           0   <span class="d">← busts cache</span>
-distil (cache-aware lossless)          0.01019         <span class="g">33.1%</span>       1,028
+naive compress + cache                 0.01696        <span class="w">-11.3%</span>           0   <span class="d">← busts cache</span>
+distil (cache-aware lossless)          0.01023         <span class="g">32.8%</span>       1,028
 
 <span class="d">$ distil certify --strategy distil</span>
 decision-equivalence match rate: <span class="g">100.0%</span>
@@ -567,7 +567,7 @@ VERDICT: <span class="g">PASS</span>  (certified non-inferior)
 <span class="d">$ distil certify --strategy aggressive</span>
 decision-equivalence match rate: <span class="w">0.0%</span>
 VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
-  <img loading="lazy" src="assets/cache-aware.svg" alt="Bar chart of per-run cost: baseline (no cache, no compress) $0.01524; cache only $0.01115 (-27%); naive recompression busts the prefix cache and costs more, $0.01691; distil's cache-aware lossless approach $0.01019 (-33%), the lowest of the four" style="width:100%;border:1px solid var(--line);border-radius:16px;margin-top:18px"/>
+  <img loading="lazy" src="assets/cache-aware.svg" alt="Bar chart of per-run cost: baseline (no cache, no compress) $0.01524; cache only $0.01115 (-27%); naive recompression busts the prefix cache and costs more, $0.01696; distil's cache-aware lossless approach $0.01023 (-33%), the lowest of the four" style="width:100%;border:1px solid var(--line);border-radius:16px;margin-top:18px"/>
 </div></section>
 
 <section id="domains"><div class="wrap">
@@ -575,7 +575,7 @@ VERDICT: <span class="w">FAIL</span>  (would degrade quality — blocked)</pre>
   <h2>Measured across 7 domains <span class="g">— the same gate, not one example</span><a class="hlink" href="#domains" aria-label="Link to section: Measured across 7 domains — the same gate, not one example">#</a></h2>
   <p class="lead">A strategy isn't trustworthy because it works once. <code>distil bench</code> certifies
     every domain — ops, coding, support, research, data, devops, finance — or it doesn't ship.</p>
-  <img loading="lazy" src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 33.1%, coding 28.7%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 25.0%, finance 29.1%; aggregate 26.8% cheaper losslessly across 5,761 prunable tokens" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
+  <img loading="lazy" src="assets/domains.svg" alt="Bar chart of lossless savings across 7 domains, all passing the decision-equivalence gate: ops/sre 32.8%, coding 25.5%, support 32.6%, research 25.7%, data-analysis 18.1%, devops 22.8%, finance 24.9%; aggregate 25.3% cheaper reversibly across 5,761 prunable tokens" style="width:100%;border:1px solid var(--line);border-radius:16px"/>
 </div></section>
 
 <section id="tiers"><div class="wrap">

--- a/docs/techniques.html
+++ b/docs/techniques.html
@@ -144,8 +144,8 @@ strategy                               $ / run   vs baseline  cache hits
 ------------------------------------------------------------------------
 baseline (no cache, no compress)       0.01524          0.0%           0
 cache only                             0.01115         26.8%       1,028
-naive compress + cache                 0.01691        <span class="w">-11.0%</span>           0  <span class="d">← busts cache</span>
-distil (cache-aware lossless)          0.01019         <span class="g">33.1%</span>       1,028</pre>
+naive compress + cache                 0.01696        <span class="w">-11.3%</span>           0  <span class="d">← busts cache</span>
+distil (cache-aware lossless)          0.01023         <span class="g">32.8%</span>       1,028</pre>
 
     <hr/>
 

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "distil-llm",
-  "version": "1.27.0",
-  "description": "Compress your AI agent's context and prove its decisions don't change — cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
+  "version": "1.34.0",
+  "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",
     "ai-agent",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,7 +99,12 @@ else
   [ "$PLUGIN_V" = "$VERSION" ] || die "plugin.json is $PLUGIN_V, pyproject is $VERSION"
   SERVER_V="$(grep -E '^\s*"version":' server.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
   [ "$SERVER_V" = "$VERSION" ] || die "server.json is $SERVER_V, pyproject is $VERSION"
-  ok "version $VERSION consistent (pyproject, CITATION, plugin.json, server.json)"
+  # The npm wrapper carries a version badge in the README and nothing checked it:
+  # it sat at 1.27.0 in-repo while the registry served 1.25.0 and PyPI was on
+  # 1.33.1 — a badge advertising a build nine releases old.
+  NPM_V="$(grep -E '^\s*"version":' packaging/npm/package.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  [ "$NPM_V" = "$VERSION" ] || die "packaging/npm/package.json is $NPM_V, pyproject is $VERSION"
+  ok "version $VERSION consistent (pyproject, CITATION, plugin.json, server.json, npm)"
 fi
 
 git rev-parse "$TAG" >/dev/null 2>&1 && die "tag $TAG already exists — bump the version or delete the tag"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -209,6 +209,22 @@ def test_manifests_agree_on_version_and_name() -> None:
     assert spec["name"] in marker, f"server.json name {spec['name']!r} not in README marker"
 
 
+def test_npm_package_version_matches() -> None:
+    """The npm wrapper is a published surface with a version badge in the README,
+    and nothing was checking it. It drifted to 1.27.0 in-repo while the registry
+    still served 1.25.0 and PyPI was on 1.33.1 — a badge advertising a build nine
+    releases old. Same failure class as server.json: a manifest promises a version
+    and nothing verifies the promise.
+    """
+    pkg = json.loads((ROOT / "packaging" / "npm" / "package.json").read_text())
+    version = _pyproject()["project"]["version"]
+    assert pkg["version"] == version, (
+        f"packaging/npm/package.json is {pkg['version']}, package is {version} — "
+        "bump it with the other manifests at release time"
+    )
+    assert pkg["name"] == _pyproject()["project"]["name"]
+
+
 # ---------------------------------------------------------------------------
 # Other declared surfaces: Docker, Homebrew, the Claude Code plugin.
 # Same class as the registry outage — a manifest promises something and nothing


### PR DESCRIPTION
Two release-surface defects. Both are the same shape: something promises to publish, and nothing checks that it did.

---

## 1. v1.34.0 tagged green and shipped nothing

`013bb78` (*ci: install compass SDLC workflows + CODEOWNERS*) overwrote `release.yml` with compass's generic template — **188 lines out, 127 in**. Removed:

- the pre-release gate (`distil bench` + `distil verify`)
- wheel + sdist build, `distil.pyz`, CycloneDX SBOM
- GitHub release **asset upload**
- the entire **`publish-pypi`** job — Trusted Publishing via OIDC, PEP 740 attestations, and the step that *verifies PyPI recorded them*
- `publish-image`, and a `bump-homebrew` that matched this repo

| | |
|---|---|
| tag `v1.34.0` | pushed |
| GitHub Release | created, **0 assets** |
| PyPI `1.34.0` | **absent** — still 1.33.1 |
| workflow conclusion | **success** |

1.32.0 / 1.33.0 / 1.33.1 all reached PyPI (upload times match their runs). 1.34.0 is the first release after the clobber and the first to silently publish nothing. A pipeline that reports success without shipping is worse than one that fails loudly.

**Why restore rather than patch:** the compass Homebrew steps were already inert here — they scan for `Formula/*.rb` (this repo keeps it at `packaging/homebrew/distil.rb`), read `secrets.HOMEBREW_TAP_PAT` (this repo has `TAP_TOKEN`), and their PR body describes `brew install dshakes/tap/compass`. Nothing load-bearing is lost. This is the exact workflow that published the last three releases, and what `RELEASING.md` and `scripts/release.sh` still document — the dry-run told me `publish-pypi` would run, which is how the gap got past me.

---

## 2. The npm badge has been nine releases stale

| | version |
|---|---|
| PyPI | 1.33.1 |
| `packaging/npm/package.json` | **1.27.0** |
| npm registry | **1.25.0** |

Nothing published the package after its first manual push, and nothing bumped it — `test_packaging_smoke.py` guarded pyproject / CITATION / `server.json` / `plugin.json` but not this one, so it drifted unseen. CI only ran its tests.

- new `test_npm_package_version_matches` pins it to pyproject — **verified to fail** on the real 1.27.0 drift before the bump
- `release.sh` preflight checks it beside the other manifests, so a release can't be cut with it stale
- bumped to 1.34.0
- new `publish-npm` job: skipped for rc, **dormant until an `NPM_TOKEN` secret exists**, warns rather than failing without one, and no-ops if the version is already on npm (mirrors `publish-pypi`'s `skip-existing`)

To turn npm publishing on, add an automation token from npmjs.com → Access Tokens as `NPM_TOKEN`. Until then the version simply can't drift silently again.

---

## After merge

Re-dispatch `release` for 1.34.0. The release-create step is idempotent: it uploads the missing assets to the existing release and publishes wheel + sdist to PyPI with attestations, which the job then verifies.