### PR TITLE
release(1.35.0): metrics export, a truthful dry-run, and three stale numbers fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.35.0] — see what it does before you trust it
+
+Eight merged PRs. The theme is the same one twice: **a number that claims to be
+current, and a preview that claims to be complete.** Both were wrong, in public.
+
+**Three adoption numbers were stale, not false.** Reported as "the page shows a
+previous version when I have the latest" and it turned out to be three separate
+bugs of one shape. `distil wrap` is deliberately long-lived — hot-swap replaces
+the proxy *worker* on upgrade so your session never restarts, which means the
+wrap parent keeps running the code it started with, for days, and it is the
+process that emits the census. Every wrap user's beat reported whatever was
+installed when their session began; a machine running 1.34.0 was observed beating
+`1.28.0`, two upgrades later. `by_version` also counted every install ever seen
+under a chart that says "in the wild", so a machine that pinged once and vanished
+sat there forever. And the live hero read "2 machines saving now" directly above
+its own sentence "summed from 1 machine that actually reported savings" — the
+endpoint's `active` field is a *consent* count, and the page fell back to it.
+All three fixed; the version now reads from disk, the histogram is 30d-scoped,
+and "saving now" means saving.
+
+**`distil simulate` — a dry run that says what it will NOT touch.** Running the
+real pipeline locally with no model in the path was already possible. What was
+missing is the question that actually decides adoption: *what would you leave
+alone, and why?* distil already computes that — the recency exemption, the
+assistant's own words, tool_use arguments, lines the keep policy pins as
+decision-bearing — so the protected set is now first-class output, per block,
+naming the rule. Two guarantees are reported separately, because conflating them
+made the first version lie: `byte-exact` (not touched at all) and `lossless-only`
+(bytes may change, meaning preserved, nothing moved behind a handle). Recency is
+the second kind, not the first — it exempts a block from the Tier-1 digest, not
+from Tier-0.
+
+**Prometheus and OpenTelemetry.** `GET /distil/metrics` serves the standard text
+exposition, stdlib-only, behind the same admin gate as `/distil/stats` because the
+series are labelled by tenant. OTel counters mirror it, recorded at the same
+instrumentation point as the span attributes and *before* the span guard, so they
+survive tracing being sampled off. This corrects two published claims: the README
+and Deploy & Security both said distil has no metrics endpoint and cited that as a
+differentiator. It has one; the gate is the differentiator, and it is tested.
+
+**Images become a certifiable content type (ADR 0003).** The prevailing technique
+here downscales, which is lossy by construction — the model sees a different image
+and nobody can say whether the answer changed. Instead, the second and later
+appearances of a *byte-identical* image become a recoverable reference; the first
+is untouched. It ships **disabled**: `vision.enabled()` parses the certificate and
+requires an explicit passing verdict, so with none present the adapter is
+byte-for-byte what it was before. Reversibility is proven; decision-equivalence is
+not yet, and ADR 0004 records exactly what blocks it.
+
+**A savings figure that was wrong in public.** The proxy's estimator never counted
+image blocks, so an image was ~0 tokens on the "before" side. Any agent that sends
+images had an understated baseline. Now counted at pixel-area cost — which means
+**reported savings and census figures will shift for image traffic.** That is a
+correction, not an improvement.
+
+**Docs search.** 22 pages with no way to search them. ⌘K, static index, no service
+and no dependency. A test fails if the committed index goes stale, because a
+generated artifact that is committed rots the first time someone adds a page — and
+rots silently, since search simply never returns it.
+
+Also: Agno, Strands, Cursor and CrewAI added to the integration matrix, each with
+the caveat that actually bites (Cursor's override covers its agent panel but not
+tab-completion; CrewAI resolves `planning_llm` separately, so leaving it unset
+bypasses the proxy with no error). ADR 0004 stack-ranks what is genuinely left and
+records three gaps the earlier audit had *understated* — we had more than we
+thought. And the Gemini cross-audit workflow, dead on every PR, now runs from the
+base commit with a fail-closed tool allowlist rather than trusting the PR's tree.
+
 ## [1.34.0] — say whose savings those are
 
 The counter fix in 1.33.1 stopped the community total moving backwards. This is

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.34.0
+version: 1.35.0
 date-released: 2026-07-26
 keywords:
   - llm

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.34.0"
+version = "1.35.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.34.0",
+  "version": "1.35.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.34.0",
+      "version": "1.35.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.34.0"
+version = "1.35.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts **1.35.0** from the eight PRs merged today (#44–#50, #52). Full narrative in `CHANGELOG.md`.

### Version bumped in six locations, not four

`pyproject.toml`, `CITATION.cff`, `server.json` (×2), `packaging/npm/package.json`, `plugins/distil/.claude-plugin/plugin.json`.

My first attempt bumped four and **failed the repo's own gate** — `tests/test_packaging_smoke.py` caught the npm wrapper and the plugin manifest both still claiming 1.34.0. That test exists precisely because those manifests drift silently at release time, and it did its job.

### Two corrections to things that were wrong in public

The changelog states both as **corrections, not improvements**:

- **The metrics claim.** README and Deploy & Security both said distil has no metrics endpoint and cited that as a security differentiator. It has one now — the admin gate is the differentiator, and it's tested (403 unauthenticated, 401 on a wrong token, plus label-injection and no-secrets-in-exposition).
- **The savings figure.** The proxy's estimator never counted image blocks, so any agent sending images had an understated baseline. Now counted at pixel-area cost — **reported savings and census figures will shift for that traffic.**

### What's in it

| | |
|---|---|
| #44 | Three adoption numbers that claimed to be current and weren't |
| #45 | Prometheus `/distil/metrics` + OTel counters, behind the admin gate |
| #46 | ADR 0003 — images as a certifiable content type, **ships disabled** |
| #47 | ADR 0004 — gap stack-rank + Agno/Strands/Cursor/CrewAI |
| #48 | Gemini cross-audit unbroken, base-sha workspace + fail-closed allowlist |
| #49 | Landing page: install pill, works-with row, adoption section moved |
| #50 | ⌘K docs search across 22 pages |
| #52 | `distil simulate` — a dry-run that reports what it will *not* touch |

### Gates on this commit

**1964 passed**, coverage **95.06%** (floor 95) · `distil verify` PASS · `distil validate` PASS 60/60 · `distil bench` GATE PASS · ruff 0.15.10 + mypy 1.17.1 clean.

### Note on what is NOT claimed

Vision compression is merged but **inert**: it requires a certificate with an explicit passing verdict, and none exists. No release note claims image compression works, because decision-equivalence for it is unproven — ADR 0004 rank 1 records exactly what blocks it (the certification path is text-only end to end; `Block.text` is a `str`).