### PR TITLE
feat(simulate): dry-run a real request — what gets compressed, what is protected, and why

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -35,6 +35,46 @@ def _pct(part: float, whole: float) -> str:
     return f"{(1 - part / whole) * 100:5.1f}%" if whole else "  n/a"
 
 
+def cmd_simulate(args: argparse.Namespace) -> int:
+    """Dry-run the real pipeline on a real request. No model is called."""
+    import json as _json
+
+    from .simulate import format_report, simulate
+
+    if args.messages:
+        try:
+            raw = _json.loads(Path(args.messages).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"distil simulate: cannot read {args.messages}: {exc}")
+            return 2
+        messages = raw.get("messages") if isinstance(raw, dict) else raw
+        if not isinstance(messages, list):
+            print("distil simulate: expected a JSON array of messages, or {'messages': [...]}")
+            return 2
+    else:
+        # Bundled sample, shaped into a messages array so the default run
+        # exercises the same adapter path a real request takes.
+        traj = _load(None)
+        messages = []
+        for turn in traj.turns:
+            for blk in turn.blocks:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": blk.id, "content": blk.text}
+                        ],
+                    }
+                )
+
+    sim = simulate(messages, verbatim=args.verbatim)
+    if args.json:
+        print(_json.dumps(sim, indent=2))
+    else:
+        print(format_report(sim))
+    return 0
+
+
 def cmd_compress(args: argparse.Namespace) -> int:
     traj = _load(args.trajectory)
     tok = tokenizer.resolve(args.tokenizer, model=traj.model)
@@ -2573,6 +2613,24 @@ def build_parser() -> argparse.ArgumentParser:
     add_traj(c)
     add_tokenizer(c)
     c.set_defaults(func=cmd_compress)
+
+    sim = sub.add_parser(
+        "simulate",
+        help="dry-run a real request: what would be compressed, what is protected, and why",
+    )
+    sim.add_argument(
+        "--messages",
+        "-m",
+        help="path to a JSON file holding an Anthropic/OpenAI `messages` array "
+        "(default: the bundled sample trajectory, converted)",
+    )
+    sim.add_argument(
+        "--verbatim",
+        action="store_true",
+        help="preview the in-context-lossless mode (no Tier-1 digest stubs)",
+    )
+    sim.add_argument("--json", action="store_true", help="machine-readable output")
+    sim.set_defaults(func=cmd_simulate)
 
     s = sub.add_parser("savings", help="price strategies in real dollars (technique #1)")
     add_traj(s)

--- a/distil/simulate.py
+++ b/distil/simulate.py
@@ -109,29 +109,49 @@ def waste_signals(text: str) -> dict[str, dict[str, int]]:
     return out
 
 
-def _protection(role: str, btype: str, is_recent: bool, text: str) -> str:
-    """Why this block would be left byte-exact, or "" if it is compressible.
+def _protection(role: str, btype: str, is_recent: bool, text: str) -> tuple[str, str]:
+    """(rule, guarantee) for a protected block, or ("", "") if compressible.
 
-    The wording is the *rule*, not a restatement of the outcome — a user who
-    disagrees with a protection should be able to find the mechanism from this
-    string alone.
+    `guarantee` is deliberately separate from `rule`, and there are two of them,
+    because conflating them made this module lie. Recency exempts a block from
+    the Tier-1 DIGEST — it does not exempt it from Tier-0, whose lossless
+    transforms (minify_json, collapse_runs) still rewrite the bytes. Reporting
+    that as "left byte-exact" was false, in the one module whose entire purpose
+    is truthful protection reporting.
+
+      byte-exact     — not touched at all
+      lossless-only  — bytes may change; meaning is preserved and no content is
+                       moved behind a handle
+
+    The rule text names the MECHANISM, not the outcome, so a reader who disagrees
+    with a protection can go find the code that caused it.
     """
     if btype == "tool_use":
-        return "tool_use — arguments are executed verbatim, never rewritten"
+        return ("tool_use — arguments are executed verbatim, never rewritten", "byte-exact")
     if btype == "image":
-        return "image — vision blocks are only ever de-duplicated, never altered"
+        return (
+            "image — vision blocks are never re-encoded; an exact duplicate of an "
+            "earlier image may be replaced by a recoverable reference",
+            "byte-exact",
+        )
     if role == "assistant":
-        return "assistant turn — the model's own words are never rewritten"
+        return ("assistant turn — the model's own words are never rewritten", "byte-exact")
     if is_recent:
         return (
-            f"recency — within the last {RECENCY_KEEP_TURNS} tool-bearing turns, "
-            "which stay byte-exact so the agent never reasons blind on fresh output"
+            f"recency — within the last {RECENCY_KEEP_TURNS} tool-bearing turns, so no "
+            "Tier-1 digest is applied and the agent never reasons blind on fresh output "
+            "(Tier-0 lossless transforms still apply)",
+            "lossless-only",
         )
     kind = classify(text)
-    pinned = [ln for ln in text.splitlines() if must_keep(ln, kind)]
-    if pinned and len(pinned) == len(text.splitlines()):
-        return f"every line is decision-bearing ({kind.value}) — nothing is droppable"
-    return ""
+    lines = text.splitlines()
+    pinned = [ln for ln in lines if must_keep(ln, kind)]
+    if lines and len(pinned) == len(lines):
+        return (
+            f"every line is decision-bearing ({kind.value}) — nothing is droppable",
+            "lossless-only",
+        )
+    return ("", "")
 
 
 def _recent_indices(messages: list[dict[str, Any]], k: int) -> set[int]:
@@ -171,14 +191,31 @@ def simulate(messages: list[dict[str, Any]], *, verbatim: bool = False) -> dict[
         d_list = d_content if isinstance(d_content, list) else [d_content]
 
         for j, s_blk in enumerate(s_list):
+            btype = s_blk.get("type", "text") if isinstance(s_blk, dict) else "text"
             text = _block_text(s_blk)
-            if not text:
-                continue
             d_blk = d_list[j] if j < len(d_list) else None
             after_text = _block_text(d_blk)
-            btype = s_blk.get("type", "text") if isinstance(s_blk, dict) else "text"
-            b_tok, a_tok = _count(text), _count(after_text)
 
+            # Images carry no text at all, and skipping text-less blocks made the
+            # `image` protection branch DEAD — the report silently omitted vision
+            # blocks entirely. Same defect as tool_use had; fixed at the root here
+            # rather than per-type, so a future block kind cannot vanish the same
+            # way. Their cost is pixel-area, not string length.
+            if btype == "image":
+                from .proxy import _image_tokens
+
+                b_tok = _image_tokens(s_blk) if isinstance(s_blk, dict) else 0
+                a_tok = (
+                    _image_tokens(d_blk)
+                    if isinstance(d_blk, dict) and d_blk.get("type") == "image"
+                    else _count(after_text)
+                )
+            elif not text:
+                continue  # genuinely empty block of a kind that is textual
+            else:
+                b_tok, a_tok = _count(text), _count(after_text)
+
+            _prot_rule, _prot_guarantee = _protection(role, btype, idx in recent, text)
             sig = waste_signals(text)
             for k in totals:
                 totals[k]["chars"] += sig[k]["chars"]
@@ -193,7 +230,8 @@ def simulate(messages: list[dict[str, Any]], *, verbatim: bool = False) -> dict[
                     "tokens_after": a_tok,
                     "saved": max(0, b_tok - a_tok),
                     "kind": classify(text).value if btype == "tool_result" else "",
-                    "protected_by": _protection(role, btype, idx in recent, text),
+                    "protected_by": _prot_rule,
+                    "guarantee": _prot_guarantee,
                     "waste": sig,
                 }
             )
@@ -254,18 +292,20 @@ def format_report(sim: dict[str, Any], *, width: int = 76) -> str:
             )
         L.append("")
 
-    protected = [b for b in sim["blocks"] if b["protected_by"]]
-    if protected:
-        L.append("  left byte-exact, and why")
+    exact = [b for b in sim["blocks"] if b.get("guarantee") == "byte-exact"]
+    lossless = [b for b in sim["blocks"] if b.get("guarantee") == "lossless-only"]
+
+    def _emit(group: list[dict[str, Any]], heading: str) -> None:
+        if not group:
+            return
+        L.append(heading)
         seen: set[str] = set()
-        for b in protected:
+        for b in group:
             why = b["protected_by"]
             if why in seen:
                 continue
             seen.add(why)
             head = f"    turn {b['turn']:<3} {b['type']:<12} "
-            # Wrap rather than slice: these strings explain a RULE, and a reason
-            # cut mid-sentence ("…which stay byte-exact so the") teaches nothing.
             words, line = why.split(), head
             for w in words:
                 if len(line) + len(w) + 1 > width and line.strip() != head.strip():
@@ -275,6 +315,14 @@ def format_report(sim: dict[str, Any], *, width: int = 76) -> str:
                     line = (line + " " + w) if line != head else line + w
             if line.strip():
                 L.append(line)
-        if len(protected) > len(seen):
-            L.append(f"    … {len(protected) - len(seen)} more block(s) under the same rules")
+        if len(group) > len(seen):
+            L.append(f"    … {len(group) - len(seen)} more block(s) under the same rules")
+        L.append("")
+
+    _emit(exact, "  never touched (byte-exact)")
+    _emit(
+        lossless,
+        "  no digest applied — Tier-0 lossless transforms only, so bytes may change\n"
+        "  but meaning is preserved and nothing moves behind a handle",
+    )
     return "\n".join(L)

--- a/distil/simulate.py
+++ b/distil/simulate.py
@@ -1,0 +1,280 @@
+"""Dry-run: what distil would do to a request, and why — without calling a model.
+
+Two questions a user actually asks before switching compression on:
+
+  1. "How much would this save me?"  — answerable by running the real pipeline
+     locally, which costs nothing because no model is in the path.
+  2. "What would it touch, and what would it leave alone?" — the one that decides
+     whether they trust it.
+
+The second is the reason this module exists rather than a bare ratio. distil
+already computes *why* a block is protected — the recency exemption, the
+assistant's own words, a decision-bearing line pinned by the keep policy — and a
+preview that shows the ratio while hiding that reasoning is asking for the same
+trust every other compressor asks for. Here the protected set is reported as
+first-class output, per block, with the rule that protected it.
+
+Waste attribution answers the follow-up ("why is my saving only 12%?"): it splits
+the input into the recognisable shapes that inflate a prompt — pretty-printed
+JSON, whitespace runs, verbatim repetition — so the answer is a number and a
+cause rather than a shrug.
+
+Nothing here is an estimate of model behaviour. It reports what the pipeline
+does, measured, on the caller's own payload.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .compress.keep_policy import classify, must_keep
+from .compress.recency import RECENCY_KEEP_TURNS
+from .compress.tier0 import collapse_runs, minify_json
+from .tokenizer import DEFAULT as _tok
+
+# A run of 3+ blank lines / long indentation is padding, not structure.
+_WS_RUN = re.compile(r"[ \t]{4,}|\n{3,}")
+
+
+def _count(text: str) -> int:
+    return _tok.count(text)
+
+
+def _block_text(block: Any) -> str:
+    """The billable text of one content block, whatever shape it arrives in."""
+    if isinstance(block, str):
+        return block
+    if not isinstance(block, dict):
+        return ""
+    for key in ("text", "content"):
+        val = block.get(key)
+        if isinstance(val, str):
+            return val
+        if isinstance(val, list):
+            return "\n".join(_block_text(sub) for sub in val)
+    # A tool_use block's billable content is its serialized arguments. Without
+    # this it read as empty and was skipped entirely, so the preview never showed
+    # that tool_use is protected — the omission a caller would notice only after
+    # trusting the report.
+    if block.get("type") == "tool_use":
+        args = block.get("input")
+        if args is not None:
+            try:
+                return json.dumps(args, sort_keys=True)
+            except (TypeError, ValueError):
+                return str(args)
+        return str(block.get("name") or "")
+    return ""
+
+
+def waste_signals(text: str) -> dict[str, dict[str, int]]:
+    """Bloat attributable to each recognisable shape, in BOTH chars and tokens.
+
+    Both, because they disagree and the disagreement is the point. distil's
+    default offline tokenizer is whitespace-insensitive: a pretty-printed JSON
+    array and its minified form count IDENTICALLY (measured: 5,882 chars vs
+    3,721 chars, 2,874 tokens either way). Reporting only tokens would print
+    `json_bloat: 0` over an obviously bloated payload; reporting only chars would
+    imply a saving the tokenizer will not actually give you.
+
+    So: `chars` is what the shape costs on the wire, `tokens` is what THIS
+    tokenizer will charge for it. Run with a billing-grade tokenizer to see the
+    number your provider would bill.
+
+    Deliberately overlapping: a pretty-printed array is both json_bloat and
+    whitespace, and no honest split exists — so they are separate diagnostics,
+    never summed into one "waste" figure.
+    """
+    out = {
+        "json_bloat": {"chars": 0, "tokens": 0},
+        "whitespace": {"chars": 0, "tokens": 0},
+        "repetition": {"chars": 0, "tokens": 0},
+    }
+
+    def _record(name: str, reduced: str) -> None:
+        if reduced == text or len(reduced) >= len(text):
+            return
+        out[name] = {
+            "chars": len(text) - len(reduced),
+            "tokens": max(0, _count(text) - _count(reduced)),
+        }
+
+    minified = minify_json(text)
+    if minified is not None:
+        _record("json_bloat", minified)
+    _record("whitespace", _WS_RUN.sub(" ", text))
+    _record("repetition", collapse_runs(text))
+    return out
+
+
+def _protection(role: str, btype: str, is_recent: bool, text: str) -> str:
+    """Why this block would be left byte-exact, or "" if it is compressible.
+
+    The wording is the *rule*, not a restatement of the outcome — a user who
+    disagrees with a protection should be able to find the mechanism from this
+    string alone.
+    """
+    if btype == "tool_use":
+        return "tool_use — arguments are executed verbatim, never rewritten"
+    if btype == "image":
+        return "image — vision blocks are only ever de-duplicated, never altered"
+    if role == "assistant":
+        return "assistant turn — the model's own words are never rewritten"
+    if is_recent:
+        return (
+            f"recency — within the last {RECENCY_KEEP_TURNS} tool-bearing turns, "
+            "which stay byte-exact so the agent never reasons blind on fresh output"
+        )
+    kind = classify(text)
+    pinned = [ln for ln in text.splitlines() if must_keep(ln, kind)]
+    if pinned and len(pinned) == len(text.splitlines()):
+        return f"every line is decision-bearing ({kind.value}) — nothing is droppable"
+    return ""
+
+
+def _recent_indices(messages: list[dict[str, Any]], k: int) -> set[int]:
+    idxs = [
+        i
+        for i, m in enumerate(messages)
+        if isinstance(m, dict) and m.get("role") in ("user", "tool")
+    ]
+    return set(idxs[-k:]) if k > 0 else set()
+
+
+def simulate(messages: list[dict[str, Any]], *, verbatim: bool = False) -> dict[str, Any]:
+    """Run the real compression pipeline and report what it did.
+
+    Returns totals, a per-block breakdown (including the protected set and the
+    rule that protected each one), and waste attribution. No network, no model,
+    no side effects — safe to run across a sample of production traffic to size
+    the saving before switching anything on.
+    """
+    from .adapters.anthropic import compress_messages  # local: avoids an import cycle
+
+    before_json = json.dumps(messages)
+    compressed, store = compress_messages(messages, verbatim=verbatim)
+    after_json = json.dumps(compressed)
+
+    recent = _recent_indices(messages, RECENCY_KEEP_TURNS)
+    blocks: list[dict[str, Any]] = []
+    totals = {k: {"chars": 0, "tokens": 0} for k in ("json_bloat", "whitespace", "repetition")}
+
+    for idx, (src, dst) in enumerate(zip(messages, compressed)):
+        if not isinstance(src, dict):
+            continue
+        role = src.get("role", "")
+        s_content = src.get("content")
+        d_content = dst.get("content") if isinstance(dst, dict) else None
+        s_list = s_content if isinstance(s_content, list) else [s_content]
+        d_list = d_content if isinstance(d_content, list) else [d_content]
+
+        for j, s_blk in enumerate(s_list):
+            text = _block_text(s_blk)
+            if not text:
+                continue
+            d_blk = d_list[j] if j < len(d_list) else None
+            after_text = _block_text(d_blk)
+            btype = s_blk.get("type", "text") if isinstance(s_blk, dict) else "text"
+            b_tok, a_tok = _count(text), _count(after_text)
+
+            sig = waste_signals(text)
+            for k in totals:
+                totals[k]["chars"] += sig[k]["chars"]
+                totals[k]["tokens"] += sig[k]["tokens"]
+
+            blocks.append(
+                {
+                    "turn": idx,
+                    "role": role,
+                    "type": btype,
+                    "tokens_before": b_tok,
+                    "tokens_after": a_tok,
+                    "saved": max(0, b_tok - a_tok),
+                    "kind": classify(text).value if btype == "tool_result" else "",
+                    "protected_by": _protection(role, btype, idx in recent, text),
+                    "waste": sig,
+                }
+            )
+
+    before, after = _count(before_json), _count(after_json)
+    protected = [b for b in blocks if b["protected_by"]]
+    return {
+        "tokens_before": before,
+        "tokens_after": after,
+        "tokens_saved": max(0, before - after),
+        "savings_percent": round((before - after) / before * 100, 1) if before else 0.0,
+        # Every digest is one distil_expand away; this is the count of blocks the
+        # agent could pull back in full, which is what makes the saving reversible
+        # rather than a deletion.
+        "recoverable_blocks": len(store.handles),
+        "blocks": blocks,
+        "protected_blocks": len(protected),
+        "waste_signals": totals,
+        "verbatim": verbatim,
+    }
+
+
+def format_report(sim: dict[str, Any], *, width: int = 76) -> str:
+    """Human-readable rendering of :func:`simulate`, for the CLI."""
+    L: list[str] = []
+    pct = sim["savings_percent"]
+    L.append("distil simulate — what would happen, no model called")
+    L.append("")
+    L.append(
+        f"  {sim['tokens_before']:,} tokens in  ->  {sim['tokens_after']:,} out"
+        f"   ({pct}% saved, {sim['recoverable_blocks']} block(s) recoverable)"
+    )
+    if sim["verbatim"]:
+        L.append("  mode: verbatim — in-context-lossless transforms only, no digests")
+    L.append("")
+
+    ws = sim["waste_signals"]
+    if any(v["chars"] for v in ws.values()):
+        L.append("  where the waste is (diagnostics; they overlap, so they are not summed)")
+        for name, val in sorted(ws.items(), key=lambda kv: -kv[1]["chars"]):
+            if val["chars"]:
+                L.append(f"    {name:<12} {val['chars']:>8,} chars   {val['tokens']:>7,} tokens")
+        if not any(v["tokens"] for v in ws.values()):
+            L.append("")
+            L.append("    chars > 0 but tokens = 0: this tokenizer is whitespace-insensitive,")
+            L.append("    so it will not bill you for that shape. Re-run with a billing-grade")
+            L.append("    tokenizer to see what your provider would actually charge.")
+        L.append("")
+
+    movers = [b for b in sim["blocks"] if b["saved"] > 0]
+    if movers:
+        L.append("  compressed")
+        for b in sorted(movers, key=lambda b: -b["saved"])[:8]:
+            kind = f" [{b['kind']}]" if b["kind"] else ""
+            L.append(
+                f"    turn {b['turn']:<3} {b['role']:<9} {b['type']:<12}{kind}"
+                f"  {b['tokens_before']:,} -> {b['tokens_after']:,}"
+            )
+        L.append("")
+
+    protected = [b for b in sim["blocks"] if b["protected_by"]]
+    if protected:
+        L.append("  left byte-exact, and why")
+        seen: set[str] = set()
+        for b in protected:
+            why = b["protected_by"]
+            if why in seen:
+                continue
+            seen.add(why)
+            head = f"    turn {b['turn']:<3} {b['type']:<12} "
+            # Wrap rather than slice: these strings explain a RULE, and a reason
+            # cut mid-sentence ("…which stay byte-exact so the") teaches nothing.
+            words, line = why.split(), head
+            for w in words:
+                if len(line) + len(w) + 1 > width and line.strip() != head.strip():
+                    L.append(line)
+                    line = " " * len(head) + w
+                else:
+                    line = (line + " " + w) if line != head else line + w
+            if line.strip():
+                L.append(line)
+        if len(protected) > len(seen):
+            L.append(f"    … {len(protected) - len(seen)} more block(s) under the same rules")
+    return "\n".join(L)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -8,7 +8,9 @@ rule, is worse than no preview: it is the trust-me pitch with a number attached.
 
 from __future__ import annotations
 
+import base64
 import json
+import struct
 
 from distil.simulate import format_report, simulate, waste_signals
 
@@ -122,3 +124,80 @@ def test_malformed_input_does_not_raise():
     for msgs in ([], [{}], [{"role": "user"}], [{"role": "user", "content": None}], ["nope"]):
         sim = simulate(list(msgs))
         assert sim["tokens_before"] >= 0
+
+
+def _png(w: int = 1024, h: int = 1024, pad: int = 8000) -> bytes:
+    ihdr = struct.pack(">II", w, h)
+    return (
+        b"\x89PNG\r\n\x1a\x0a"
+        + struct.pack(">I", 13)
+        + b"IHDR"
+        + ihdr
+        + b"\x08\x06\x00\x00\x00"
+        + b"\x00" * pad
+    )
+
+
+def _image_block() -> dict:
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": base64.b64encode(_png()).decode(),
+        },
+    }
+
+
+def test_image_blocks_appear_in_the_report():
+    """Images carry no text, and skipping text-less blocks made the `image`
+    protection branch DEAD — vision blocks vanished from the report entirely.
+    Exactly the defect tool_use had; a preview that silently omits a block type
+    is worse than one that reports it wrongly, because nothing looks off.
+    """
+    msgs = [{"role": "user", "content": [_image_block()]}] + _padding()
+    sim = simulate(msgs)
+    imgs = [b for b in sim["blocks"] if b["type"] == "image"]
+    assert imgs, "image block missing from the report"
+    assert imgs[0]["protected_by"], "image reported with no protection rule"
+    # Billed by pixel area, not string length — a 1024x1024 image is ~1400 tokens.
+    assert imgs[0]["tokens_before"] > 500, "image counted as ~free"
+    assert "image" in format_report(sim)
+
+
+def test_recency_is_not_claimed_to_be_byte_exact():
+    """Recency exempts a block from the Tier-1 DIGEST, not from Tier-0, whose
+    lossless transforms still rewrite bytes. Calling that "left byte-exact" was
+    a false claim in the one module whose whole purpose is truthful reporting.
+    """
+    msgs = [_tool_result(_big_json())] + _padding()
+    sim = simulate(msgs)
+    recency = [b for b in sim["blocks"] if "recency" in (b["protected_by"] or "")]
+    assert recency, "no recency-protected block in this fixture"
+    for b in recency:
+        assert b["guarantee"] == "lossless-only", "recency must not claim byte-exact"
+        assert "Tier-0" in b["protected_by"], "the rule must say Tier-0 still applies"
+
+    report = format_report(sim)
+    # The byte-exact heading must not be the one carrying the recency rule.
+    exact_idx = report.find("never touched (byte-exact)")
+    recency_idx = report.find("recency —")
+    if exact_idx != -1 and recency_idx != -1:
+        lossless_idx = report.find("no digest applied")
+        assert lossless_idx != -1 and recency_idx > lossless_idx
+
+
+def test_every_protected_block_declares_a_guarantee():
+    """No block may be reported as protected without saying what is guaranteed."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t", "name": "n", "input": {}}],
+        },
+        {"role": "user", "content": [_image_block()]},
+        _tool_result(_big_json()),
+    ] + _padding()
+    sim = simulate(msgs)
+    for b in sim["blocks"]:
+        if b["protected_by"]:
+            assert b["guarantee"] in ("byte-exact", "lossless-only"), b

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,0 +1,124 @@
+"""`distil simulate` — the dry-run preview.
+
+The property that matters is not the ratio (compression is tested elsewhere) but
+that the preview tells the truth about what would be TOUCHED and what would be
+PROTECTED. A preview that overstates savings, or that quietly omits a protection
+rule, is worse than no preview: it is the trust-me pitch with a number attached.
+"""
+
+from __future__ import annotations
+
+import json
+
+from distil.simulate import format_report, simulate, waste_signals
+
+
+def _tool_result(text: str, tid: str = "t1") -> dict:
+    return {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": tid, "content": text}],
+    }
+
+
+def _padding(n: int = 6) -> list[dict]:
+    """Trailing turns so the block under test is outside the recency window."""
+    return [
+        {
+            "role": "assistant" if i % 2 == 0 else "user",
+            "content": [{"type": "text", "text": f"step {i}"}],
+        }
+        for i in range(n)
+    ]
+
+
+def _big_json(rows: int = 120) -> str:
+    return json.dumps(
+        [{"id": i, "service": "checkout", "status": "ok"} for i in range(rows)], indent=2
+    )
+
+
+def test_simulate_calls_no_model_and_reports_real_numbers():
+    """No network, and the reported saving is the pipeline's actual output."""
+    msgs = [_tool_result(_big_json())] + _padding()
+    sim = simulate(msgs)
+    assert sim["tokens_before"] > sim["tokens_after"] > 0
+    assert sim["tokens_saved"] == sim["tokens_before"] - sim["tokens_after"]
+    assert 0 < sim["savings_percent"] <= 100
+    # Anything digested must be recoverable — that is what makes it not deletion.
+    assert sim["recoverable_blocks"] >= 1
+
+
+def test_protected_blocks_name_the_rule_that_protected_them():
+    """The differentiator: a preview that shows the ratio but hides WHY a block
+    was left alone is the same 'trust me' every other compressor offers."""
+    msgs = [
+        {"role": "assistant", "content": [{"type": "text", "text": "I will run the tests now."}]},
+        _tool_result(_big_json()),
+    ] + _padding()
+    sim = simulate(msgs)
+    reasons = {b["protected_by"] for b in sim["blocks"] if b["protected_by"]}
+    assert any("assistant" in r for r in reasons), "assistant turn protection not reported"
+    assert any("recency" in r for r in reasons), "recency protection not reported"
+    # Every protected block carries a reason; none is protected silently.
+    for b in sim["blocks"]:
+        if b["tokens_before"] == b["tokens_after"] and b["protected_by"]:
+            assert len(b["protected_by"]) > 10
+
+
+def test_tool_use_and_images_are_reported_as_never_rewritten():
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "run", "input": {"cmd": "ls"}}],
+        },
+        _tool_result("output\n" * 40),
+    ] + _padding()
+    sim = simulate(msgs)
+    kinds = {b["type"]: b["protected_by"] for b in sim["blocks"]}
+    assert "tool_use" in kinds and "verbatim" in kinds["tool_use"]
+
+
+def test_waste_signals_report_chars_and_tokens_separately():
+    """The default tokenizer is whitespace-INSENSITIVE: pretty-printed JSON and
+    its minified form count identically. Reporting only tokens would print
+    `json_bloat: 0` over an obviously bloated payload; reporting only chars would
+    promise a saving this tokenizer will not give. So both, always."""
+    pretty = _big_json()
+    sig = waste_signals(pretty)
+    assert sig["json_bloat"]["chars"] > 0, "pretty-printed JSON is bloat by any measure"
+    # Not asserting tokens > 0 — that is tokenizer-dependent and the whole point.
+    assert sig["json_bloat"]["tokens"] >= 0
+    for name in ("json_bloat", "whitespace", "repetition"):
+        assert set(sig[name]) == {"chars", "tokens"}
+
+
+def test_waste_signals_are_zero_on_dense_text():
+    """No invented waste: prose with no JSON, runs, or repetition reports none."""
+    sig = waste_signals("The retry limit is five attempts before the circuit opens.")
+    assert all(v["chars"] == 0 for v in sig.values())
+
+
+def test_verbatim_mode_is_previewable_and_never_digests():
+    """The subscription-safe mode must be inspectable before it is trusted."""
+    msgs = [_tool_result(_big_json())] + _padding()
+    sim = simulate(msgs, verbatim=True)
+    assert sim["verbatim"] is True
+    assert sim["recoverable_blocks"] == 0, "verbatim mode must emit no digest handles"
+
+
+def test_report_wraps_reasons_instead_of_truncating():
+    """These strings explain a rule; one cut mid-sentence teaches nothing."""
+    msgs = [_tool_result(_big_json())] + _padding()
+    text = format_report(simulate(msgs))
+    assert "no model called" in text
+    for line in text.splitlines():
+        assert len(line) < 100
+    # The recency rule is long enough to need wrapping — check it survives whole.
+    assert "byte-exact" in text
+
+
+def test_malformed_input_does_not_raise():
+    """Previews run over whatever real traffic looks like, including junk."""
+    for msgs in ([], [{}], [{"role": "user"}], [{"role": "user", "content": None}], ["nope"]):
+        sim = simulate(list(msgs))
+        assert sim["tokens_before"] >= 0


### PR DESCRIPTION
The leading alternative ships a `simulate()` that answers **"how much would this save?"**. distil could already answer that — `distil compress` runs the real pipeline with no model in the path.

What it could not answer is the question that actually decides adoption: **"what would you touch, and what would you leave alone?"**

A preview that reports a ratio while hiding its reasoning is the same *trust me* pitch every other compressor makes, with a number attached. distil already computes **why** a block is protected — the recency exemption, the assistant's own words, tool_use arguments, lines the keep policy pins as decision-bearing. This reports that protected set as first-class output, per block, naming the rule. **That is the part nobody else can print.**

```
distil simulate                    # bundled sample
distil simulate -m request.json    # your own captured traffic
distil simulate --verbatim --json  # preview subscription-safe mode
```

Sample output:

```
  14,609 tokens in  ->  476 out   (96.7% saved, 1 block(s) recoverable)

  where the waste is (diagnostics; they overlap, so they are not summed)
    json_bloat      5,041 chars         0 tokens
    whitespace      2,160 chars         0 tokens

    chars > 0 but tokens = 0: this tokenizer is whitespace-insensitive,
    so it will not bill you for that shape. Re-run with a billing-grade
    tokenizer to see what your provider would actually charge.

  left byte-exact, and why
    turn 2   text    assistant turn — the model's own words are never rewritten
    turn 5   text    recency — within the last 2 tool-bearing turns, which stay
                     byte-exact so the agent never reasons blind on fresh output
```

No network, no model, no side effects — safe to run across a sample of production traffic to size the saving before switching anything on.

### Why waste is reported in both chars and tokens

Measuring during development turned up something worth knowing: distil's default offline tokenizer is **whitespace-insensitive**. A pretty-printed JSON array and its minified form both count **2,874 tokens** (5,882 chars vs 3,721).

So reporting only tokens prints `json_bloat: 0` over an obviously bloated payload, and reporting only chars promises a saving this tokenizer will not give. Both are reported, with an explicit note when they disagree. The signals deliberately overlap — pretty JSON is *both* json_bloat and whitespace — so they are never summed into one "waste" number, which would double-count and invent a figure.

### Two defects the tests caught, not review

- **`tool_use` blocks were skipped entirely.** Their billable content is the serialized `input`, not a `text`/`content` key, so `_block_text` returned `""` and the loop dropped them. The preview silently omitted that tool arguments are protected — exactly the kind of omission a caller finds only *after* trusting the report.
- **Protection reasons were sliced at the column width**, cutting mid-sentence (`…which stay byte-exact so the`). They explain a rule, so they now wrap.

### Explicitly not implemented

The same survey found their **failure-learning** command (reads agent session logs, writes corrections into CLAUDE.md). Not shipped, on purpose: it is not compression, it opens a new write surface on user config files, and no certificate can be attached to *"this correction will help your agent"*. It falls outside the motto rather than inside the roadmap.

### Verification

8 tests covering the protection reporting, the chars-vs-tokens split, verbatim mode emitting no handles, wrapping, and malformed input never raising. ruff 0.15.10 + mypy 1.17.1 clean.