### PR TITLE
fix(test): stop test_streaming's timing asserts flaking on loaded CI runners

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -17,7 +17,13 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from distil.proxy import build_handler
 
-_DELAY = 0.6  # upstream pause between chunks; first byte must beat this
+_DELAY = 3.0  # upstream pause between chunks; first byte must beat this
+# 0.6s previously: on a loaded shared CI runner (observed on windows-latest) the
+# whole first-chunk round trip — thread spin-up, socket connect, HTTP framing —
+# can itself take over a second with no buffering bug involved, which left only
+# ~450ms of slack and flaked. 3.0s keeps the assertion meaningful (a genuinely
+# buffered response still needs the full upstream pause before any byte arrives)
+# while giving the streamed path enough absolute slack to absorb that jitter.
 # Realistic Anthropic SSE deltas (with the `type` fields real streams carry) so the
 # decision signature reconstructs to a real "text" decision, not "none" — shadow
 # recording deliberately skips "none" signatures (transient/unparseable responses).


### PR DESCRIPTION
## What broke

CI went red on `main`: `gate (windows-latest, 3.12)` failed in commit ade1bee (#49) with

```
FAILED tests/test_streaming.py::test_gateway_streams_sse_incrementally
  assert (1.25 is not None and 1.25 < (0.6 * 0.75))
```

## Root cause

Not a product regression — ade1bee touched only `docs/index.html`, and the exact same job passed cleanly on the immediately preceding commit with unchanged test code. `test_streaming.py`'s three timing assertions share one `_DELAY = 0.6` constant and check that the first SSE chunk arrives well before the upstream's artificial pause elapses (proving the proxy streams rather than buffers). The allowed margin was `_DELAY * 0.75` = 450ms — on a loaded shared Windows runner, thread spin-up + socket connect + HTTP framing alone can eat past that with no buffering bug involved. The tests were already commented "generous margin so slow CI never flakes"; the margin just wasn't generous enough in absolute terms.

## Fix

Raise `_DELAY` from 0.6s to 3.0s. This keeps the assertion meaningful (a genuinely buffered response still needs the full upstream pause before any byte arrives) while giving the streamed path real absolute slack to absorb runner jitter. No product code changed.

## Verification

- `uv run --with pytest python -m pytest -q` — 1944 passed, 0 failed
- `uvx ruff@0.15.10 check distil tests` — clean
- `uvx mypy@1.17.1 --python-version 3.12 --ignore-missing-imports distil` — clean
- `uv run distil bench` / `distil verify` / `distil validate` — all PASS
- Ran the affected test 5x locally to confirm it isn't flaky here either

---
_Generated by [Claude Code](https://claude.ai/code/session_015LsuW1Tn1j2f6K3LkQGU7w)_