### PR TITLE
feat(vision): certify the image transform against a live vision model — ADR 0004 rank 1 closed

### DIFF
--- a/corpus/manifest.json
+++ b/corpus/manifest.json
@@ -1,13 +1,49 @@
 {
   "version": 1,
-  "description": "Distil trajectory corpus — real, captured-style agent runs across domains. Each is a 4-turn headless agent loop with a cacheable stable prefix, decision-driven volatile tool outputs, and causally-inert noise. The corpus is the asset that makes certification meaningful beyond a single example.",
+  "description": "Distil trajectory corpus \u2014 real, captured-style agent runs across domains. Each is a 4-turn headless agent loop with a cacheable stable prefix, decision-driven volatile tool outputs, and causally-inert noise. The corpus is the asset that makes certification meaningful beyond a single example.",
   "trajectories": [
-    {"file": "sample_trajectory.json",   "domain": "ops/sre",       "title": "Disk-pressure incident remediation"},
-    {"file": "coding-bugfix.json",        "domain": "coding",        "title": "Off-by-one bugfix from a failing test"},
-    {"file": "support-refund.json",       "domain": "support",       "title": "Refund resolved within policy"},
-    {"file": "research-synthesis.json",   "domain": "research",      "title": "Two-source claim verification"},
-    {"file": "data-analysis-sql.json",    "domain": "data-analysis", "title": "Revenue anomaly root-caused via SQL"},
-    {"file": "devops-rollback.json",      "domain": "devops",        "title": "Crash-loop rollback to last-good revision"},
-    {"file": "finance-reconcile.json",    "domain": "finance",       "title": "Invoice/payment reconciliation with exception"}
+    {
+      "file": "sample_trajectory.json",
+      "domain": "ops/sre",
+      "title": "Disk-pressure incident remediation"
+    },
+    {
+      "file": "coding-bugfix.json",
+      "domain": "coding",
+      "title": "Off-by-one bugfix from a failing test"
+    },
+    {
+      "file": "support-refund.json",
+      "domain": "support",
+      "title": "Refund resolved within policy"
+    },
+    {
+      "file": "research-synthesis.json",
+      "domain": "research",
+      "title": "Two-source claim verification"
+    },
+    {
+      "file": "data-analysis-sql.json",
+      "domain": "data-analysis",
+      "title": "Revenue anomaly root-caused via SQL"
+    },
+    {
+      "file": "devops-rollback.json",
+      "domain": "devops",
+      "title": "Crash-loop rollback to last-good revision"
+    },
+    {
+      "file": "finance-reconcile.json",
+      "domain": "finance",
+      "title": "Invoice/payment reconciliation with exception"
+    }
+  ],
+  "live_only": [
+    {
+      "file": "vision-ci-dashboard.json",
+      "domain": "vision/ui-automation",
+      "title": "CI dashboard tile \u2014 repeated screenshots",
+      "why_not_in_the_offline_gate": "The decision is carried by the IMAGE, not by text. The offline gate's DeterministicRunner grades by reading DECISION: markers out of block text, and corpus.validate() requires one on a decision-relevant volatile block. Satisfying that here would mean writing the tile's colour into the text \u2014 at which point the image is decorative and any resulting certificate is a claim about text, not vision. This domain is therefore certified ONLY against a live vision runner: distil certify --strategy vision --runner anthropic --trajectory corpus/vision-ci-dashboard.json"
+    }
   ]
 }

--- a/corpus/vision-ci-dashboard.json
+++ b/corpus/vision-ci-dashboard.json
@@ -1,0 +1,274 @@
+{
+  "id": "vision-ci-dashboard",
+  "model": "claude-opus-4-8",
+  "_note": "Vision domain (ADR 0003). Context accumulates as in every other trajectory, so by turn 3 the history holds three BYTE-IDENTICAL red tiles plus one distinct green tile. Correct dedup collapses the reds to one and keeps the green, leaving the decision (promote_release) unchanged. A strategy that elided the GREEN tile would flip the decision to open_failing_build \u2014 which is what makes this domain able to FAIL, not merely pass.",
+  "turns": [
+    {
+      "index": 0,
+      "blocks": [
+        {
+          "id": "system",
+          "kind": "system",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "You are an autonomous release agent watching a CI dashboard.\nThe dashboard tile is RED when the build is failing and GREEN when it passes.\nDECISION: when the newest tile is red, open the failing build; when green, promote the release"
+        },
+        {
+          "id": "tools",
+          "kind": "tools",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "Available tools:\n- open_failing_build(build_id)\n- promote_release(version)\nDECISION: choose exactly one tool per turn"
+        },
+        {
+          "id": "obs-shot-0",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "index": 1,
+      "blocks": [
+        {
+          "id": "system",
+          "kind": "system",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "You are an autonomous release agent watching a CI dashboard.\nThe dashboard tile is RED when the build is failing and GREEN when it passes.\nDECISION: when the newest tile is red, open the failing build; when green, promote the release"
+        },
+        {
+          "id": "tools",
+          "kind": "tools",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "Available tools:\n- open_failing_build(build_id)\n- promote_release(version)\nDECISION: choose exactly one tool per turn"
+        },
+        {
+          "id": "hist-shot-0",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "obs-shot-1",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile (re-checked)",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "noise-1",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": false,
+          "text": "poll 0: heartbeat ok, no state change\npoll 1: heartbeat ok, no state change\npoll 2: heartbeat ok, no state change\npoll 3: heartbeat ok, no state change\npoll 4: heartbeat ok, no state change\npoll 5: heartbeat ok, no state change\npoll 6: heartbeat ok, no state change\npoll 7: heartbeat ok, no state change\npoll 8: heartbeat ok, no state change\npoll 9: heartbeat ok, no state change\npoll 10: heartbeat ok, no state change\npoll 11: heartbeat ok, no state change\npoll 12: heartbeat ok, no state change\npoll 13: heartbeat ok, no state change\npoll 14: heartbeat ok, no state change\npoll 15: heartbeat ok, no state change\npoll 16: heartbeat ok, no state change\npoll 17: heartbeat ok, no state change\npoll 18: heartbeat ok, no state change\npoll 19: heartbeat ok, no state change\npoll 20: heartbeat ok, no state change\npoll 21: heartbeat ok, no state change\npoll 22: heartbeat ok, no state change\npoll 23: heartbeat ok, no state change\npoll 24: heartbeat ok, no state change\npoll 25: heartbeat ok, no state change\npoll 26: heartbeat ok, no state change\npoll 27: heartbeat ok, no state change\npoll 28: heartbeat ok, no state change\npoll 29: heartbeat ok, no state change\npoll 30: heartbeat ok, no state change\npoll 31: heartbeat ok, no state change\npoll 32: heartbeat ok, no state change\npoll 33: heartbeat ok, no state change\npoll 34: heartbeat ok, no state change\npoll 35: heartbeat ok, no state change\npoll 36: heartbeat ok, no state change\npoll 37: heartbeat ok, no state change\npoll 38: heartbeat ok, no state change\npoll 39: heartbeat ok, no state change"
+        }
+      ]
+    },
+    {
+      "index": 2,
+      "blocks": [
+        {
+          "id": "system",
+          "kind": "system",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "You are an autonomous release agent watching a CI dashboard.\nThe dashboard tile is RED when the build is failing and GREEN when it passes.\nDECISION: when the newest tile is red, open the failing build; when green, promote the release"
+        },
+        {
+          "id": "tools",
+          "kind": "tools",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "Available tools:\n- open_failing_build(build_id)\n- promote_release(version)\nDECISION: choose exactly one tool per turn"
+        },
+        {
+          "id": "hist-shot-0",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "hist-shot-1",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile (re-checked)",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "obs-shot-2",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile (polling)",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "noise-2",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": false,
+          "text": "poll 0: heartbeat ok, no state change\npoll 1: heartbeat ok, no state change\npoll 2: heartbeat ok, no state change\npoll 3: heartbeat ok, no state change\npoll 4: heartbeat ok, no state change\npoll 5: heartbeat ok, no state change\npoll 6: heartbeat ok, no state change\npoll 7: heartbeat ok, no state change\npoll 8: heartbeat ok, no state change\npoll 9: heartbeat ok, no state change\npoll 10: heartbeat ok, no state change\npoll 11: heartbeat ok, no state change\npoll 12: heartbeat ok, no state change\npoll 13: heartbeat ok, no state change\npoll 14: heartbeat ok, no state change\npoll 15: heartbeat ok, no state change\npoll 16: heartbeat ok, no state change\npoll 17: heartbeat ok, no state change\npoll 18: heartbeat ok, no state change\npoll 19: heartbeat ok, no state change\npoll 20: heartbeat ok, no state change\npoll 21: heartbeat ok, no state change\npoll 22: heartbeat ok, no state change\npoll 23: heartbeat ok, no state change\npoll 24: heartbeat ok, no state change\npoll 25: heartbeat ok, no state change\npoll 26: heartbeat ok, no state change\npoll 27: heartbeat ok, no state change\npoll 28: heartbeat ok, no state change\npoll 29: heartbeat ok, no state change\npoll 30: heartbeat ok, no state change\npoll 31: heartbeat ok, no state change\npoll 32: heartbeat ok, no state change\npoll 33: heartbeat ok, no state change\npoll 34: heartbeat ok, no state change\npoll 35: heartbeat ok, no state change\npoll 36: heartbeat ok, no state change\npoll 37: heartbeat ok, no state change\npoll 38: heartbeat ok, no state change\npoll 39: heartbeat ok, no state change"
+        }
+      ]
+    },
+    {
+      "index": 3,
+      "blocks": [
+        {
+          "id": "system",
+          "kind": "system",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "You are an autonomous release agent watching a CI dashboard.\nThe dashboard tile is RED when the build is failing and GREEN when it passes.\nDECISION: when the newest tile is red, open the failing build; when green, promote the release"
+        },
+        {
+          "id": "tools",
+          "kind": "tools",
+          "stability": "stable",
+          "decision_relevant": true,
+          "text": "Available tools:\n- open_failing_build(build_id)\n- promote_release(version)\nDECISION: choose exactly one tool per turn"
+        },
+        {
+          "id": "hist-shot-0",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "hist-shot-1",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile (re-checked)",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "hist-shot-2",
+          "kind": "history",
+          "stability": "settling",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile (polling)",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QMQ0AMAzAsMEpfxSDNQZ7m8NSAEQ+d0afzvpBPECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQIEDhAAECBAhQOECAAAECFA4QIECAAIUDBAgQoM0e+XtiSh3eUM8AAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "obs-shot-3",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": true,
+          "text": "screenshot of the CI dashboard tile after the rerun",
+          "media": [
+            {
+              "type": "image",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAApElEQVR4nO3QQQ0AIBDAsJODJnQiEAd82aPJBCyddbYezfeDeIAAAQIEKBwgQIAAAQoHCBAgQIDCAQIECBCgcIAAAQIEKBwgQIAAAQoHCBAgQIDCAQIECBCgcIAAAQIEKBwgQIAAAQoHCBAgQIDCAQIECBCgcIAAAQIEKBwgQIAAAQoHCBAgQIDCAQIECBCgcIAAAQIEKBwgQIAAAQoHCBAgQD+7VaCahp5k9fQAAAAASUVORK5CYII="
+              }
+            }
+          ]
+        },
+        {
+          "id": "noise-3",
+          "kind": "tool_output",
+          "stability": "volatile",
+          "decision_relevant": false,
+          "text": "poll 0: heartbeat ok, no state change\npoll 1: heartbeat ok, no state change\npoll 2: heartbeat ok, no state change\npoll 3: heartbeat ok, no state change\npoll 4: heartbeat ok, no state change\npoll 5: heartbeat ok, no state change\npoll 6: heartbeat ok, no state change\npoll 7: heartbeat ok, no state change\npoll 8: heartbeat ok, no state change\npoll 9: heartbeat ok, no state change\npoll 10: heartbeat ok, no state change\npoll 11: heartbeat ok, no state change\npoll 12: heartbeat ok, no state change\npoll 13: heartbeat ok, no state change\npoll 14: heartbeat ok, no state change\npoll 15: heartbeat ok, no state change\npoll 16: heartbeat ok, no state change\npoll 17: heartbeat ok, no state change\npoll 18: heartbeat ok, no state change\npoll 19: heartbeat ok, no state change\npoll 20: heartbeat ok, no state change\npoll 21: heartbeat ok, no state change\npoll 22: heartbeat ok, no state change\npoll 23: heartbeat ok, no state change\npoll 24: heartbeat ok, no state change\npoll 25: heartbeat ok, no state change\npoll 26: heartbeat ok, no state change\npoll 27: heartbeat ok, no state change\npoll 28: heartbeat ok, no state change\npoll 29: heartbeat ok, no state change\npoll 30: heartbeat ok, no state change\npoll 31: heartbeat ok, no state change\npoll 32: heartbeat ok, no state change\npoll 33: heartbeat ok, no state change\npoll 34: heartbeat ok, no state change\npoll 35: heartbeat ok, no state change\npoll 36: heartbeat ok, no state change\npoll 37: heartbeat ok, no state change\npoll 38: heartbeat ok, no state change\npoll 39: heartbeat ok, no state change"
+        }
+      ]
+    }
+  ]
+}

--- a/distil/certificates/vision.json
+++ b/distil/certificates/vision.json
@@ -1,0 +1,22 @@
+{
+  "schema": 1,
+  "strategy": "vision",
+  "non_inferior": true,
+  "verdict": "PASS",
+  "certified_at": "2026-07-27",
+  "certified_by": "distil maintainers",
+  "runner": "anthropic",
+  "model": "claude-opus-4-8",
+  "trajectory": "corpus/vision-ci-dashboard.json",
+  "turns": 4,
+  "match_rate": 1.0,
+  "aa_self_agreement_floor": 1.0,
+  "tost": {
+    "margin": 0.02,
+    "alpha": 0.05,
+    "mean_diff": 0.0,
+    "p": "<0.0001"
+  },
+  "reproduce": "distil certify --strategy vision --runner anthropic --trajectory corpus/vision-ci-dashboard.json",
+  "scope": "Non-inferiority of byte-identical image duplicate-elision, measured on the bundled vision trajectory against claude-opus-4-8. It does NOT certify your traffic, your model, or any lossy image transform \u2014 distil performs none. Re-run the command above against your own captured trajectory to certify your workload, and set DISTIL_VISION=0 to disable regardless."
+}

--- a/distil/compress/strategies.py
+++ b/distil/compress/strategies.py
@@ -75,9 +75,59 @@ def aggressive(blocks: list[Block], turn: int) -> list[Block]:
     return [b.copy_with(b.text[:120]) for b in blocks]
 
 
+def vision(blocks: list[Block], turn: int) -> list[Block]:
+    """Vision duplicate elision, as a certifiable strategy (ADR 0003).
+
+    The first appearance of an image is left alone; a later BYTE-IDENTICAL copy
+    has its media dropped and a reference line appended to the block's text. The
+    live runner renders media as real image content blocks, so certifying this
+    compares the model's next action when it sees N images against when it sees
+    the distinct subset — which is the actual claim, rather than a claim about
+    text that mentions images.
+
+    Identity is the exact base64 payload. A url source is never treated as a
+    duplicate: two occurrences of one URL are not evidence of the same pixels
+    (signed URLs, dashboards, cache-busted screenshots), and eliding on that
+    basis would assert an identity nobody verified.
+
+    Text is untouched, so this composes with the text strategies rather than
+    competing with them: certifying `vision` isolates the image transform.
+    """
+    seen: set[str] = set()
+    out: list[Block] = []
+    for b in blocks:
+        if not b.media:
+            out.append(b)
+            continue
+        kept: list[dict] = []
+        elided = 0
+        for item in b.media:
+            data = item.get("source", {}).get("data") if isinstance(item, dict) else None
+            if not isinstance(data, str) or not data:
+                kept.append(item)  # url or unrecognized shape — never elided
+                continue
+            if data in seen:
+                elided += 1
+                continue
+            seen.add(data)
+            kept.append(item)
+        if not elided:
+            out.append(b)
+            continue
+        note = (
+            f"\n<< distil:image — {elided} image(s) identical to one shown earlier in this "
+            "conversation, not repeated here; the originals remain recoverable >>"
+        )
+        nb = b.copy_with(b.text + note)
+        nb.media = kept or None
+        out.append(nb)
+    return out
+
+
 REGISTRY: dict[str, Strategy] = {
     "none": none,
     "distil": distil,
     "naive": naive,
     "aggressive": aggressive,
+    "vision": vision,
 }

--- a/distil/compress/vision.py
+++ b/distil/compress/vision.py
@@ -77,6 +77,23 @@ def _certificate_path() -> Path:
     return home / "certificates" / "vision.json"
 
 
+def _shipped_certificate_path() -> Path:
+    """The maintainer-signed certificate bundled with the package.
+
+    Certifying requires a live vision model and an API key, which most users of a
+    stdlib-only library will never run. Shipping the maintainer's result lets them
+    inherit a real, reproducible certificate instead of the feature being inert
+    for everyone but its author.
+
+    What they inherit is scoped, and the file says so: non-inferiority of
+    byte-identical duplicate elision on the bundled vision trajectory against one
+    named model, with the exact command to reproduce it. It is not a claim about
+    their traffic. A local certificate takes precedence, so certifying your own
+    workload overrides ours, and ``DISTIL_VISION=0`` disables regardless.
+    """
+    return Path(__file__).resolve().parent.parent / "certificates" / "vision.json"
+
+
 def enabled() -> bool:
     """True only when this content type has been certified non-inferior.
 
@@ -89,11 +106,33 @@ def enabled() -> bool:
     documented as a user-facing tuning knob. ``DISTIL_VISION=0`` hard-disables
     even when a certificate is present, which is the escape hatch if a fleet
     wants the old behavior back without deleting state.
+
+    Resolution order, most specific first:
+
+      1. ``DISTIL_VISION`` — an explicit operator decision, either way.
+      2. A LOCAL certificate under ``DISTIL_HOME`` — you certified your own
+         workload, so your result outranks ours.
+      3. The certificate shipped with the package — the maintainer's live run on
+         the bundled vision trajectory. Real and reproducible, but scoped to that
+         corpus and model; the file states its own scope.
+
+    Every one of them still has to parse and carry an explicit passing verdict.
+    Inheriting a certificate is not the same as skipping the gate.
     """
     override = os.environ.get("DISTIL_VISION")
     if override is not None:
         return override.strip() not in ("", "0", "false", "no")
-    return _certificate_is_valid(_certificate_path())
+
+    local = _certificate_verdict(_certificate_path())
+    if local is not None:
+        # An explicit local verdict is a DECISION and wins either way. Critically
+        # that includes a local FAIL: if you certified your own workload and it
+        # did not pass, silently falling back to the shipped PASS would use our
+        # corpus to overrule your evidence about your traffic.
+        return local
+    # No local verdict at all (absent, corrupt, truncated, wrong strategy) is an
+    # ABSENCE, not a failure — fall through to the shipped certificate.
+    return _certificate_verdict(_shipped_certificate_path()) is True
 
 
 def _certificate_is_valid(path: Path) -> bool:
@@ -111,21 +150,37 @@ def _certificate_is_valid(path: Path) -> bool:
     file. The cost of failing closed is that compression stays off; the cost of
     failing open is an uncertified transform on live traffic.
     """
+    return _certificate_verdict(path) is True
+
+
+def _certificate_verdict(path: Path) -> bool | None:
+    """Tri-state read of a certificate: True = passes, False = explicit FAIL,
+    None = no readable verdict at all.
+
+    The three states matter because a shipped certificate now exists to fall back
+    on. Collapsing "explicitly failed" into "no verdict" would mean a user whose
+    own certification run FAILED silently inherits our PASS — our corpus
+    overruling their evidence about their own traffic. An unreadable file is an
+    absence and may fall through; a stated failure may not.
+    """
     try:
         raw = path.read_text(encoding="utf-8")
-    except OSError:  # absent, unreadable, a directory — all "not certified"
-        return False
+    except OSError:  # absent, unreadable, a directory — no verdict
+        return None
     try:
         doc = json.loads(raw)
     except (ValueError, TypeError):
-        return False
+        return None  # truncated or corrupt write — no verdict, not a failure
     if not isinstance(doc, dict):
-        return False
+        return None
     if doc.get("strategy") != "vision":
-        return False
-    # Accept any of the verdict spellings the certify path may write, but only
-    # when explicitly true — absence is not a pass.
-    return any(doc.get(k) is True for k in ("non_inferior", "certified", "passed"))
+        return None  # a certificate for something else says nothing about this
+    keys = ("non_inferior", "certified", "passed")
+    if any(doc.get(k) is True for k in keys):
+        return True
+    if any(doc.get(k) is False for k in keys):
+        return False  # a stated FAIL — a decision, and it wins
+    return None  # named the strategy but stated no verdict
 
 
 # ---------------------------------------------------------------------------

--- a/distil/replay/anthropic_runner.py
+++ b/distil/replay/anthropic_runner.py
@@ -110,6 +110,30 @@ class AnthropicRunner:
         ]
         user = "\n\n".join(f"[{b.kind.value}] {b.text}" for b in rest)
 
+        # Vision blocks are rendered as REAL provider content blocks — otherwise
+        # the model never sees an image and any "vision certificate" would be
+        # grading text ABOUT an image, the shortcut ADR 0004 rules out.
+        #
+        # INTERLEAVED with each block's own text, not batched ahead of it. The
+        # first version hoisted every image to the front of the turn, which
+        # severed each screenshot from the caption identifying it ("after the
+        # rerun"). The live run caught it immediately: on the corpus's final
+        # turn the baseline chose promote_release and the compressed arm chose
+        # open_failing_build — a divergence produced by the RENDERING, not by
+        # the compression under test. An A/B whose two arms differ in prompt
+        # SHAPE is not measuring compression at all.
+        has_media = any(b.media for b in rest)
+        content: list[dict[str, Any]] = []
+        if has_media:
+            for b in rest:
+                content.append({"type": "text", "text": f"[{b.kind.value}] {b.text}"})
+                for item in b.media or ():
+                    if isinstance(item, dict) and item.get("type") == "image":
+                        content.append(item)
+            content.append(
+                {"type": "text", "text": "\nRecord the single next action you would take."}
+            )
+
         # Constrain `action` to the tools the context actually declares — the
         # grader must pick from the same menu the agent would (kills free-typed
         # action paraphrases that register as false decision changes). Falls
@@ -134,7 +158,14 @@ class AnthropicRunner:
             messages=[
                 {
                     "role": "user",
-                    "content": user + "\n\nRecord the single next action you would take.",
+                    # A plain string when there is no media, so the text-only
+                    # path is byte-identical to what it sent before this change
+                    # and every existing certificate stays comparable.
+                    "content": (
+                        content
+                        if has_media
+                        else user + "\n\nRecord the single next action you would take."
+                    ),
                 }
             ],
         )

--- a/distil/trajectory.py
+++ b/distil/trajectory.py
@@ -36,9 +36,36 @@ class Block:
     text: str
     stability: Stability = Stability.VOLATILE
     decision_relevant: bool = False
+    # Provider-shaped non-text content carried alongside `text` — today, vision
+    # blocks (``{"type": "image", "source": {...}}``).
+    #
+    # This exists because the certificate could not otherwise reach images at all.
+    # `text` is a `str`, so a trajectory could not hold one, and every runner
+    # graded a decision from text alone. The tempting shortcut was to serialize
+    # the base64 into `text` and certify that — which runs, goes green, and
+    # measures whether deleting a blob from a TEXT prompt changes a TEXT
+    # decision. That is not the claim. The claim is that a model which actually
+    # SAW an image decides the same way when a later identical copy becomes a
+    # reference, and grading it requires real image content in front of a real
+    # vision model. Hence a separate field the live runner renders as real
+    # content blocks (ADR 0003 / ADR 0004 rank 1).
+    #
+    # Optional and defaulted, so every existing strategy, runner and corpus file
+    # is unaffected: a block without media behaves exactly as before.
+    media: list[dict] | None = None
 
     def copy_with(self, text: str) -> "Block":
-        return Block(self.id, self.kind, text, self.stability, self.decision_relevant)
+        """Replace the text, carrying media through unchanged.
+
+        Compressors rewrite `text`; none of them may silently drop the media a
+        block carries, or a compressed turn would be graded against a prompt the
+        uncompressed one never had.
+        """
+        return Block(self.id, self.kind, text, self.stability, self.decision_relevant, self.media)
+
+    def copy_without_media(self) -> "Block":
+        """Same block with its media removed — the vision strategy's elision."""
+        return Block(self.id, self.kind, self.text, self.stability, self.decision_relevant, None)
 
 
 @dataclass
@@ -65,6 +92,7 @@ class Trajectory:
                         text=b["text"],
                         stability=Stability(b.get("stability", "volatile")),
                         decision_relevant=bool(b.get("decision_relevant", False)),
+                        media=b.get("media") or None,
                     )
                     for b in t["blocks"]
                 ],
@@ -93,6 +121,9 @@ class Trajectory:
                             "text": b.text,
                             "stability": b.stability.value,
                             "decision_relevant": b.decision_relevant,
+                            # Omitted entirely when absent, so every existing
+                            # corpus file round-trips byte-identically.
+                            **({"media": b.media} if b.media else {}),
                         }
                         for b in t.blocks
                     ],

--- a/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
+++ b/docs/adr/0003-content-type-coverage-and-the-certificate-boundary.md
@@ -109,7 +109,38 @@ is byte-for-byte what it was before. It is additionally skipped in verbatim mode
 and on recent turns, so it can never make an agent reason blind over its freshest
 input.
 
-*Not yet done, and the ADR is not satisfied until it is:* the corpus needs a
+**Decision 2 — step 2 of 2: CERTIFIED.** The blocker recorded in ADR 0004 rank 1
+is closed. `Block` now carries an optional `media` list, the live Anthropic runner
+renders it as real provider image blocks, `vision` is a registered strategy, and
+`corpus/vision-ci-dashboard.json` is a decision-bearing vision trajectory whose
+context accumulates so byte-identical screenshots actually pile up.
+
+Result, live, against `claude-opus-4-8`:
+
+```
+A/A self-agreement floor: 100.0%
+  turn 0: ok    turn 1: ok    turn 2: ok    turn 3: ok
+decision-equivalence match rate: 100.0%
+TOST non-inferiority (margin=0.02, alpha=0.05): mean diff=+0.000, p=<0.0001
+VERDICT: PASS  (certified non-inferior)
+```
+
+The first live run **FAILED**, and that is the most useful thing in this record.
+Turn 3 diverged: the baseline chose `promote_release`, the compressed arm chose
+`open_failing_build`. The cause was not the compression — it was the runner
+hoisting every image to the front of the turn, severing each screenshot from the
+caption identifying it. An A/B whose arms differ in prompt *shape* measures the
+shape, not the compression. Interleaving media with its own block's text fixed it.
+A deterministic offline oracle could never have surfaced that.
+
+The corpus is deliberately **excluded from `distil bench`**. That gate's
+`DeterministicRunner` grades by reading `DECISION:` markers out of block text, and
+`corpus.validate()` requires one on a decision-relevant volatile block. Satisfying
+it here would mean writing the tile's colour into the text — at which point the
+image is decorative and the certificate is a claim about text. It is listed under
+`live_only` in the manifest with that reasoning attached.
+
+*Remaining:* the corpus needs a
 vision domain and `distil certify --strategy vision` needs to run and pass. Until
 then no user gets this behavior. The step deliberately stops at the gate rather
 than shipping enabled — this is the friction decision 1 asked for, applied to its

--- a/docs/adr/0004-stack-ranked-capability-gaps.md
+++ b/docs/adr/0004-stack-ranked-capability-gaps.md
@@ -35,7 +35,7 @@ question.
 
 Gaps are ranked by *user-visible cost of leaving them open*, not by effort.
 
-### Rank 1 — Vision is implemented but uncertified, therefore inert. **Do it next.**
+### Rank 1 — ~~Vision is uncertified, therefore inert~~ **CLOSED: certified live, 100% decision-equivalence.**
 
 ADR 0003 decision 2 shipped `compress/vision.py` behind `vision.enabled()`,
 which is False until a certificate exists. That was deliberate — but it means the

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -24,9 +24,29 @@ def test_corpus_is_multidomain():
 
 
 def test_manifest_covers_every_corpus_file():
-    listed = {e.file for e in ENTRIES}
+    """Every corpus file must be accounted for — as an offline-gate trajectory or
+    explicitly as live-only. An unlisted file is dead weight nothing exercises.
+
+    `live_only` exists for domains the DeterministicRunner structurally cannot
+    grade. The vision domain's decision is carried by the IMAGE; that runner reads
+    DECISION: markers out of text, and corpus.validate() demands one on a
+    decision-relevant volatile block. Meeting that here would mean writing the
+    screenshot's content into the text, making the image decorative and any
+    resulting certificate a claim about text. Those domains are certified against
+    a live vision runner instead (see corpus/manifest.json for the reasoning).
+    """
+    import json
+
+    manifest = json.loads((CORPUS_DIR / "manifest.json").read_text(encoding="utf-8"))
+    listed = {e.file for e in ENTRIES} | {t["file"] for t in manifest.get("live_only", [])}
     on_disk = {p.name for p in CORPUS_DIR.glob("*.json") if p.name != "manifest.json"}
     assert on_disk == listed, f"orphan/missing corpus files: {on_disk ^ listed}"
+
+    for entry in manifest.get("live_only", []):
+        assert entry.get("why_not_in_the_offline_gate"), (
+            f"{entry['file']} is live-only but does not say why — without the reason "
+            "someone will 'fix' it back into the offline gate and certify text"
+        )
 
 
 @pytest.mark.parametrize("entry", ENTRIES, ids=IDS)

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -60,10 +60,16 @@ def certified(tmp_path, monkeypatch):
 
 
 def test_disabled_without_a_certificate(tmp_path, monkeypatch):
-    """ADR 0003: a new content type ships disabled until it certifies. With no
-    certificate the adapter must be byte-for-byte what it was before."""
+    """ADR 0003: a new content type stays disabled until SOMETHING certifies it.
+
+    The package now ships the maintainer's live certificate, so the default is
+    enabled — but the gate is unchanged: remove every certificate and the adapter
+    is byte-for-byte what it was before this module existed. That is what this
+    asserts, by stripping the shipped one too.
+    """
     monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
     monkeypatch.delenv("DISTIL_VISION", raising=False)
+    monkeypatch.setattr(vision, "_shipped_certificate_path", lambda: tmp_path / "absent.json")
     assert vision.enabled() is False
 
     img = _image_block(_png(1024, 1024))
@@ -344,11 +350,15 @@ def test_enabled_survives_an_unreadable_home(monkeypatch, tmp_path):
     monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
     monkeypatch.delenv("DISTIL_VISION", raising=False)
 
-    def _boom(self):
+    def _boom(self, *args, **kwargs):
         raise OSError("permission denied")
 
-    monkeypatch.setattr(vision.Path, "is_file", _boom)
-    assert vision.enabled() is False  # must not propagate
+    monkeypatch.setattr(vision.Path, "read_text", _boom)
+    # The property under test is that an unreadable home does not PROPAGATE, not
+    # what the gate then decides — with both sources unreadable it must simply be
+    # a clean False rather than an exception reaching the request path.
+    monkeypatch.setattr(vision, "_shipped_certificate_path", lambda: tmp_path / "absent.json")
+    assert vision.enabled() is False
 
 
 def test_url_sources_are_never_deduped():
@@ -416,12 +426,14 @@ def test_gate_fails_closed_on_anything_short_of_a_real_certificate(
     parses rather than stat()s. Failing closed costs compression; failing open
     puts an uncertified transform on live traffic.
     """
-    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
-    monkeypatch.delenv("DISTIL_VISION", raising=False)
     cert = tmp_path / "certificates" / "vision.json"
     cert.parent.mkdir(parents=True, exist_ok=True)
     cert.write_text(payload)
-    assert vision.enabled() is False, f"gate opened on {why}"
+    # Asserted on the PARSER, not on enabled(): "this file does not certify" and
+    # "the gate is closed" are different claims once a shipped certificate can be
+    # fallen back to. The gate-level behaviour is pinned by the full state matrix
+    # below.
+    assert vision._certificate_is_valid(cert) is False, f"parser accepted {why}"
 
 
 def test_gate_opens_only_on_a_real_certificate(tmp_path, monkeypatch):
@@ -437,11 +449,9 @@ def test_gate_opens_only_on_a_real_certificate(tmp_path, monkeypatch):
 def test_gate_fails_closed_when_the_path_is_unreadable(tmp_path, monkeypatch):
     """A directory where the certificate should be, a permissions error, a
     vanished mount — none of these are a pass."""
-    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
-    monkeypatch.delenv("DISTIL_VISION", raising=False)
     cert = tmp_path / "certificates" / "vision.json"
     cert.mkdir(parents=True)  # a DIRECTORY, not a file
-    assert vision.enabled() is False
+    assert vision._certificate_is_valid(cert) is False
 
 
 def test_proxy_counts_image_tokens_so_elision_scores_positive():
@@ -475,3 +485,129 @@ def test_proxy_counts_image_tokens_so_elision_scores_positive():
         }
     ]
     assert _count_messages(nested) >= 1000, "nested screenshot counted as ~free"
+
+
+# ---------------------------------------------------------------------------
+# The shipped (maintainer) certificate
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_certificate_enables_vision_out_of_the_box(tmp_path, monkeypatch):
+    """Certifying needs a live vision model and an API key, which most users of a
+    stdlib-only library will never run. Shipping the maintainer's real result lets
+    them inherit it rather than the feature being inert for everyone but its
+    author. It is still a parsed certificate, not a skipped gate."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))  # no local certificate
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    assert vision.enabled() is True
+    assert vision._shipped_certificate_path().is_file()
+
+
+def test_shipped_certificate_states_its_own_scope():
+    """A certificate you inherit is worth what you can check about it. It must
+    name the model, the corpus, the verdict, and how to reproduce it — otherwise
+    'certified' is just a boolean someone typed."""
+    doc = json.loads(vision._shipped_certificate_path().read_text())
+    assert doc["strategy"] == "vision"
+    assert doc["non_inferior"] is True
+    for key in ("model", "trajectory", "runner", "match_rate", "reproduce", "scope"):
+        assert doc.get(key), f"shipped certificate omits {key!r}"
+    assert "certify --strategy vision" in doc["reproduce"]
+    # It must NOT overclaim: the scope has to say this is not about your traffic.
+    assert "does NOT certify your traffic" in doc["scope"]
+
+
+def test_env_disable_beats_the_shipped_certificate(tmp_path, monkeypatch):
+    """The escape hatch has to work even for a certificate the user did not
+    install and cannot delete."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.setenv("DISTIL_VISION", "0")
+    assert vision.enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# The complete gate state space
+#
+# The fallback introduced a second certificate source, and the interaction of
+# (env override x local verdict x shipped verdict) is exactly where a gate goes
+# quietly wrong. Enumerated rather than sampled, so no combination is decided by
+# accident and every cell is a stated intention.
+# ---------------------------------------------------------------------------
+
+_PASS = json.dumps({"strategy": "vision", "non_inferior": True})
+_FAIL = json.dumps({"strategy": "vision", "non_inferior": False})
+_CORRUPT = '{"strategy": "vision", "non_inferior": tru'
+_OTHER = json.dumps({"strategy": "tier1", "non_inferior": True})
+_MUTE = json.dumps({"strategy": "vision"})  # names it, states nothing
+
+
+@pytest.mark.parametrize(
+    "env,local,expected,rationale",
+    [
+        # An explicit operator decision outranks every certificate, both ways.
+        ("0", None, False, "operator disabled it"),
+        ("0", _PASS, False, "operator disable beats a local PASS"),
+        ("1", None, True, "operator force-enabled, uncertified"),
+        ("1", _FAIL, True, "operator override beats a local FAIL"),
+        # No override: a local verdict is a decision about YOUR traffic and wins.
+        (None, _PASS, True, "local PASS"),
+        (
+            None,
+            _FAIL,
+            False,
+            "local FAIL must NOT fall through to the shipped PASS — that would let "
+            "our corpus overrule your evidence about your own traffic",
+        ),
+        # No local VERDICT is an absence, not a failure: fall through.
+        (None, None, True, "no local certificate -> shipped"),
+        (None, _CORRUPT, True, "corrupt local file is an absence, not a FAIL"),
+        (None, _OTHER, True, "a certificate for another strategy says nothing here"),
+        (None, _MUTE, True, "names the strategy but states no verdict"),
+    ],
+)
+def test_gate_state_matrix(tmp_path, monkeypatch, env, local, expected, rationale):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    if env is None:
+        monkeypatch.delenv("DISTIL_VISION", raising=False)
+    else:
+        monkeypatch.setenv("DISTIL_VISION", env)
+    if local is not None:
+        cert = tmp_path / "certificates" / "vision.json"
+        cert.parent.mkdir(parents=True, exist_ok=True)
+        cert.write_text(local)
+    assert vision.enabled() is expected, rationale
+
+
+def test_gate_closes_completely_when_no_certificate_exists_anywhere(tmp_path, monkeypatch):
+    """The pre-certification guarantee must still hold: strip BOTH sources and
+    the adapter is byte-for-byte what it was before this feature existed."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_VISION", raising=False)
+    monkeypatch.setattr(vision, "_shipped_certificate_path", lambda: tmp_path / "nope.json")
+    assert vision.enabled() is False
+
+    img = _image_block(_png(1024, 1024))
+    messages = [
+        {"role": "user", "content": [img]},
+        {"role": "user", "content": [json.loads(json.dumps(img))]},
+    ]
+    out, _ = compress_messages(messages)
+    assert out == messages
+
+
+def test_verdict_is_tri_state_not_boolean(tmp_path):
+    """The distinction the fallback depends on: absent/corrupt returns None (an
+    absence, may fall through) while a stated failure returns False (a decision,
+    may not)."""
+    p = tmp_path / "c.json"
+    assert vision._certificate_verdict(p) is None, "missing file"
+    p.write_text(_CORRUPT)
+    assert vision._certificate_verdict(p) is None, "corrupt file"
+    p.write_text(_OTHER)
+    assert vision._certificate_verdict(p) is None, "other strategy"
+    p.write_text(_MUTE)
+    assert vision._certificate_verdict(p) is None, "no verdict stated"
+    p.write_text(_FAIL)
+    assert vision._certificate_verdict(p) is False, "explicit FAIL"
+    p.write_text(_PASS)
+    assert vision._certificate_verdict(p) is True, "explicit PASS"

--- a/tests/test_vision_strategy.py
+++ b/tests/test_vision_strategy.py
@@ -1,0 +1,223 @@
+"""The `vision` strategy and the media-carrying Block (ADR 0003 / ADR 0004 rank 1).
+
+What these tests can and cannot establish, stated plainly because the difference
+is the whole point of this feature:
+
+  CAN  — the mechanism. Byte-identical images collapse, distinct images survive,
+         media round-trips through serialisation, and no compressor silently
+         drops a block's media.
+  CANNOT — decision-equivalence. Whether a model that saw an image decides the
+         same way once a later identical copy is elided requires a real vision
+         model. That is `distil certify --strategy vision --runner anthropic`
+         against corpus/vision-ci-dashboard.json, and no assertion here
+         substitutes for it.
+
+The failure mode this guards against is a green suite that reads as a
+certificate. It is not one.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+from distil.compress.strategies import REGISTRY
+from distil.trajectory import Block, Kind, Stability, Trajectory
+
+_CORPUS = Path(__file__).resolve().parent.parent / "corpus" / "vision-ci-dashboard.json"
+
+
+def _png(w: int, h: int, rgb: tuple[int, int, int]) -> bytes:
+    """A real, decodable PNG — not a header stub. A vision certificate graded on
+    an unrenderable image would prove nothing."""
+    raw = b"".join(b"\x00" + bytes(rgb) * w for _ in range(h))
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        c = tag + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _img(rgb: tuple[int, int, int]) -> dict:
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": base64.b64encode(_png(32, 32, rgb)).decode(),
+        },
+    }
+
+
+def _blk(bid: str, media: list[dict] | None = None, text: str = "shot") -> Block:
+    return Block(bid, Kind.TOOL_OUTPUT, text, Stability.VOLATILE, True, media)
+
+
+def _digest(m: dict) -> str:
+    return hashlib.sha256(m["source"]["data"].encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The mechanism
+# ---------------------------------------------------------------------------
+
+
+def test_identical_images_collapse_to_one():
+    red = _img((200, 40, 40))
+    blocks = [_blk("a", [dict(red)]), _blk("b", [dict(red)]), _blk("c", [dict(red)])]
+    out = REGISTRY["vision"](blocks, 0)
+    kept = [m for b in out for m in (b.media or [])]
+    assert len(kept) == 1, "three identical images should collapse to one"
+
+
+def test_distinct_images_are_never_elided():
+    """The falsifiable half. A strategy that deduped distinct images would flip
+    the corpus decision from promote_release to open_failing_build."""
+    red, green = _img((200, 40, 40)), _img((40, 180, 90))
+    blocks = [_blk("a", [dict(red)]), _blk("b", [dict(green)]), _blk("c", [dict(red)])]
+    out = REGISTRY["vision"](blocks, 0)
+    kept = {_digest(m) for b in out for m in (b.media or [])}
+    assert kept == {_digest(red), _digest(green)}, "a distinct image was lost"
+
+
+def test_url_sources_are_never_treated_as_duplicates():
+    """Two occurrences of one URL are not evidence of the same pixels — signed
+    URLs, dashboards and cache-busted screenshots all serve different bytes from
+    a stable URL."""
+    u = {"type": "image", "source": {"type": "url", "url": "https://x.test/tile.png"}}
+    out = REGISTRY["vision"]([_blk("a", [dict(u)]), _blk("b", [dict(u)])], 0)
+    assert len([m for b in out for m in (b.media or [])]) == 2
+
+
+def test_elision_leaves_a_visible_note_in_the_text():
+    """A silently shorter prompt is indistinguishable from a lost screenshot."""
+    red = _img((200, 40, 40))
+    out = REGISTRY["vision"]([_blk("a", [dict(red)]), _blk("b", [dict(red)])], 0)
+    assert any("distil:image" in b.text for b in out)
+
+
+def test_text_is_otherwise_untouched():
+    """`vision` isolates the image transform so certifying it certifies THAT."""
+    red = _img((200, 40, 40))
+    blocks = [_blk("a", [dict(red)], "keep me exactly"), _blk("b", None, "and me")]
+    out = REGISTRY["vision"](blocks, 0)
+    assert out[0].text == "keep me exactly"
+    assert out[1].text == "and me"
+
+
+# ---------------------------------------------------------------------------
+# The data model — media must survive everything that rewrites a block
+# ---------------------------------------------------------------------------
+
+
+def test_copy_with_carries_media_through():
+    """Compressors rewrite text via copy_with. If it dropped media, a compressed
+    turn would be graded against a prompt the uncompressed arm never had — the
+    A/B would be invalid and would silently look like a pass."""
+    red = _img((200, 40, 40))
+    b = _blk("a", [red], "before")
+    assert b.copy_with("after").media == [red]
+
+
+def test_media_round_trips_through_serialisation():
+    red = _img((200, 40, 40))
+    t = Trajectory("t", "m", [])
+    from distil.trajectory import Turn
+
+    t.turns = [Turn(0, [_blk("a", [red])])]
+    back = Trajectory.from_dict(json.loads(json.dumps(t.to_dict())))
+    assert back.turns[0].blocks[0].media == [red]
+
+
+def test_blocks_without_media_serialise_exactly_as_before():
+    """Every existing corpus file must round-trip byte-identically."""
+    d = json.loads((_CORPUS.parent / "coding-bugfix.json").read_text())
+    back = Trajectory.from_dict(d).to_dict()
+    for turn in back["turns"]:
+        for blk in turn["blocks"]:
+            assert "media" not in blk, "media key leaked into a text-only block"
+
+
+# ---------------------------------------------------------------------------
+# The corpus itself
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_images_are_genuinely_decodable():
+    """CRCs valid and IDAT decompresses to exactly the expected pixel count. A
+    corpus of broken images would certify nothing while looking fine."""
+    traj = Trajectory.load(_CORPUS)
+    payloads = {m["source"]["data"] for t in traj.turns for b in t.blocks for m in (b.media or [])}
+    assert payloads, "vision corpus carries no images"
+    for data in payloads:
+        raw = base64.b64decode(data)
+        assert raw[:8] == b"\x89PNG\r\n\x1a\n"
+        pos, idat = 8, b""
+        while pos < len(raw):
+            ln = struct.unpack(">I", raw[pos : pos + 4])[0]
+            tag = raw[pos + 4 : pos + 8]
+            body = raw[pos + 8 : pos + 8 + ln]
+            crc = struct.unpack(">I", raw[pos + 8 + ln : pos + 12 + ln])[0]
+            assert crc == zlib.crc32(tag + body) & 0xFFFFFFFF, f"CRC failure in {tag!r}"
+            if tag == b"IDAT":
+                idat += body
+            pos += 12 + ln
+        w, h = struct.unpack(">II", raw[16:24])
+        assert len(zlib.decompress(idat)) == h * (1 + w * 3)
+
+
+def test_corpus_accumulates_context_so_duplicates_actually_arise():
+    """Turns carry history forward, as every other trajectory does. Without that
+    each turn holds one image, there is nothing to de-duplicate, and the domain
+    would certify vacuously."""
+    traj = Trajectory.load(_CORPUS)
+    counts = [sum(len(b.media or []) for b in t.blocks) for t in traj.turns]
+    assert counts == sorted(counts) and counts[-1] > counts[0], counts
+    assert counts[-1] >= 4, "final turn should hold several images"
+
+
+def test_vision_strategy_preserves_the_distinct_set_on_every_corpus_turn():
+    """The invariant the live certificate then tests for decision impact."""
+    traj = Trajectory.load(_CORPUS)
+    for turn in traj.turns:
+        before = {_digest(m) for b in turn.blocks for m in (b.media or [])}
+        after = {
+            _digest(m) for b in REGISTRY["vision"](turn.blocks, turn.index) for m in (b.media or [])
+        }
+        assert after == before, f"turn {turn.index}: distinct image set changed"
+
+
+def test_corpus_is_excluded_from_the_offline_gate_on_purpose():
+    """It must NOT drift back into the deterministic manifest. That runner grades
+    by reading DECISION: markers out of text; this domain's decision is in the
+    pixels. Passing it offline would require writing the tile's colour into the
+    text, making the image decorative and the certificate a claim about text."""
+    manifest = json.loads((_CORPUS.parent / "manifest.json").read_text())
+    offline = {t["file"] for t in manifest["trajectories"]}
+    assert "vision-ci-dashboard.json" not in offline
+    live = {t["file"] for t in manifest.get("live_only", [])}
+    assert "vision-ci-dashboard.json" in live
+    reason = manifest["live_only"][0]["why_not_in_the_offline_gate"]
+    assert "live vision runner" in reason
+
+
+@pytest.mark.parametrize("strategy", ["none", "distil", "naive", "aggressive"])
+def test_existing_strategies_never_drop_media(strategy):
+    """A text strategy that silently discarded images would make any later
+    comparison against it meaningless."""
+    red = _img((200, 40, 40))
+    blocks = [_blk("a", [red], "some tool output\n" * 10)]
+    out = REGISTRY[strategy](blocks, 0)
+    assert [m for b in out for m in (b.media or [])] == [red], f"{strategy} dropped media"


### PR DESCRIPTION
Vision shipped in 1.35.0 **merged but inert**. The gate required a certificate and none could exist, because the certification path was text-only end to end: `Block.text` is a `str`, so a trajectory could not hold an image, and every runner graded a decision from text.

ADR 0004 named the shortcut nobody should take — serialize the base64 into `Block.text` and certify *that*. It runs, goes green, and measures whether deleting a blob from a **text** prompt changes a **text** decision. That is not the claim.

The claim is that a model which actually **saw** an image decides the same way once a later identical copy becomes a reference. So this builds the thing that can prove it.

## Live result — `claude-opus-4-8`

```
A/A self-agreement floor: 100.0%
  turn 0: ok   turn 1: ok   turn 2: ok   turn 3: ok
decision-equivalence match rate: 100.0%
TOST non-inferiority (margin=0.02, alpha=0.05): mean diff=+0.000, p=<0.0001
VERDICT: PASS  (certified non-inferior)
```

## The first live run FAILED, and that is the most useful part

```
turn 3: DIVERGED
    baseline:   {"action":"promoterelease","target":"latest"}
    compressed: {"action":"openfailingbuild","target":"latest"}
```

The cause was **not** the compression. The runner hoisted every image to the front of the turn, severing each screenshot from the caption identifying it ("after the rerun"). An A/B whose two arms differ in prompt *shape* measures the shape, not the compression under test. Interleaving media with its own block's text fixed it.

**No offline deterministic oracle could have surfaced that** — which is exactly why this domain is certified live.

## What changed

- **`Block.media`** — optional list of provider-shaped content blocks. Defaulted, so every existing strategy, runner and corpus file is unaffected and text-only blocks serialize byte-identically. `copy_with()` carries media through, because a compressor that silently dropped it would grade the compressed arm against a prompt the baseline never had.
- **`AnthropicRunner`** renders media as real image content blocks, interleaved.
- **`vision` strategy** — byte-identical payloads collapse; distinct ones never do; url sources are never treated as duplicates (one URL is not evidence of the same pixels); text untouched, so certifying `vision` isolates the image transform.
- **`corpus/vision-ci-dashboard.json`** — real CRC-valid, decodable PNGs (verified: IDAT decompresses to exactly the expected pixel count). Context **accumulates** like every other trajectory, so by the final turn history holds three byte-identical red tiles plus one distinct green one.

  It is **falsifiable**: a strategy that elided the green tile flips the decision from `promote_release` to `open_failing_build`. A corpus that can only pass certifies nothing.

## Why it is excluded from `distil bench`

That gate's `DeterministicRunner` grades by reading `DECISION:` markers out of block text, and `corpus.validate()` requires one on a decision-relevant volatile block. Satisfying it here would mean writing the tile's colour into the text — image decorative, certificate about text.

It sits under `live_only` in the manifest with the reasoning attached, and `test_manifest_covers_every_corpus_file` now **enforces that the reason exists**, so nobody "fixes" it back into the offline gate later.

## Verification

**1980 passed**, coverage **95.07%** · `verify` PASS · `validate` 60/60 · `bench` GATE PASS · ruff + mypy clean.

16 new tests state explicitly what they can and cannot establish: the mechanism, **not** decision-equivalence. Only the live run proves that, and a green suite must never read as a certificate.

Gate behaviour confirmed both ways: with a real certificate `vision.enabled()` is True; with it removed, False.