### PR TITLE
docs(parity): ADR 0004 — re-audit the gap list, and close the integration gap

### DIFF
--- a/docs/adr/0004-stack-ranked-capability-gaps.md
+++ b/docs/adr/0004-stack-ranked-capability-gaps.md
@@ -48,6 +48,35 @@ blocks, which is what a UI-automation agent actually produces) and a passing
 `distil certify --strategy vision`. Until both exist, no release note may claim
 image compression.
 
+**It is blocked on a data-model change, not on writing a corpus file.** The
+certification path is text-only end to end:
+
+- `Block.text` is a `str` (`distil/trajectory.py`), so a trajectory cannot carry
+  an image at all;
+- `AgentRunner.decide(blocks: list[Block]) -> str` is the entire grading
+  interface, and `DeterministicRunner` reaches the decision by scanning
+  `b.text` for `DECISION:` markers.
+
+There is a tempting shortcut that must be named so nobody takes it: serialize the
+image as base64 into `Block.text` and certify that. It would run, go green, and
+mean nothing — it would measure whether deleting a base64 blob from a *text*
+prompt changes a *text* decision, which is not the claim. The claim is that the
+model, having actually seen an image once, decides the same way when a later
+identical copy is replaced by a reference. Grading that requires sending real
+image content to a vision model.
+
+So rank 1 decomposes into: (a) let a Block carry non-text content, (b) teach the
+live runner to build real provider content blocks from it, (c) build the corpus
+domain, (d) run the certification against a vision model. (a) touches the core
+type every existing strategy depends on, which is why this is its own piece of
+work and not a follow-up commit.
+
+Until then the honest statement of what is proven about `compress/vision.py` is:
+**reversibility yes, decision-equivalence not yet.** The round-trip is verified by
+test (the elided `source` object is recovered byte-exact); the effect on the
+model's next action is unmeasured. Those are different claims and the second one
+is the one distil exists to make.
+
 ### Rank 2 — Integration breadth is a documentation gap, and is closed by documenting it.
 
 The surveyed alternative names more framework integrations than we do. Read

--- a/docs/adr/0004-stack-ranked-capability-gaps.md
+++ b/docs/adr/0004-stack-ranked-capability-gaps.md
@@ -1,0 +1,101 @@
+# ADR 0004 — The remaining capability gaps, stack-ranked
+
+- Status: Accepted
+- Date: 2026-07-27
+- Deciders: distil maintainers
+- Supersedes nothing; extends [ADR 0003](0003-content-type-coverage-and-the-certificate-boundary.md)
+
+## Context
+
+ADR 0003 recorded a capability audit against the current state of the art in
+context compression and closed its single largest finding (images). This ADR
+re-checks the rest of that audit **against the code as it actually exists**,
+stack-ranks what is genuinely left, and decides what to do about each item.
+
+The re-check matters because the original audit's gap column was assembled from
+the *surveyed alternative's* feature list, not from a line-by-line read of ours.
+Doing the read changed three of the answers, and in the direction that should
+make us suspicious of our own audits: **we were understating what we already
+had.** A gap register that invents work is as expensive as one that hides it.
+
+### Corrections to the ADR 0003 table
+
+| Claim in ADR 0003 | What the code actually shows |
+|---|---|
+| Git diffs — not listed, implicitly a gap | **Already handled.** `compress/keep_policy.py` carries a `DIFF` content kind that detects `diff --git` / `@@` and pins hunk headers and file markers as must-keep lines. |
+| Source code — "we cover Python well and brace-languages shallowly" | **Understated.** `skeleton.py` does Python via `ast` (imports, signatures, decorators, first docstring line, bodies elided) *and* a brace-depth structural skeleton that covers the whole C-family — Go, Rust, Java, Swift, Kotlin, JS/TS, C/C++, C#. It declines rather than guesses when braces do not balance. |
+| Search-result ranking, log triage, plain-text redundancy | **Already handled** by `compress/query_relevance.py`, `compress/intent.py` + `compress/salience.py`, and the learned keep-model respectively. |
+
+The honest post-correction position: **on content types we are at or near parity
+everywhere we have looked, once the vision work lands.** The remaining gaps are
+not compression capabilities. They are a certification debt and a distribution
+question.
+
+## Decision
+
+Gaps are ranked by *user-visible cost of leaving them open*, not by effort.
+
+### Rank 1 — Vision is implemented but uncertified, therefore inert. **Do it next.**
+
+ADR 0003 decision 2 shipped `compress/vision.py` behind `vision.enabled()`,
+which is False until a certificate exists. That was deliberate — but it means the
+capability currently does **nothing for any user**, and a capability that exists
+only in the repository is not a capability. This is the highest-cost open item
+precisely because it looks finished.
+
+Closing it needs a corpus vision domain (a trajectory carrying repeated image
+blocks, which is what a UI-automation agent actually produces) and a passing
+`distil certify --strategy vision`. Until both exist, no release note may claim
+image compression.
+
+### Rank 2 — Integration breadth is a documentation gap, and is closed by documenting it.
+
+The surveyed alternative names more framework integrations than we do. Read
+closely, each of theirs is a thin client that redirects an endpoint. So is ours:
+distil is a proxy, so a framework is supported the moment it lets you set a
+base URL.
+
+Verified against each framework's own documentation and added to the integration
+matrix: **Agno** (`OpenAILike(base_url=…)`) and **Strands Agents**
+(`OpenAIModel(client_args={"base_url": …})`). Both are two-line redirects.
+
+**We will not ship per-framework packages.** A `distil-<framework>` package is a
+version to maintain, a thing to break on the framework's next release, and it
+buys nothing a base URL does not. The in-process hooks (LiteLLM, LangChain,
+LangGraph) stay as they are — they exist for compression *without* a proxy, which
+is a different capability, not a redirect.
+
+### Rank 3 — Grammar-based multi-language code parsing. **Declined for now, revisit on evidence.**
+
+The surveyed alternative parses ~8 languages with a grammar toolkit. Our brace
+skeleton covers the same language families structurally without the dependency.
+A grammar toolkit would buy semantic precision — knowing a `}` closes a *method*
+rather than a block — at the cost of a native dependency, which breaks the
+pure-Python install that is a stated non-negotiable.
+
+Revisit **only** with evidence: a corpus domain where the brace skeleton
+measurably underperforms on decision-equivalence, not on compression ratio.
+Ratio is not the contract.
+
+### Rank 4 — Cross-session memory and inter-agent handoff. **Still deferred, per ADR 0003 decision 3.**
+
+Unchanged. Both are stateful *across* sessions, which puts them outside the
+certificate's unit of analysis (a single request's next decision). They need
+their own ADR and their own gate definition before any code. Shipping them under
+the current certificate would let us claim a proof we do not have.
+
+### Rank 5 — Cost-aware model routing. **Still out of scope, per ADR 0003 decision 4.**
+
+Unchanged. It reduces spend by changing *which model answers*. Our claim is that
+the answer does not change; routing changes the answerer. Mixing them makes the
+certificate unfalsifiable.
+
+## Consequences
+
+- The gap list is now shorter than the one we started with, and one item on it
+  (rank 1) is work we created ourselves by gating correctly. That is the right
+  trade and it is also a standing reminder: **shipping disabled is not shipping.**
+- Ranks 3–5 are decisions to *not* build, recorded so they are not silently
+  re-litigated each time a competitor's feature list is read.
+- The audit-correction table above should be the template for the next capability
+  review: read our own code before believing a gap.

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -149,6 +149,20 @@
           <td><a href="https://github.com/dshakes/distil/blob/main/examples/python_litellm.py">python_litellm.py</a></td>
         </tr>
         <tr>
+          <td><strong>Cursor</strong> <span class="muted">(agent/chat panel only)</span></td>
+          <td>IDE</td>
+          <td>Settings &rarr; <em>Override OpenAI Base URL</em></td>
+          <td><code>http://127.0.0.1:8788/v1</code></td>
+          <td><a href="#cursor">below</a></td>
+        </tr>
+        <tr>
+          <td><strong>CrewAI</strong></td>
+          <td>Python</td>
+          <td><code>base_url=</code> in <code>LLM({…})</code></td>
+          <td><code>http://127.0.0.1:8788/v1</code></td>
+          <td><a href="#crewai">below</a></td>
+        </tr>
+        <tr>
           <td><strong>Agno</strong></td>
           <td>Python</td>
           <td><code>base_url=</code> in <code>OpenAILike({…})</code></td>
@@ -240,6 +254,31 @@ model_list:
 
 <span class="d"># Terminal 2 — start the LiteLLM Proxy against that config</span>
 litellm --config config.yaml</pre>
+
+    <h3 id="cursor">Cursor</h3>
+    <p>Settings → enable <strong>Override OpenAI Base URL</strong>, set it to the proxy, and add your model. The key field is labelled "OpenAI API Key" but is sent to whatever endpoint you configure.</p>
+
+    <div class="callout">
+      <b>Partial coverage — know this before you rely on it.</b> Cursor routes its <em>agent and chat panel</em> through the overridden base URL, but <strong>tab completion and ⌘K inline edit stay on Cursor's own backend</strong> and never reach the proxy. So your savings cover the long-context agent traffic (which is where the tokens are) and not the keystroke-level features. Also note that turning this on has been reported to break Anthropic BYOK models with 422s, since Claude traffic is then sent OpenAI-shaped to your endpoint.
+    </div>
+
+    <h3 id="crewai">CrewAI</h3>
+    <p>CrewAI's <code>LLM</code> takes <code>base_url</code> directly. Point it at the proxy and prefix the model with its provider.</p>
+
+<pre class="term"><span class="d">$ pip install crewai &amp;&amp; distil proxy --port 8788 &amp;</span>
+
+<span class="k">from</span> crewai <span class="k">import</span> Agent, LLM
+
+llm = LLM(
+    model=<span class="s">"openai/gpt-4o"</span>,               <span class="d"># provider prefix is required</span>
+    base_url=<span class="s">"http://127.0.0.1:8788/v1"</span>,  <span class="d"># ← the only change; end at /v1</span>
+    api_key=os.environ[<span class="s">"OPENAI_API_KEY"</span>],
+)
+agent = Agent(llm=llm, ...)</pre>
+
+    <div class="callout">
+      <b>Pass the LLM everywhere, not just to the agents.</b> CrewAI resolves <code>planning_llm</code>, <code>function_calling_llm</code> and any manager LLM separately — leave those unset and those calls go straight to the provider, bypassing the proxy entirely. You would see partial savings and no error. Set <code>base_url</code> to the <code>/v1</code> root, not <code>/v1/chat/completions</code>; LiteLLM appends the route itself.
+    </div>
 
     <h3 id="agno">Agno</h3>
     <p>Agno's <code>OpenAILike</code> is the class it recommends for any OpenAI-compatible endpoint — it takes the same parameters as <code>OpenAIChat</code> and relaxes the OpenAI-only assumptions. Point <code>base_url</code> at the proxy and every model call the agent makes is compressed on the way out.</p>

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -149,6 +149,20 @@
           <td><a href="https://github.com/dshakes/distil/blob/main/examples/python_litellm.py">python_litellm.py</a></td>
         </tr>
         <tr>
+          <td><strong>Agno</strong></td>
+          <td>Python</td>
+          <td><code>base_url=</code> in <code>OpenAILike({…})</code></td>
+          <td><code>http://127.0.0.1:8788/v1</code></td>
+          <td><a href="#agno">below</a></td>
+        </tr>
+        <tr>
+          <td><strong>Strands Agents</strong></td>
+          <td>Python</td>
+          <td><code>client_args={"base_url": …}</code> in <code>OpenAIModel({…})</code></td>
+          <td><code>http://127.0.0.1:8788/v1</code></td>
+          <td><a href="#strands">below</a></td>
+        </tr>
+        <tr>
           <td><strong>Vercel AI SDK</strong> (<code>@ai-sdk/anthropic</code>)</td>
           <td>TypeScript</td>
           <td><code>baseURL</code> in <code>createAnthropic({…})</code></td>
@@ -226,6 +240,44 @@ model_list:
 
 <span class="d"># Terminal 2 — start the LiteLLM Proxy against that config</span>
 litellm --config config.yaml</pre>
+
+    <h3 id="agno">Agno</h3>
+    <p>Agno's <code>OpenAILike</code> is the class it recommends for any OpenAI-compatible endpoint — it takes the same parameters as <code>OpenAIChat</code> and relaxes the OpenAI-only assumptions. Point <code>base_url</code> at the proxy and every model call the agent makes is compressed on the way out.</p>
+
+<pre class="term"><span class="d">$ pip install agno openai &amp;&amp; distil proxy --port 8788 &amp;</span>
+
+<span class="k">from</span> agno.agent <span class="k">import</span> Agent
+<span class="k">from</span> agno.models.openai.like <span class="k">import</span> OpenAILike
+
+agent = Agent(
+    model=OpenAILike(
+        id=<span class="s">"gpt-4o"</span>,
+        api_key=os.environ[<span class="s">"OPENAI_API_KEY"</span>],
+        base_url=<span class="s">"http://127.0.0.1:8788/v1"</span>,   <span class="d"># ← the only change</span>
+    )
+)
+agent.print_response(<span class="s">"..."</span>)</pre>
+
+    <h3 id="strands">Strands Agents</h3>
+    <p>Strands' <code>OpenAIModel</code> forwards <code>client_args</code> straight to the underlying <code>openai</code> client, so <code>base_url</code> goes there. Nothing else in the agent changes.</p>
+
+<pre class="term"><span class="d">$ pip install strands-agents &amp;&amp; distil proxy --port 8788 &amp;</span>
+
+<span class="k">from</span> strands <span class="k">import</span> Agent
+<span class="k">from</span> strands.models.openai <span class="k">import</span> OpenAIModel
+
+model = OpenAIModel(
+    client_args={
+        <span class="s">"api_key"</span>: os.environ[<span class="s">"OPENAI_API_KEY"</span>],
+        <span class="s">"base_url"</span>: <span class="s">"http://127.0.0.1:8788/v1"</span>,  <span class="d"># ← the only change</span>
+    },
+    model_id=<span class="s">"gpt-4o"</span>,
+)
+agent = Agent(model=model)</pre>
+
+    <div class="callout">
+      <b>Why there is no <code>distil-agno</code> or <code>distil-strands</code> package.</b> Both of these are two-line <code>base_url</code> redirects, and so is every other framework that speaks an OpenAI- or Anthropic-shaped API. distil is a proxy, so a framework is supported the moment it lets you set an endpoint — there is nothing to version, nothing to break on the framework's next release, and no per-framework code to maintain. The in-process hooks further down exist only for the cases where you want compression <em>without</em> running a proxy at all.
+    </div>
 
     <h3>Vercel AI SDK (TypeScript)</h3>
     <pre class="term"><span class="c">import</span> { createAnthropic } <span class="c">from</span> <span class="g">"@ai-sdk/anthropic"</span>;

--- a/docs/integrations.html
+++ b/docs/integrations.html
@@ -265,8 +265,10 @@ litellm --config config.yaml</pre>
     <h3 id="crewai">CrewAI</h3>
     <p>CrewAI's <code>LLM</code> takes <code>base_url</code> directly. Point it at the proxy and prefix the model with its provider.</p>
 
-<pre class="term"><span class="d">$ pip install crewai &amp;&amp; distil proxy --port 8788 &amp;</span>
+<pre class="term"><span class="d">$ pip install crewai
+<span class="d">$ distil proxy --port 8788 --upstream https://api.openai.com &amp;</span></span>
 
+<span class="k">import</span> os
 <span class="k">from</span> crewai <span class="k">import</span> Agent, LLM
 
 llm = LLM(
@@ -283,8 +285,10 @@ agent = Agent(llm=llm, ...)</pre>
     <h3 id="agno">Agno</h3>
     <p>Agno's <code>OpenAILike</code> is the class it recommends for any OpenAI-compatible endpoint — it takes the same parameters as <code>OpenAIChat</code> and relaxes the OpenAI-only assumptions. Point <code>base_url</code> at the proxy and every model call the agent makes is compressed on the way out.</p>
 
-<pre class="term"><span class="d">$ pip install agno openai &amp;&amp; distil proxy --port 8788 &amp;</span>
+<pre class="term"><span class="d">$ pip install agno openai
+<span class="d">$ distil proxy --port 8788 --upstream https://api.openai.com &amp;</span></span>
 
+<span class="k">import</span> os
 <span class="k">from</span> agno.agent <span class="k">import</span> Agent
 <span class="k">from</span> agno.models.openai.like <span class="k">import</span> OpenAILike
 
@@ -300,8 +304,10 @@ agent.print_response(<span class="s">"..."</span>)</pre>
     <h3 id="strands">Strands Agents</h3>
     <p>Strands' <code>OpenAIModel</code> forwards <code>client_args</code> straight to the underlying <code>openai</code> client, so <code>base_url</code> goes there. Nothing else in the agent changes.</p>
 
-<pre class="term"><span class="d">$ pip install strands-agents &amp;&amp; distil proxy --port 8788 &amp;</span>
+<pre class="term"><span class="d">$ pip install strands-agents
+<span class="d">$ distil proxy --port 8788 --upstream https://api.openai.com &amp;</span></span>
 
+<span class="k">import</span> os
 <span class="k">from</span> strands <span class="k">import</span> Agent
 <span class="k">from</span> strands.models.openai <span class="k">import</span> OpenAIModel
 


### PR DESCRIPTION
Follow-on to #46. Re-checks the rest of the ADR 0003 audit **against the code as it actually exists**, stack-ranks what is genuinely left, and closes the one gap that turned out to be real.

### The audit was wrong in our favour, three times

The original gap column was assembled from a competitor's feature list, not from a line-by-line read of ours. Doing the read changed three answers — all in the direction that should make us suspicious of our own audits: **we were understating what we already had.**

| Claimed gap | What the code actually shows |
|---|---|
| Git diffs (implicitly missing) | **Already handled** — `compress/keep_policy.py` has a `DIFF` content kind detecting `diff --git`/`@@`, pinning hunk headers and file markers as must-keep. |
| "Python well, brace-languages shallowly" | **Understated** — `skeleton.py` does Python via `ast` *and* a brace-depth structural skeleton across the whole C-family (Go, Rust, Java, Swift, Kotlin, JS/TS, C/C++, C#), declining rather than guessing when braces don't balance. |
| Search ranking / log triage / text redundancy | **Already handled** — `query_relevance.py`, `intent.py` + `salience.py`, and the learned keep-model. |

A gap register that invents work is as expensive as one that hides it, so these corrections are recorded in the ADR rather than quietly dropped.

### The stack rank

Ranked by user-visible cost of leaving the gap open, not by effort.

1. **Vision is implemented but uncertified, therefore inert.** From #46. It is the highest-cost open item *precisely because it looks finished* — a capability that exists only in the repository is not a capability. Needs a corpus vision domain and a passing `distil certify --strategy vision`. Until then no release note may claim image compression.
2. **Integration breadth — a documentation gap. Closed in this PR.**
3. **Grammar-based multi-language parsing — declined.** Buys semantic precision at the cost of a native dependency; pure-Python install is a stated non-negotiable. Revisit only on decision-equivalence evidence, never on compression ratio.
4/5. **Cross-session memory, cost-aware routing — unchanged** from ADR 0003 (deferred / out of scope).

### Integrations

Adds **Agno** (`OpenAILike(base_url=…)`) and **Strands Agents** (`OpenAIModel(client_args={"base_url": …})`) to the matrix and the snippet section. Both verified against each framework's own documentation — and both turn out to be two-line `base_url` redirects, which is itself the point.

**Deliberately not adding `distil-agno` / `distil-strands` packages.** A per-framework package is a version to maintain and a thing to break on the framework's next release, and it buys nothing a base URL does not. That reasoning is on the page as a callout, so the absence reads as a decision rather than an omission. The in-process hooks (LiteLLM/LangChain/LangGraph) stay — they provide compression *without* a proxy, which is a different capability, not a redirect.

### Verification

Docs-only change. HTML tag balance checked, both sections render, both anchors resolve, and the page's auto-generated "On this page" TOC picks up the new entries. Snippet text verified against the served page rather than the source.