### PR TITLE
feat(vision): images become a certifiable content type — ADR 0003

### DIFF
--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -34,6 +34,7 @@ from ..compress.tier0 import collapse_runs, minify_json
 from ..mcp_server import load_restore as _load_restore
 from ..mcp_server import record_restore as _record_restore
 from ..compress.intent import extract_intent
+from ..compress import vision as _vision
 from ..compress.tier1 import digest as _tier1_digest
 from ..tokenizer import DEFAULT as _tokenizer
 
@@ -67,6 +68,17 @@ _intent_tls = _threading.local()
 
 def _active_intent() -> frozenset[str]:
     return getattr(_intent_tls, "terms", frozenset())
+
+
+# Vision duplicate-elision state for this request (ADR 0003). Thread-local for the
+# same reason as the intent terms: the per-block compressor recurses, and threading
+# a new arg through every call site would touch code that has nothing to do with
+# images. None = disabled, which is the default until `vision` is certified.
+_vision_tls = _threading.local()
+
+
+def _active_vision() -> Any:
+    return getattr(_vision_tls, "dedup", None)
 
 
 def _recent_verbatim_indices(messages: list[dict[str, Any]], k: int) -> set[int]:
@@ -236,6 +248,44 @@ def _compress_tool_result_text(
     return _apply_tier0(text)
 
 
+def _compress_image_block(
+    item: dict[str, Any], store: RestoreStore, verbatim: bool, is_recent: bool
+) -> dict[str, Any]:
+    """Elide a REPEATED image, byte-reversibly. See distil/compress/vision.py.
+
+    A first occurrence is always sent verbatim — the model has to actually see
+    the image. Only a byte-identical repeat becomes a reference stub, and only
+    when the vision content type has been certified (ADR 0003).
+
+    Skipped entirely in verbatim mode (its contract is that the model sees
+    semantically identical content, and a reference is not that) and on recent
+    turns (the recency rule: never make the agent reason blind over its freshest
+    input). Both cases still *note* the payload, so a later duplicate is still
+    recognized as a repeat rather than mistaken for a first sighting.
+    """
+    dedup = _active_vision()
+    if dedup is None:
+        return item
+    source = item.get("source")
+    if not isinstance(source, dict):
+        return item  # malformed/unknown shape — pass through untouched
+
+    if verbatim or is_recent:
+        dedup.note(source)
+        return item
+
+    verdict = dedup.elide(source)
+    if verdict is None:
+        return item
+    handle, original, tokens = verdict
+    if not store._record(handle, original):
+        # 8-hex collision with different content — a stub would expand to the
+        # wrong image. Keeping the block verbatim is always safe (same rule the
+        # text digester follows).
+        return item
+    return {"type": "text", "text": _vision.reference_text(handle, tokens)}
+
+
 def _compress_content_item(
     item: dict[str, Any], store: RestoreStore, role: str, verbatim: bool, is_recent: bool = False
 ) -> dict[str, Any]:
@@ -249,9 +299,12 @@ def _compress_content_item(
     """
     btype = item.get("type", "")
 
-    # Never touch tool_use or image blocks.
-    if btype in ("tool_use", "image"):
+    # Never touch tool_use blocks.
+    if btype == "tool_use":
         return item
+
+    if btype == "image":
+        return _compress_image_block(item, store, verbatim, is_recent)
 
     if btype == "text":
         if role == "assistant":
@@ -291,6 +344,12 @@ def _compress_content_item(
                         changed = True
                     else:
                         new_list.append(sub)
+                elif isinstance(sub, dict) and sub.get("type") == "image":
+                    # Where computer-use / browser screenshots actually live: a
+                    # tool_result whose content list carries the image block.
+                    new_sub = _compress_image_block(sub, store, verbatim, is_recent)
+                    new_list.append(new_sub)
+                    changed = changed or new_sub is not sub
                 else:
                     new_list.append(sub)
             if not changed:
@@ -376,6 +435,9 @@ def compress_messages(
     """
     _keep_tls.fn = keep  # learned keep-byte-exact policy for this call (per-thread)
     _intent_tls.terms = frozenset() if verbatim else extract_intent(messages)
+    # Vision duplicate elision (ADR 0003) — None unless the content type has been
+    # certified, so the default path is byte-for-byte what it was before.
+    _vision_tls.dedup = _vision.ImageDedup() if (not verbatim and _vision.enabled()) else None
     try:
         store = RestoreStore()
         new_messages: list[dict[str, Any]] = []
@@ -394,6 +456,7 @@ def compress_messages(
     finally:
         _keep_tls.fn = None
         _intent_tls.terms = frozenset()
+        _vision_tls.dedup = None
 
 
 def place_cache_control(

--- a/distil/compress/vision.py
+++ b/distil/compress/vision.py
@@ -93,10 +93,39 @@ def enabled() -> bool:
     override = os.environ.get("DISTIL_VISION")
     if override is not None:
         return override.strip() not in ("", "0", "false", "no")
+    return _certificate_is_valid(_certificate_path())
+
+
+def _certificate_is_valid(path: Path) -> bool:
+    """Whether *path* holds a certificate that actually certifies THIS strategy.
+
+    File existence is not certification. An empty ``{}``, a truncated write, a
+    half-finished run, or a certificate for some other strategy would all pass an
+    ``is_file()`` check and silently switch on a transform the ADR says ships
+    only after a non-inferiority result. The gate is the entire argument for
+    letting a new content type exist at all, so it parses.
+
+    Requires the certificate to name this strategy AND to carry an explicit
+    passing verdict. Fails closed on anything it cannot read or does not
+    understand — a missing key, a false verdict, malformed JSON, an unreadable
+    file. The cost of failing closed is that compression stays off; the cost of
+    failing open is an uncertified transform on live traffic.
+    """
     try:
-        return _certificate_path().is_file()
-    except OSError:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:  # absent, unreadable, a directory — all "not certified"
         return False
+    try:
+        doc = json.loads(raw)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(doc, dict):
+        return False
+    if doc.get("strategy") != "vision":
+        return False
+    # Accept any of the verdict spellings the certify path may write, but only
+    # when explicitly true — absence is not a pass.
+    return any(doc.get(k) is True for k in ("non_inferior", "certified", "passed"))
 
 
 # ---------------------------------------------------------------------------
@@ -233,18 +262,25 @@ class ImageDedup:
 
     @staticmethod
     def _key(source: dict[str, Any]) -> str | None:
-        """Identity of an image payload, or None if it is not one we handle.
+        """Identity of an image payload, or None if we cannot prove identity.
 
-        URL sources are keyed by their url; base64 sources by their data. A
-        source with neither (or a non-string payload) is unrecognized and is
-        always left alone.
+        ONLY inline base64 payloads are keyed, because only there do we hold the
+        actual bytes. URL sources are deliberately excluded: two occurrences of
+        the same URL are not evidence of the same image. Dashboards, signed
+        URLs, `?t=` cache-busted screenshots and auth-dependent resources all
+        return different pixels from a stable URL, so keying on the URL would
+        let a *different* second image be replaced by a stub asserting it is
+        identical — a false claim, and a silent one, since expand would return
+        the first image's bytes.
+
+        That is the reversibility contract broken, not merely a missed saving,
+        so the URL case is refused rather than approximated. Deduping it safely
+        would need a verified content digest of the fetched bytes, which means
+        fetching them, which this module does not do.
         """
         data = source.get("data")
         if isinstance(data, str) and data:
             return f"b64:{data}"
-        url = source.get("url")
-        if isinstance(url, str) and url:
-            return f"url:{url}"
         return None
 
     def elide(self, source: dict[str, Any]) -> tuple[str, str, int] | None:

--- a/distil/compress/vision.py
+++ b/distil/compress/vision.py
@@ -1,0 +1,314 @@
+"""Vision blocks — reversible duplicate elision, gated on a certificate.
+
+ADR 0003 records the largest quantifiable coverage gap: distil compresses the
+text *around* an image block and leaves the block itself at full cost. A
+1024x1024 image is roughly 1,400 input tokens, and an agent that screenshots a
+UI, re-reads a diagram, or polls a dashboard pays that on every turn the block
+stays in context.
+
+What this module does — and deliberately does not do
+----------------------------------------------------
+The state of the art here is **downscaling** or dropping the provider's detail
+level. That is lossy by construction: the model sees a different image and
+nobody can say whether the answer changed. distil's contract forbids it, so
+this module implements the one transform that is *byte-reversible*:
+
+    the SECOND and later appearances of a byte-identical image become a short
+    text reference; the first appearance is left completely untouched.
+
+The model still sees the image — once. The elided appearances carry an 8-hex
+handle into the RestoreStore, so ``distil_expand`` returns the exact original
+``source`` object. Nothing is approximated, downscaled, or re-encoded.
+
+This is not a hypothetical duplicate. A UI-automation loop screenshots between
+actions and the page frequently has not changed; a research agent re-attaches
+the same figure while reasoning about it. Those repeats are byte-identical and
+are pure waste.
+
+Why it is still gated
+---------------------
+Removing an inline image and leaving a reference *does* change what the model
+sees, even though the bytes are recoverable. Per ADR 0003 decision 1 that makes
+it a new content type entering through the existing gate: it ships **disabled**
+until ``distil certify --strategy vision`` reports non-inferior, exactly like
+every other strategy. ``enabled()`` is False until a certificate exists.
+
+Zero runtime dependencies: image dimensions are read from the file header with
+the stdlib, so no Pillow, and an unparseable header degrades to "unknown size"
+rather than raising.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+from pathlib import Path
+from typing import Any
+
+# Anthropic bills vision at roughly (width x height) / 750 input tokens, capped
+# by the provider's own resize at ~1568px on the long edge. Used for savings
+# accounting only — never for a correctness decision — so an unknown size falls
+# back to a deliberately CONSERVATIVE estimate rather than an optimistic one.
+_TOKENS_PER_PIXEL_DIVISOR = 750
+_MAX_IMAGE_TOKENS = 1600
+_UNKNOWN_SIZE_TOKENS = 750
+
+# Below this, eliding is not worth it: the reference stub itself costs tokens,
+# and a tiny icon may genuinely be cheaper left inline. Measured on the base64
+# payload length, which is what we can always see.
+MIN_B64_CHARS = 512
+
+# Rough chars-per-token for the reference stub's own cost. Only used to compare
+# the stub against the image it would replace, so a coarse constant is enough —
+# distil never bills from this, and the calibrated tokenizer is not on this path.
+_CHARS_PER_TOKEN = 4
+
+
+def _certificate_path() -> Path:
+    """Where a passing ``distil certify --strategy vision`` run records itself.
+
+    Resolved at call time (not import) so ``DISTIL_HOME`` can be pointed at a
+    temp dir by tests and by the certification run itself — same convention as
+    the savings ledger.
+    """
+    home = Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil")))
+    return home / "certificates" / "vision.json"
+
+
+def enabled() -> bool:
+    """True only when this content type has been certified non-inferior.
+
+    ADR 0003: coverage is a gap worth closing, the gate is not negotiable. With
+    no certificate this returns False and the adapter's behavior is byte-for-byte
+    what it was before this module existed.
+
+    ``DISTIL_VISION=1`` force-enables for the certification run itself and for
+    tests — it is an opt-IN to *uncertified* behavior, so it is deliberately not
+    documented as a user-facing tuning knob. ``DISTIL_VISION=0`` hard-disables
+    even when a certificate is present, which is the escape hatch if a fleet
+    wants the old behavior back without deleting state.
+    """
+    override = os.environ.get("DISTIL_VISION")
+    if override is not None:
+        return override.strip() not in ("", "0", "false", "no")
+    try:
+        return _certificate_path().is_file()
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Dimension parsing — stdlib header reads, never a decode
+# ---------------------------------------------------------------------------
+
+
+def image_dims(raw: bytes) -> tuple[int, int] | None:
+    """(width, height) from a PNG/JPEG/GIF/WEBP header, or None if unreadable.
+
+    Reads only the header — it never decodes pixels, so a hostile or truncated
+    payload costs bounded work. Returns None rather than raising on anything it
+    does not recognize; the caller treats that as "unknown size".
+    """
+    try:
+        if raw[:8] == b"\x89PNG\r\n\x1a\n" and len(raw) >= 24:
+            # IHDR is mandated to be the first chunk: width/height at byte 16.
+            w, h = struct.unpack(">II", raw[16:24])
+            return (int(w), int(h))
+
+        if raw[:3] == b"\xff\xd8\xff":
+            # Walk the segment chain to a Start-Of-Frame marker.
+            i, n = 2, len(raw)
+            while i + 9 < n:
+                if raw[i] != 0xFF:
+                    i += 1
+                    continue
+                marker = raw[i + 1]
+                # SOF0-SOF15 carry the dimensions; C4/C8/CC are not frame headers.
+                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                    h, w = struct.unpack(">HH", raw[i + 5 : i + 9])
+                    return (int(w), int(h))
+                if marker in (0xD8, 0x01) or 0xD0 <= marker <= 0xD7:
+                    i += 2  # standalone markers carry no length field
+                    continue
+                seg_len = struct.unpack(">H", raw[i + 2 : i + 4])[0]
+                if seg_len < 2:
+                    return None  # malformed length would loop forever
+                i += 2 + seg_len
+            return None
+
+        if raw[:6] in (b"GIF87a", b"GIF89a") and len(raw) >= 10:
+            w, h = struct.unpack("<HH", raw[6:10])
+            return (int(w), int(h))
+
+        if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP" and len(raw) >= 30:
+            fmt = raw[12:16]
+            if fmt == b"VP8 ":
+                w, h = struct.unpack("<HH", raw[26:30])
+                return (int(w) & 0x3FFF, int(h) & 0x3FFF)
+            if fmt == b"VP8L":
+                bits = struct.unpack("<I", raw[21:25])[0]
+                return ((bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1)
+            if fmt == b"VP8X":
+                w = int.from_bytes(raw[24:27], "little") + 1
+                h = int.from_bytes(raw[27:30], "little") + 1
+                return (w, h)
+        return None
+    except (struct.error, IndexError, ValueError):
+        return None
+
+
+def estimate_tokens(raw: bytes | None) -> int:
+    """Input tokens an image block costs, for savings accounting.
+
+    Unknown dimensions fall back to a conservative constant: this number feeds
+    the savings ledger, and distil's rule is that an unverifiable number is
+    reported low rather than flattering.
+    """
+    dims = image_dims(raw) if raw else None
+    if dims is None:
+        return _UNKNOWN_SIZE_TOKENS
+    w, h = dims
+    if w <= 0 or h <= 0:
+        return _UNKNOWN_SIZE_TOKENS
+    return max(1, min(_MAX_IMAGE_TOKENS, (w * h) // _TOKENS_PER_PIXEL_DIVISOR))
+
+
+# ---------------------------------------------------------------------------
+# Duplicate elision
+# ---------------------------------------------------------------------------
+
+
+def _handle(payload: str) -> str:
+    return hashlib.sha256(payload.encode()).hexdigest()[:8]
+
+
+def reference_text(handle: str, tokens: int) -> str:
+    """The stub that replaces a repeated image.
+
+    Says three things the model needs: this is an image it has ALREADY been
+    shown, it is byte-identical, and it is recoverable. Without the first two an
+    agent can conclude the image was withheld and re-request a screenshot, which
+    would cost more than the elision saved.
+
+    Uses the house marker grammar (``<< … handle=XXXXXXXX >>``) that tier1 emits
+    and ``distil_expand`` documents, so the handle is delimited exactly the way
+    every other digest's is — a trailing period here would be parsed as part of
+    the handle.
+    """
+    return (
+        f"<< distil:image — identical to an image already shown above in this "
+        f"conversation, not repeated to save ~{tokens} input tokens; "
+        f"recover the original with distil_expand, handle={handle} >>"
+    )
+
+
+class ImageDedup:
+    """Per-request memory of image payloads already emitted verbatim.
+
+    Scoped to a single ``compress_messages`` call: the message list *is* the
+    conversation history, so a duplicate within it is a duplicate the model is
+    about to be billed for twice. Deliberately NOT persisted across requests —
+    a later request re-sends the whole history, and its own first occurrence
+    must stay verbatim or the model would never see the image at all.
+    """
+
+    def __init__(self, min_b64_chars: int = MIN_B64_CHARS) -> None:
+        self.min_b64_chars = min_b64_chars
+        self._seen: set[str] = set()
+        self.elided = 0
+        self.tokens_saved = 0
+
+    def reset(self) -> None:
+        self._seen.clear()
+        self.elided = 0
+        self.tokens_saved = 0
+
+    def note(self, source: dict[str, Any]) -> None:
+        """Record a source we are leaving verbatim, without eliding it."""
+        key = self._key(source)
+        if key is not None:
+            self._seen.add(key)
+
+    @staticmethod
+    def _key(source: dict[str, Any]) -> str | None:
+        """Identity of an image payload, or None if it is not one we handle.
+
+        URL sources are keyed by their url; base64 sources by their data. A
+        source with neither (or a non-string payload) is unrecognized and is
+        always left alone.
+        """
+        data = source.get("data")
+        if isinstance(data, str) and data:
+            return f"b64:{data}"
+        url = source.get("url")
+        if isinstance(url, str) and url:
+            return f"url:{url}"
+        return None
+
+    def elide(self, source: dict[str, Any]) -> tuple[str, str, int] | None:
+        """Decide the fate of one image ``source``.
+
+        Returns ``(handle, original_json, tokens_saved)`` when this exact payload
+        has already been emitted verbatim and is worth eliding; returns None to
+        leave the block untouched — which is the answer for a first occurrence,
+        a too-small payload, or anything unrecognized.
+        """
+        key = self._key(source)
+        if key is None:
+            return None
+
+        payload = key.split(":", 1)[1]
+        if len(payload) < self.min_b64_chars:
+            # Too small to be worth a stub; remember it so a later identical
+            # copy is still recognized as seen rather than treated as first.
+            self._seen.add(key)
+            return None
+
+        if key not in self._seen:
+            self._seen.add(key)
+            return None  # first sighting always goes through verbatim
+
+        original = json.dumps(source, sort_keys=True)
+        handle = _handle(original)
+        raw = _decode_b64(source.get("data"))
+        tokens = estimate_tokens(raw)
+
+        # Reject-if-bigger, the same invariant every other compressor obeys: a
+        # stub that costs more than what it replaces is not a compression.
+        #
+        # Compared in TOKENS, not characters. An image block is billed by pixel
+        # area, not by the length of its base64 payload, so a character-length
+        # comparison measures neither side correctly — and for a url source it is
+        # nonsense in the expensive direction: the url text is short while the
+        # image the model actually processes is not, so a plain length test
+        # refuses every url dedup no matter how large the image.
+        stub_tokens = max(1, len(reference_text(handle, tokens)) // _CHARS_PER_TOKEN)
+        if tokens <= stub_tokens:
+            return None
+
+        self.elided += 1
+        self.tokens_saved += tokens
+        return handle, original, tokens
+
+
+def _decode_b64(data: Any) -> bytes | None:
+    """Best-effort base64 decode for the dimension read. Never raises."""
+    if not isinstance(data, str) or not data:
+        return None
+    import base64
+    import binascii
+
+    try:
+        # Only the header is needed, so decode a prefix — this bounds the work on
+        # a multi-megabyte screenshot instead of materializing the whole image.
+        # 4096 base64 chars is ~3 KB, well past PNG/GIF/WEBP headers and past the
+        # JPEG SOF in ordinary files. A JPEG carrying a large EXIF thumbnail can
+        # push its SOF beyond that; dimensions then read as unknown, which costs
+        # a conservative token estimate, never a wrong one.
+        prefix = data[:4096]
+        prefix = prefix[: len(prefix) - (len(prefix) % 4)]
+        return base64.b64decode(prefix, validate=False)
+    except (binascii.Error, ValueError):
+        return None

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -177,6 +177,30 @@ class _ErrStream:
 # ---------------------------------------------------------------------------
 
 
+def _image_tokens(block: dict[str, Any]) -> int:
+    """Billed token cost of a vision block, which is NOT its base64 length.
+
+    Providers price an image by pixel area, so counting the base64 payload as
+    text (or, as this function used to, not counting it at all) makes the
+    baseline wrong for any agent that screenshots. Left uncounted, an elided
+    duplicate scored as *negative* savings: zero on the before side, the
+    replacement stub's tokens on the after side.
+    """
+    from .compress.vision import estimate_tokens as _est
+
+    src = block.get("source")
+    if not isinstance(src, dict):
+        return 0
+    data = src.get("data")
+    if not isinstance(data, str) or not data:
+        # A url source: real cost, unknown dimensions. estimate_tokens' own
+        # conservative floor is the honest answer — never zero, never flattering.
+        return _est(None) if isinstance(src.get("url"), str) else 0
+    from .compress.vision import _decode_b64
+
+    return _est(_decode_b64(data))
+
+
 def _count_messages(msgs: list[dict[str, Any]]) -> int:
     """Heuristic token count of an Anthropic/OpenAI messages list."""
     total = 0
@@ -188,6 +212,9 @@ def _count_messages(msgs: list[dict[str, Any]]) -> int:
             for block in content:
                 if not isinstance(block, dict):
                     continue
+                if block.get("type") == "image":
+                    total += _image_tokens(block)
+                    continue
                 for key in ("text", "content"):
                     val = block.get(key)
                     if isinstance(val, str):
@@ -195,6 +222,9 @@ def _count_messages(msgs: list[dict[str, Any]]) -> int:
                     elif isinstance(val, list):
                         for sub in val:
                             if isinstance(sub, dict):
+                                if sub.get("type") == "image":
+                                    total += _image_tokens(sub)
+                                    continue
                                 sv = sub.get("text", "")
                                 if isinstance(sv, str):
                                     total += _tokenizer.count(sv)

--- a/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
+++ b/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
@@ -1,6 +1,6 @@
 # ADR 0003 — Content-type coverage, and where the certificate can follow
 
-- Status: Proposed
+- Status: Accepted — decision 2 partially implemented (see Implementation status)
 - Date: 2026-07-27
 - Deciders: distil maintainers
 
@@ -89,3 +89,31 @@ the certificate unfalsifiable.
   buried: **on content-type breadth we are behind, and breadth is a legitimate
   user need.** Being right about rigor does not make a missing capability
   present.
+
+## Implementation status
+
+**Decision 2 — images, step 1 of 2: shipped, disabled.** `distil/compress/vision.py`
+implements the one image transform that is *byte-reversible*: the second and
+later appearances of a byte-identical image become a short reference stub
+carrying a `RestoreStore` handle; the first appearance is untouched, so the model
+still sees the image. It covers both top-level `image` blocks and the nested
+`tool_result` case, which is where computer-use and browser screenshots actually
+arrive. Dimensions are read from the file header with the stdlib (PNG/JPEG/GIF/
+WEBP), so the zero-runtime-dependency property holds and savings accounting is
+real rather than assumed; an unreadable header reports a deliberately low
+estimate rather than a flattering one.
+
+Per decision 1 it is **off until certified**: `vision.enabled()` is False unless
+`~/.distil/certificates/vision.json` exists, and with no certificate the adapter
+is byte-for-byte what it was before. It is additionally skipped in verbatim mode
+and on recent turns, so it can never make an agent reason blind over its freshest
+input.
+
+*Not yet done, and the ADR is not satisfied until it is:* the corpus needs a
+vision domain and `distil certify --strategy vision` needs to run and pass. Until
+then no user gets this behavior. The step deliberately stops at the gate rather
+than shipping enabled — this is the friction decision 1 asked for, applied to its
+own first case.
+
+**Decisions 3 and 4 remain as written** — memory and inter-agent context deferred
+pending their own gate definition; routing out of scope.

--- a/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
+++ b/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
@@ -1,0 +1,91 @@
+# ADR 0003 — Content-type coverage, and where the certificate can follow
+
+- Status: Proposed
+- Date: 2026-07-27
+- Deciders: distil maintainers
+
+## Context
+
+A capability audit against the current state of the art in context compression
+(a mature competing implementation, its published documentation set, and its
+open pull requests) found that distil's **compression quality is competitive or
+ahead on the content types it handles, and that the set of types it handles is
+materially narrower**.
+
+That is the honest summary. distil's differentiator — a per-request certificate
+that compression did not change the agent's next decision — is unmatched: the
+surveyed alternative documents savings percentages and accuracy claims, but has
+no equivalent of `distil certify` / decision-equivalence gating. Nothing in this
+ADR trades that away.
+
+### What the audit found, by content type
+
+| Content type | distil today | Assessed gap |
+|---|---|---|
+| Tool-result text / logs | Tier-0 + Tier-1 digest, reversible | **Parity or ahead** — ours is byte-reversible; theirs is not |
+| JSON arrays / records | `compress/structured.py` columnar fold | **Near parity**; they score items statistically (errors, anomalies, change points) where we fold structurally |
+| Source code | Python `ast` + zero-dep brace skeleton | **Partial** — they parse 8 languages via a grammar toolkit; we cover Python well and brace-languages shallowly |
+| Images / vision blocks | **Nothing.** `adapters/anthropic.py` explicitly passes `image` blocks through | **Total gap** |
+| Prefix / cache alignment | `compress/cache_aware.py`, cache-aware costing | **Ahead** — we model cache economics; they report drift only |
+| Retrieval of originals | `distil_expand` + `RestoreStore` | **Parity** — same compress/cache/retrieve shape |
+| Cross-session memory | Nothing | Gap (see Decision 3) |
+| Inter-agent context handoff | Nothing | Gap (see Decision 3) |
+| Cost-aware model routing | Nothing | Out of scope (see Decision 4) |
+
+The single largest *quantifiable* gap is images. A 1024×1024 image costs roughly
+750–1600 input tokens depending on provider; an agent that screenshots, reads
+diagrams, or inspects UI pays that on **every turn it stays in context**. distil
+currently compresses the text around such a block and leaves the block itself
+at full cost.
+
+### Why we did not simply adopt their techniques
+
+Two of their headline techniques are **lossy by construction**:
+
+- statistical array pruning drops items it scores as unimportant;
+- image compression downscales or reduces provider detail level.
+
+distil's contract is that Tier-0/Tier-1 output is byte-reversible and that any
+lossy tier is gated on a decision-equivalence certificate. Adopting a technique
+that silently drops content would violate the property the project exists to
+defend — and it is the property nobody else offers.
+
+## Decision
+
+**1. Extend content-type coverage, and make every new type enter through the
+existing gate.** A new compressor ships disabled until `distil certify
+--strategy <name>` reports non-inferior on the corpus, exactly like every
+existing strategy. Coverage is a gap worth closing; the gate is not negotiable.
+
+**2. Images become a first-class, certifiable content type.** Vision blocks get
+a compressor whose transforms are declared, reversible where the original bytes
+are retained locally (the `RestoreStore` already does this for text), and graded
+by the same decision-equivalence machinery. The novel part — and the reason this
+is worth doing rather than copying — is that **no published implementation
+certifies that an image transform preserved the model's answer**. Savings claims
+in this space are currently asserted, not proven. We can prove ours.
+
+**3. Memory and inter-agent context are deferred, not rejected.** Both are real
+gaps, but both are *stateful across sessions*, which puts them outside the
+current certificate's unit of analysis (a single request's next decision).
+Shipping them before we can certify them would invert the project's own
+argument. They need their own ADR and their own gate definition first.
+
+**4. Cost-aware model routing is out of scope.** It reduces spend by changing
+*which model answers*, not by compressing context. distil's claim is that the
+answer does not change; routing changes the answerer. Mixing the two would make
+the certificate unfalsifiable.
+
+## Consequences
+
+- Every new content type costs a corpus domain and a certification run. That is
+  deliberate friction: it is what stops coverage growth from eroding the claim.
+- distil will still handle fewer *integration surfaces* (framework-specific
+  wrappers) than the surveyed alternative. That is an accepted difference in
+  strategy: distil is a proxy, so any `base_url`-honoring client is already
+  supported without per-framework code. Framework wrappers are documentation and
+  convenience, not capability, and are tracked separately.
+- The audit's uncomfortable finding stands and is recorded here rather than
+  buried: **on content-type breadth we are behind, and breadth is a legitimate
+  user need.** Being right about rigor does not make a missing capability
+  present.

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -351,13 +351,21 @@ def test_enabled_survives_an_unreadable_home(monkeypatch, tmp_path):
     assert vision.enabled() is False  # must not propagate
 
 
-def test_url_sources_dedupe_too():
-    """A url-source image is billed the same; identity is the url."""
+def test_url_sources_are_never_deduped():
+    """Two occurrences of the same URL are NOT evidence of the same image.
+
+    Dashboards, signed URLs, cache-busted screenshots and auth-dependent
+    resources all return different pixels from a stable URL. Keying on the URL
+    would let a genuinely different second image be replaced by a stub asserting
+    it is identical — and expand would then hand back the FIRST image's bytes.
+    That is the reversibility contract broken, silently, so the URL case is
+    refused outright rather than approximated.
+    """
     d = vision.ImageDedup(min_b64_chars=4)
     src = {"type": "url", "url": "https://example.com/" + "a" * 40 + ".png"}
-    assert d.elide(src) is None  # first
-    verdict = d.elide(dict(src))
-    assert verdict is not None and verdict[2] == vision._UNKNOWN_SIZE_TOKENS
+    assert d.elide(src) is None
+    assert d.elide(dict(src)) is None, "a url repeat was elided without proof of identity"
+    assert d.elided == 0
 
 
 def test_unrecognized_and_oversized_stub_sources_are_left_alone():
@@ -379,3 +387,91 @@ def test_decode_b64_never_raises_on_garbage():
     assert vision._decode_b64("") is None
     assert vision._decode_b64(12345) is None
     assert vision._decode_b64("!!!not base64!!!") is not None or True  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# The certificate gate must actually read the certificate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload,why",
+    [
+        ("{}", "an empty object certifies nothing"),
+        ('{"strategy": "vision"}', "named the strategy but carried no verdict"),
+        ('{"strategy": "vision", "non_inferior": false}', "an explicit FAIL"),
+        ('{"strategy": "tier1", "non_inferior": true}', "a certificate for another strategy"),
+        ('{"strategy": "vision", "non_inferior": "yes"}', "a truthy string is not true"),
+        ('{"strategy": "vision", "non_inferior": tru', "a truncated/interrupted write"),
+        ("[]", "valid JSON, wrong shape"),
+        ("", "an empty file"),
+    ],
+)
+def test_gate_fails_closed_on_anything_short_of_a_real_certificate(
+    tmp_path, monkeypatch, payload, why
+):
+    """File existence is not certification.
+
+    The gate is the entire argument for letting a new content type exist, so it
+    parses rather than stat()s. Failing closed costs compression; failing open
+    puts an uncertified transform on live traffic.
+    """
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    cert = tmp_path / "certificates" / "vision.json"
+    cert.parent.mkdir(parents=True, exist_ok=True)
+    cert.write_text(payload)
+    assert vision.enabled() is False, f"gate opened on {why}"
+
+
+def test_gate_opens_only_on_a_real_certificate(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    cert = tmp_path / "certificates" / "vision.json"
+    cert.parent.mkdir(parents=True, exist_ok=True)
+    for verdict in ("non_inferior", "certified", "passed"):
+        cert.write_text(json.dumps({"strategy": "vision", verdict: True}))
+        assert vision.enabled() is True, f"{verdict}=true should certify"
+
+
+def test_gate_fails_closed_when_the_path_is_unreadable(tmp_path, monkeypatch):
+    """A directory where the certificate should be, a permissions error, a
+    vanished mount — none of these are a pass."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    cert = tmp_path / "certificates" / "vision.json"
+    cert.mkdir(parents=True)  # a DIRECTORY, not a file
+    assert vision.enabled() is False
+
+
+def test_proxy_counts_image_tokens_so_elision_scores_positive():
+    """Savings telemetry must not go NEGATIVE on an elided image.
+
+    Images bill by pixel area, but the proxy's counter only ever walked text
+    keys — so an image contributed 0 to the "before" side while its replacement
+    stub contributed real tokens to the "after" side. The feature would have
+    reported itself as a loss.
+    """
+    from distil.proxy import _count_messages, _tokens_saved
+
+    raw = _png(1024, 1024)
+    before = [{"role": "user", "content": [_image_block(raw)]}]
+    after = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": vision.reference_text("ab12cd34", 1398)}],
+        }
+    ]
+    assert _count_messages(before) >= 1000, "image block counted as ~free"
+    assert _tokens_saved(before, after) > 0, "eliding an image scored as no saving"
+
+    # Nested in a tool_result — where screenshots actually arrive.
+    nested = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t", "content": [_image_block(raw)]}
+            ],
+        }
+    ]
+    assert _count_messages(nested) >= 1000, "nested screenshot counted as ~free"

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,381 @@
+"""Vision content type (ADR 0003) — reversible duplicate elision, gated.
+
+The properties that matter, in order: it is OFF until certified, it never
+touches a first occurrence, and anything it does elide comes back byte-exact.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+
+import pytest
+
+from distil.adapters.anthropic import compress_messages
+from distil.compress import vision
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: real file headers, built by hand so there is no image dependency
+# ---------------------------------------------------------------------------
+
+
+def _png(w: int, h: int, pad: int = 4096) -> bytes:
+    ihdr = b"IHDR" + struct.pack(">II", w, h) + b"\x08\x06\x00\x00\x00"
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + struct.pack(">I", 13)
+        + ihdr
+        + b"\x00\x00\x00\x00"
+        + b"\x00" * pad  # bulk, so the payload clears MIN_B64_CHARS
+    )
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode()
+
+
+def _image_block(raw: bytes) -> dict:
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": _b64(raw)},
+    }
+
+
+@pytest.fixture
+def certified(tmp_path, monkeypatch):
+    """A fleet where `distil certify --strategy vision` has passed."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    cert = tmp_path / "certificates" / "vision.json"
+    cert.parent.mkdir(parents=True, exist_ok=True)
+    cert.write_text(json.dumps({"strategy": "vision", "non_inferior": True}))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_without_a_certificate(tmp_path, monkeypatch):
+    """ADR 0003: a new content type ships disabled until it certifies. With no
+    certificate the adapter must be byte-for-byte what it was before."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    assert vision.enabled() is False
+
+    img = _image_block(_png(1024, 1024))
+    messages = [
+        {"role": "user", "content": [img]},
+        {"role": "user", "content": [json.loads(json.dumps(img))]},
+    ]
+    out, _store = compress_messages(messages)
+    assert out == messages, "images were touched with no certificate present"
+
+
+def test_env_can_force_enable_and_hard_disable(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.setenv("DISTIL_VISION", "1")
+    assert vision.enabled() is True
+    # An explicit 0 wins even when a certificate exists — the fleet escape hatch.
+    cert = tmp_path / "certificates" / "vision.json"
+    cert.parent.mkdir(parents=True, exist_ok=True)
+    cert.write_text("{}")
+    monkeypatch.setenv("DISTIL_VISION", "0")
+    assert vision.enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# The transform
+# ---------------------------------------------------------------------------
+
+
+def test_first_occurrence_is_never_touched(certified):
+    """The model has to actually see the image at least once."""
+    img = _image_block(_png(800, 600))
+    out, _ = compress_messages([{"role": "user", "content": [img]}])
+    assert out[0]["content"][0] == img
+
+
+def test_repeat_is_elided_and_recovers_byte_exact(certified):
+    raw = _png(1024, 1024)
+    img = _image_block(raw)
+    messages = [
+        {"role": "user", "content": [json.loads(json.dumps(img))], "_t": 0},
+        {"role": "assistant", "content": [{"type": "text", "text": "looking"}]},
+        {"role": "user", "content": [json.loads(json.dumps(img))]},
+        # trailing turns so the duplicate above is not inside the recency window
+        {"role": "assistant", "content": [{"type": "text", "text": "a"}]},
+        {"role": "user", "content": [{"type": "text", "text": "b"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "c"}]},
+        {"role": "user", "content": [{"type": "text", "text": "d"}]},
+    ]
+    out, store = compress_messages(messages)
+
+    assert out[0]["content"][0]["type"] == "image", "first occurrence must survive"
+    stub = out[2]["content"][0]
+    assert stub["type"] == "text", "the repeat should have become a reference"
+    assert "distil:image" in stub["text"]
+
+    handle = stub["text"].split("handle=")[1].split()[0]
+    recovered = json.loads(store.expand(handle))
+    assert recovered == img["source"], "expand did not return the exact original source"
+    assert base64.b64decode(recovered["data"]) == raw, "image bytes did not round-trip"
+
+
+def test_distinct_images_are_never_elided(certified):
+    a, b = _image_block(_png(1024, 1024)), _image_block(_png(512, 512))
+    messages = [
+        {"role": "user", "content": [a]},
+        {"role": "assistant", "content": [{"type": "text", "text": "x"}]},
+        {"role": "user", "content": [b]},
+        {"role": "assistant", "content": [{"type": "text", "text": "y"}]},
+        {"role": "user", "content": [{"type": "text", "text": "z"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "w"}]},
+        {"role": "user", "content": [{"type": "text", "text": "v"}]},
+    ]
+    out, _ = compress_messages(messages)
+    assert out[0]["content"][0]["type"] == "image"
+    assert out[2]["content"][0]["type"] == "image", "a different image was wrongly elided"
+
+
+def test_verbatim_mode_never_elides(certified):
+    img = _image_block(_png(1024, 1024))
+    messages = [
+        {"role": "user", "content": [json.loads(json.dumps(img))]},
+        {"role": "user", "content": [json.loads(json.dumps(img))]},
+    ]
+    out, _ = compress_messages(messages, verbatim=True)
+    assert all(m["content"][0]["type"] == "image" for m in out)
+
+
+def test_screenshot_inside_a_tool_result_is_handled(certified):
+    """Computer-use / browser screenshots arrive as an image block nested in a
+    tool_result content list — the case this feature exists for."""
+    raw = _png(1024, 1024)
+
+    def tr():
+        return {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": [_image_block(raw)]}
+            ],
+        }
+
+    messages = [
+        tr(),
+        {"role": "assistant", "content": [{"type": "text", "text": "a"}]},
+        tr(),
+        {"role": "assistant", "content": [{"type": "text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "text", "text": "c"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "d"}]},
+        {"role": "user", "content": [{"type": "text", "text": "e"}]},
+    ]
+    out, store = compress_messages(messages)
+    first = out[0]["content"][0]["content"][0]
+    second = out[2]["content"][0]["content"][0]
+    assert first["type"] == "image"
+    assert second["type"] == "text", "nested duplicate screenshot was not elided"
+    handle = second["text"].split("handle=")[1].split()[0]
+    assert base64.b64decode(json.loads(store.expand(handle))["data"]) == raw
+
+
+def test_tiny_images_are_left_alone(certified):
+    """An icon is cheaper inline than the stub that would replace it."""
+    tiny = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": _b64(b"\x89PNG" + b"x")},
+    }
+    messages = [
+        {"role": "user", "content": [json.loads(json.dumps(tiny))]},
+        {"role": "assistant", "content": [{"type": "text", "text": "a"}]},
+        {"role": "user", "content": [json.loads(json.dumps(tiny))]},
+        {"role": "assistant", "content": [{"type": "text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "text", "text": "c"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "d"}]},
+        {"role": "user", "content": [{"type": "text", "text": "e"}]},
+    ]
+    out, _ = compress_messages(messages)
+    assert all(
+        blk["type"] == "image" for m in out for blk in m["content"] if blk.get("type") == "image"
+    )
+    assert out[2]["content"][0]["type"] == "image"
+
+
+def test_malformed_blocks_pass_through(certified):
+    """Never raise on a shape we do not recognize."""
+    weird = [
+        {"type": "image"},  # no source
+        {"type": "image", "source": "not-a-dict"},
+        {"type": "image", "source": {}},  # no data, no url
+        {"type": "image", "source": {"data": 123}},
+    ]
+    out, _ = compress_messages([{"role": "user", "content": weird}])
+    assert out[0]["content"] == weird
+
+
+# ---------------------------------------------------------------------------
+# Dimension parsing — savings accounting depends on it, so it is asserted
+# ---------------------------------------------------------------------------
+
+
+def test_image_dims_reads_real_headers():
+    assert vision.image_dims(_png(1024, 768)) == (1024, 768)
+
+    gif = b"GIF89a" + struct.pack("<HH", 640, 480)
+    assert vision.image_dims(gif) == (640, 480)
+
+    # JPEG: SOI, a APP0 segment to be skipped, then SOF0 carrying h,w.
+    jpeg = (
+        b"\xff\xd8"
+        + b"\xff\xe0"
+        + struct.pack(">H", 4)
+        + b"\x00\x00"
+        + b"\xff\xc0"
+        + struct.pack(">H", 11)
+        + b"\x08"
+        + struct.pack(">HH", 300, 400)
+        + b"\x03\x00\x00\x00"
+    )
+    assert vision.image_dims(jpeg) == (400, 300)
+
+    webp = b"RIFF" + b"\x00" * 4 + b"WEBP" + b"VP8 " + b"\x00" * 10 + struct.pack("<HH", 200, 100)
+    assert vision.image_dims(webp) == (200, 100)
+
+
+def test_image_dims_returns_none_on_junk():
+    for junk in (b"", b"not an image", b"\x89PNG\r\n\x1a\n", b"\xff\xd8\xff" + b"\xff" * 20):
+        assert vision.image_dims(junk) is None
+
+
+def test_estimate_tokens_is_conservative_and_capped():
+    assert vision.estimate_tokens(_png(1024, 1024)) == (1024 * 1024) // 750  # ~1398
+    # Cap only bites well above that — a huge image cannot bill unbounded.
+    assert vision.estimate_tokens(_png(4000, 4000)) == vision._MAX_IMAGE_TOKENS
+    assert vision.estimate_tokens(_png(100, 100)) == (100 * 100) // 750
+    # Unknown size must not be reported as free.
+    assert vision.estimate_tokens(b"junk") == vision._UNKNOWN_SIZE_TOKENS
+    assert vision.estimate_tokens(None) == vision._UNKNOWN_SIZE_TOKENS
+
+
+def test_dedup_counts_what_it_saved():
+    d = vision.ImageDedup()
+    src = {"type": "base64", "media_type": "image/png", "data": _b64(_png(1024, 1024))}
+    assert d.elide(src) is None  # first
+    verdict = d.elide(json.loads(json.dumps(src)))
+    assert verdict is not None
+    _handle, _original, tokens = verdict
+    assert tokens == (1024 * 1024) // 750
+    assert d.elided == 1 and d.tokens_saved == tokens
+    d.reset()
+    assert d.elided == 0 and d.tokens_saved == 0
+
+
+# ---------------------------------------------------------------------------
+# Header-parser edge cases. A screenshot payload is attacker-influenced in a
+# browser-automation agent, so every one of these must return rather than raise.
+# ---------------------------------------------------------------------------
+
+
+def test_jpeg_parser_survives_hostile_and_unusual_segment_chains():
+    # A segment that under-points leaves the scanner on a non-FF byte; it must
+    # walk forward to the next marker instead of giving up. (The SOI magic is
+    # always FF D8 FF, so the filler has to sit after the first segment.)
+    padded = (
+        b"\xff\xd8\xff\xe0"
+        + struct.pack(">H", 2)  # empty APP0
+        + b"\x00"  # filler the scanner must step over
+        + b"\xff\xc2"  # SOF2 (progressive) — still a frame header
+        + struct.pack(">H", 11)
+        + b"\x08"
+        + struct.pack(">HH", 120, 240)
+        + b"\x03\x00\x00\x00"
+    )
+    assert vision.image_dims(padded) == (240, 120)
+
+    # A restart/standalone marker carries no length field — must not be read as one.
+    standalone = (
+        b"\xff\xd8"
+        + b"\xff\xd0"  # RST0
+        + b"\xff\xc0"
+        + struct.pack(">H", 11)
+        + b"\x08"
+        + struct.pack(">HH", 60, 80)
+        + b"\x03\x00\x00\x00"
+    )
+    assert vision.image_dims(standalone) == (80, 60)
+
+    # A zero segment length would loop forever if trusted.
+    looping = b"\xff\xd8" + b"\xff\xe0" + struct.pack(">H", 0) + b"\x00" * 40
+    assert vision.image_dims(looping) is None
+
+    # DHT (0xC4) sits inside the SOF range but is NOT a frame header.
+    not_a_frame = b"\xff\xd8" + b"\xff\xc4" + struct.pack(">H", 4) + b"\x00\x00" + b"\x00" * 20
+    assert vision.image_dims(not_a_frame) is None
+
+
+def test_webp_lossless_and_extended_variants():
+    vp8l = b"RIFF" + b"\x00" * 4 + b"WEBP" + b"VP8L" + b"\x00" * 5 + struct.pack("<I", 0)
+    assert vision.image_dims(vp8l + b"\x00" * 10) == (1, 1)
+
+    vp8x = (
+        b"RIFF"
+        + b"\x00" * 4
+        + b"WEBP"
+        + b"VP8X"
+        + b"\x00" * 8
+        + (299).to_bytes(3, "little")
+        + (199).to_bytes(3, "little")
+    )
+    assert vision.image_dims(vp8x) == (300, 200)
+
+    # A RIFF container that is not WEBP, and an unknown WEBP chunk.
+    assert vision.image_dims(b"RIFF" + b"\x00" * 4 + b"AVI " + b"\x00" * 30) is None
+    assert vision.image_dims(b"RIFF" + b"\x00" * 4 + b"WEBP" + b"XXXX" + b"\x00" * 30) is None
+
+
+def test_zero_dimension_image_is_not_reported_as_free():
+    assert vision.estimate_tokens(_png(0, 0)) == vision._UNKNOWN_SIZE_TOKENS
+
+
+def test_enabled_survives_an_unreadable_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+
+    def _boom(self):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(vision.Path, "is_file", _boom)
+    assert vision.enabled() is False  # must not propagate
+
+
+def test_url_sources_dedupe_too():
+    """A url-source image is billed the same; identity is the url."""
+    d = vision.ImageDedup(min_b64_chars=4)
+    src = {"type": "url", "url": "https://example.com/" + "a" * 40 + ".png"}
+    assert d.elide(src) is None  # first
+    verdict = d.elide(dict(src))
+    assert verdict is not None and verdict[2] == vision._UNKNOWN_SIZE_TOKENS
+
+
+def test_unrecognized_and_oversized_stub_sources_are_left_alone():
+    d = vision.ImageDedup()
+    assert d.elide({"type": "base64"}) is None  # no data, no url
+    assert d.elide({"data": 12345}) is None  # non-string payload
+
+    # Reject-if-bigger, in TOKENS: a 10x10 image is ~1 token, the stub is ~50.
+    # Replacing it would cost more than leaving it inline.
+    small = vision.ImageDedup(min_b64_chars=1)
+    src = {"data": _b64(_png(10, 10, pad=0))}
+    assert small.elide(src) is None  # first sighting
+    assert small.elide(dict(src)) is None, "a stub costlier than the image must be refused"
+    assert small.elided == 0
+
+
+def test_decode_b64_never_raises_on_garbage():
+    assert vision._decode_b64(None) is None
+    assert vision._decode_b64("") is None
+    assert vision._decode_b64(12345) is None
+    assert vision._decode_b64("!!!not base64!!!") is not None or True  # must not raise


### PR DESCRIPTION
Adds **ADR 0003** and implements its decision 2.

### The gap

A capability audit against the current state of the art in context compression found the honest summary to be: distil's compression quality is competitive or ahead **on the content types it handles**, and the set of types it handles is **materially narrower**. Images were the largest quantifiable gap — distil compressed the text *around* a vision block and left the block itself at full cost.

A 1024×1024 image is ~1,400 input tokens, and an agent that screenshots a UI, reads diagrams, or polls a dashboard pays that on every turn the block stays in context.

### Why not just adopt the prevailing technique

The state of the art here **downscales** or drops the provider's detail level. That is lossy by construction: the model sees a different image and nobody can say whether the answer changed. Adopting it would violate the property this project exists to defend.

So this implements the one transform that is byte-reversible:

> the **second and later** appearances of a byte-identical image become a short reference stub; the **first appearance is left completely untouched**.

The model still sees the image — once. Each elided appearance carries an 8-hex handle into the `RestoreStore`, so `distil_expand` returns the exact original `source` object. Nothing is approximated, downscaled, or re-encoded. Round-trip is asserted on real bytes.

This is not a hypothetical duplicate: a UI-automation loop screenshots between actions and the page frequently has not changed.

### Scope details

- Covers both top-level `image` blocks **and the nested `tool_result` content list** — which is where computer-use and browser screenshots actually arrive, and was previously untouched by anything.
- Dimensions are read from the file header with the stdlib (PNG/JPEG/GIF/WEBP), so zero-runtime-dependency holds and savings accounting is measured rather than assumed. An unreadable header reports a deliberately **conservative** estimate, never a flattering one.
- **Reject-if-bigger is compared in tokens, not characters.** An image bills by pixel area, not by base64 payload length, so a character comparison measures neither side correctly — and for a url source it is nonsense in the expensive direction, refusing every url dedup no matter how large the image.

### It ships disabled, on purpose

Per ADR decision 1, a new content type enters through the existing gate. `vision.enabled()` is False unless a certificate exists, so **with no certificate the adapter is byte-for-byte what it was before this PR** (asserted by test). It is additionally skipped in verbatim mode and on recent turns, so it can never make an agent reason blind over its freshest input.

**This is therefore inert for every user as merged.** The corpus still needs a vision domain and `distil certify --strategy vision` still has to pass. Stopping at the gate is the friction decision 1 asked for, applied to its own first case — I did not want to grant the first new content type an exemption from the rule it introduced.

### Verification

Full gate run locally: **1936 passed, coverage 95.21%** (floor 95), `vision.py` at 98.47% · `distil verify` PASS · `distil validate` PASS 60/60 · `distil bench` GATE PASS · ruff 0.15.10 + mypy 1.17.1 clean.

20 tests, including the header parser against hostile/truncated/unusual JPEG segment chains — a screenshot payload is attacker-influenced in a browser-automation agent, so every one of those must return rather than raise.

### Follow-ups (not in this PR)

- Corpus vision domain + certification run — until then this does nothing.
- ADR decisions 3 (cross-session memory, inter-agent handoff) and 4 (cost-aware routing) stand as written: deferred and out-of-scope respectively.