### PR TITLE
fix(adoption): three numbers that claimed to be current but were not

### DIFF
--- a/distil/census.py
+++ b/distil/census.py
@@ -348,6 +348,42 @@ def _accrue(
     }
 
 
+def _reported_version() -> str:
+    """The distil version to report as installed — read from DISK, not from this
+    interpreter's already-imported ``__version__``.
+
+    These differ, and the difference silently corrupted the version histogram.
+    ``distil wrap`` is the flagship surface and is deliberately long-lived: the
+    hot-swap replaces the proxy *worker* on upgrade so the agent session never
+    restarts, which means the wrap parent keeps running the code it started
+    with — for days. It is also the process that emits the census on session
+    exit. So every wrap user's beat reported whatever version was installed when
+    their session began, and kept reporting it for the life of that session. The
+    "versions in the wild" chart was therefore a picture of when people last
+    restarted, not of what they have installed. Observed live: a machine running
+    1.34.0 beat ``1.28.0`` two upgrades later.
+
+    ``importlib.metadata`` re-discovers the dist-info on each call, so a
+    pipx/pip upgrade under a running process is visible immediately — that is
+    precisely what ``hotswap.installed_version()`` was built for, so this reuses
+    it rather than re-deriving it.
+
+    Falls back to the interpreter's own version when the package metadata is not
+    discoverable (a source checkout, a zipapp, a vendored copy). That fallback is
+    the old, slightly-stale answer, which is strictly better than reporting
+    nothing and is never wrong about *which* distil is running.
+    """
+    from . import __version__
+
+    try:
+        from .hotswap import installed_version
+
+        on_disk = installed_version()
+    except Exception:  # noqa: BLE001 — telemetry must never break the caller
+        on_disk = None
+    return on_disk or __version__
+
+
 def build_payload(*, accrue: bool = False) -> dict:
     """The census, exactly as it would be sent. Numbers and platform strings
     only — never content, paths, hashes-of-content, or key material.
@@ -366,7 +402,7 @@ def build_payload(*, accrue: bool = False) -> dict:
     persisted only on a real send (`maybe_ping`). `distil census show` and any
     direct preview call leave `~/.distil/census-savings.json` untouched.
     """
-    from . import __version__, ledger
+    from . import ledger
 
     s = ledger.summary()
     raw_tokens = max(0, s.total_baseline_tokens - s.total_distil_tokens)
@@ -378,7 +414,7 @@ def build_payload(*, accrue: bool = False) -> dict:
     payload = {
         "schema": 4,
         "install_id": install_id(),
-        "version": __version__,
+        "version": _reported_version(),
         "os": platform.system(),
         "arch": platform.machine(),
         "python": platform.python_version(),

--- a/docs/adoption.html
+++ b/docs/adoption.html
@@ -66,6 +66,15 @@
 
   .gridtwo{display:grid;grid-template-columns:1fr 1fr;gap:26px}
   @media(max-width:920px){.gridtwo{grid-template-columns:1fr}}
+  /* Census charts: one reflowing grid rather than three stacked hard-coded pairs.
+     Those pairs carried their own margin-tops (12px on the first row, 22px after)
+     so the columns started at different heights and the block read as ragged.
+     auto-fit keeps rows aligned, drops to 2-up then 1-up on its own, and a new
+     chart can be added without picking a row for it. */
+  .chartgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+             gap:22px 26px;margin-top:18px}
+  .chartgrid > section{min-width:0}  /* let long bar labels ellipsize, not stretch the column */
+  .chartgrid .seyebrow{margin-top:0}
 
   .chipset{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0 6px}
   .chip{border:1px solid var(--line);border-radius:999px;padding:5px 13px;font-size:12.5px;
@@ -299,37 +308,31 @@
     <h2 style="margin-top:0">Who actually <span class="g">runs</span> it — and what it saves them</h2>
     <p>Machines that consented (<code>distil census on</code>). Anonymous install ids, schema frozen by test, <a href="https://github.com/dshakes/distil/blob/main/TELEMETRY.md">fully disclosed</a> — preview your own payload anytime with <code>distil census show</code>.</p>
 
-    <div class="gridtwo">
-      <div>
-        <div class="seyebrow p" style="margin-top:12px">Distil versions in the wild</div>
+    <div class="chartgrid">
+      <section>
+        <div class="seyebrow p">Versions in the wild &middot; active 30d</div>
         <div class="bars" id="byversion"></div>
-      </div>
-      <div>
-        <div class="seyebrow p" style="margin-top:12px">Tokens saved by model</div>
+      </section>
+      <section>
+        <div class="seyebrow p">Tokens saved by model</div>
         <div class="bars" id="bymodel"></div>
-      </div>
-    </div>
-
-    <div class="gridtwo">
-      <div>
-        <div class="seyebrow p" style="margin-top:22px">Integration surface &middot; requests</div>
+      </section>
+      <section>
+        <div class="seyebrow p">Integration surface &middot; requests</div>
         <div class="bars" id="bysurface"></div>
-      </div>
-      <div>
-        <div class="seyebrow p" style="margin-top:22px">API shape &middot; SDK wire formats</div>
+      </section>
+      <section>
+        <div class="seyebrow p">API shape &middot; SDK wire formats</div>
         <div class="bars" id="byshape"></div>
-      </div>
-    </div>
-
-    <div class="gridtwo">
-      <div>
-        <div class="seyebrow p" style="margin-top:22px">Session mode &middot; how it's driven</div>
+      </section>
+      <section>
+        <div class="seyebrow p">Session mode &middot; how it's driven</div>
         <div class="bars" id="bymode"></div>
-      </div>
-      <div>
-        <div class="seyebrow p" style="margin-top:22px">Billing mix &middot; wrapped agents &middot; channels</div>
+      </section>
+      <section>
+        <div class="seyebrow p">Billing mix &middot; wrapped agents &middot; channels</div>
         <div class="chipset" id="chips"></div>
-      </div>
+      </section>
     </div>
 
     <div class="seyebrow">How it's measured</div>
@@ -485,6 +488,10 @@
   // Pause/Resume (WCAG 2.2.2): a visible control suspends both polling
   // intervals below and this rAF easing loop; nothing updates while paused.
   var paused = false, pollTimer = null, liveTimer = null, rafId = null;
+  // Census contributor count from the last aggregates paint. The live pulse needs
+  // it because the live endpoint has no contributor field of its own, and the one
+  // it does send (`active`) is a consent count. null until the first paint.
+  var lastContributing = null;
   function desiredTokens() {
     return liveBase ? liveBase.total : targetTokens;
   }
@@ -520,11 +527,21 @@
         // No rate projection ("there is no honest amount of rate-projection"): a
         // per-interval heartbeat rate ×86400 is phantom "/day" growth from idle
         // machines. Show the honest live pulse — how many machines are saving now.
-        // "saving now" must mean *saving*, not *consenting*. A heartbeat only
-        // fires when tokens actually grew, so d.active is already contributors
-        // only — but prefer an explicit count when the endpoint sends one, and
-        // never let the consent count stand in for it.
-        var act = (d.saving != null ? d.saving : d.active) || 0;
+        // "saving now" must mean *saving*, not *consenting*.
+        //
+        // This used to fall back to d.active on the theory that a heartbeat only
+        // fires when tokens grew, so active was contributors-only. The live
+        // endpoint does not actually work that way: it returns
+        // {"active":2,"installs":2} — active IS the consent count. So the hero
+        // read "2 machines saving now" directly above its own sentence saying
+        // "summed from 1 machine that ... actually reported savings". The page
+        // contradicted itself, in the overstating direction.
+        //
+        // Order now: an explicit `saving` from the endpoint, else the census
+        // `contributing` count the rest of this page already renders, else no
+        // machine count at all. Never d.active — it cannot be distinguished from
+        // consent, and when it equals `installs` it demonstrably is consent.
+        var act = d.saving != null ? d.saving : (lastContributing != null ? lastContributing : 0);
         set("rate-sec", act > 0 ? commas(act) + (act === 1 ? " machine" : " machines") : "exact");
         set("rate-day", act > 0
           ? "saving now · exact total, moves only when it truly rises"
@@ -589,6 +606,7 @@
     // claim about how many reported, rather than substituting the consent count
     // (which is the very overstatement this exists to remove).
     var contrib = s.contributing != null ? s.contributing : null;
+    lastContributing = contrib;  // the live pulse reuses this — see pollLive()
     var consented = a.installs.census_total || 0;
     set("hero-machines", contrib == null
       ? "the machines"

--- a/scripts/census_rollup.py
+++ b/scripts/census_rollup.py
@@ -163,7 +163,15 @@ def rollup(metrics_dir: Path, now: float | None = None) -> dict:
         "shadowed": eq_shadowed,
     }
 
-    versions = Counter(r["version"] for r in latest.values())
+    # "Versions in the wild" means the CURRENT fleet, so it is scoped to installs
+    # that are still active. Counting every install_id ever seen made a machine
+    # that pinged once and vanished sit in the histogram forever, pinned to
+    # whatever it last reported — the chart drifted toward dead old versions and
+    # a fresh upgrade barely moved it. Every other population number on the page
+    # is already 7/30d-scoped; this one silently was not.
+    versions = Counter(
+        r["version"] for r in latest.values() if now - r["ts"] <= 30 * 86400 and r.get("version")
+    )
     tokens = sum(int(r["tokens_saved"]) for r in latest.values())  # Σ latest-per-install (faithful)
     # Dollars are bucketed by billing: metered = real savings; subscription =
     # notional API-rate value (shown and labeled, never mixed into real $).

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -750,3 +750,41 @@ def test_heartbeat_corrupt_marker_recovers(tmp_path, monkeypatch):
     # first beat with no prior baseline: last_ts=0 so throttle passes; grew from 0
     assert census.maybe_heartbeat() is True
     assert calls and calls[0]["tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Reported version — the "versions in the wild" histogram depends on this
+# ---------------------------------------------------------------------------
+
+
+def test_reported_version_reads_disk_not_the_running_interpreter(monkeypatch):
+    """A long-lived `distil wrap` parent keeps running the code it started with
+    (hot-swap replaces the worker, not the parent) and is the process that emits
+    the census on exit. Reporting the imported __version__ there meant every
+    wrap user's beat was pinned to whenever their session began — observed live
+    as a 1.34.0 machine reporting 1.28.0 two upgrades later.
+    """
+    import distil
+    import distil.hotswap as hotswap
+
+    monkeypatch.setattr(hotswap, "installed_version", lambda: "9.9.9")
+    monkeypatch.setattr(distil, "__version__", "1.28.0")  # the stale in-memory one
+    assert census._reported_version() == "9.9.9"
+    assert census.build_payload()["version"] == "9.9.9"
+
+
+def test_reported_version_falls_back_when_metadata_is_absent(monkeypatch):
+    """Source checkout / zipapp / vendored copy: no dist-info to discover. The
+    stale-but-real version beats reporting nothing."""
+    import distil
+    import distil.hotswap as hotswap
+
+    monkeypatch.setattr(distil, "__version__", "1.28.0")
+    monkeypatch.setattr(hotswap, "installed_version", lambda: None)
+    assert census._reported_version() == "1.28.0"
+
+    def _boom():
+        raise RuntimeError("metadata backend exploded")
+
+    monkeypatch.setattr(hotswap, "installed_version", _boom)
+    assert census._reported_version() == "1.28.0", "a probe failure must not propagate"

--- a/tests/test_census_pipeline.py
+++ b/tests/test_census_pipeline.py
@@ -94,6 +94,26 @@ def test_rollup_dedupes_by_install_id_latest_wins(tmp_path):
     assert agg["installs"]["by_version"] == {"1.21.0": 1, "1.20.0": 1}
 
 
+def test_by_version_counts_only_the_still_active_fleet(tmp_path):
+    """ "Versions in the wild" must describe the CURRENT fleet.
+
+    Counting every install_id ever seen let a machine that pinged once and
+    vanished sit in the histogram forever, pinned to whatever it last reported —
+    so the chart drifted toward dead old versions and a real upgrade barely
+    moved it. Every other population number on the page is 7/30d-scoped; this
+    one silently was not.
+    """
+    now = int(time.time())
+    rows = [
+        _row(install_id="a" * 32, ts=now, version="1.34.0"),
+        _row(install_id="b" * 32, ts=now - 31 * 86400, version="1.20.0"),  # gone
+    ]
+    agg = census_rollup.rollup(_write_metrics(tmp_path, rows, []), now=now)
+    assert agg["installs"]["by_version"] == {"1.34.0": 1}, "an abandoned install still counted"
+    # It is still a real install that once existed — the all-time tally keeps it.
+    assert agg["installs"]["census_total"] == 2
+
+
 def test_rollup_community_total_is_faithful_sum_of_latest_per_install(tmp_path):
     """The live-counter fix: the community total is Σ latest-per-install — exactly
     what each install currently reports — NOT a rollup-side ratchet.


### PR DESCRIPTION
Reported as *"why does the adoption page show a previous distil version when I have the latest?"*.

It was not one bug. It was three, all with the same shape: **a value rendered as current, read from a source that is not.**

### 1. The census beat reported the interpreter's version, not the installed one

`distil wrap` is deliberately long-lived — hot-swap replaces the proxy *worker* on upgrade so the agent session never restarts, which means the **wrap parent keeps running the code it started with, for days**. It is also the process that emits the census on session exit.

So every wrap user's beat reported whatever was installed when their session began, and kept reporting it. Observed live: a machine running `1.34.0` beat `1.28.0`, two upgrades later. The "versions in the wild" chart was a picture of *when people last restarted*, not of what they have installed.

`census._reported_version()` now reads from disk via `hotswap.installed_version()` — which existed for exactly this distinction and simply was not being used here — falling back to `__version__` when there is no dist-info to discover (source checkout, zipapp, vendored copy).

### 2. `by_version` counted every install ever seen

No recency filter, under a chart that says "in the wild". A machine that pinged once and vanished sat in the histogram forever, pinned to its last reported version, so the chart drifted toward dead versions and a real upgrade barely moved it. Every other population number on the page was already 7/30d-scoped; this one silently was not.

Now scoped to installs active in 30d. The all-time tally (`census_total`) is unchanged — it is honestly labelled "recorded".

### 3. The live hero contradicted itself

The live endpoint returns `{"active":2,"installs":2}` and **no** `saving` field — `active` *is* the consent count. The page fell back to it despite a comment saying never to, so the hero read **"2 machines saving now"** directly above its own sentence **"summed from 1 machine that ... actually reported savings"**. It overstated, next to its own correction.

Order is now: explicit `saving` from the endpoint → the census `contributing` count the page already renders → no machine count at all. Never `active`.

### Also

Folds the census chart block into one reflowing grid. It was three hard-coded 2-column pairs each carrying its own margin-top (12px on the first row, 22px after), so columns started at different heights and read as ragged.

### Known limitation

Fix 1 only reaches the public page after a release, an upgrade, and a new beat. The historical rows in `data/census.jsonl` keep their wrong versions — fix 2 is what ages them out.

### Verification

Full gate run locally: **1936 passed, coverage 95.21%** (floor 95; was 95.18% before this work, so no erosion) · `distil verify` PASS · `distil validate` PASS 60/60 · `distil bench` GATE PASS · ruff 0.15.10 + mypy 1.17.1 clean. Live-endpoint behaviour re-verified in a browser against real data: hero now reads "1 machine", matching the contributing tile.

Two regression tests pin the version source and the 30d scoping.