### PR TITLE
feat(census): ask for consent at wrap exit, not only in onboard

### DIFF
--- a/distil/census.py
+++ b/distil/census.py
@@ -113,6 +113,98 @@ def consent() -> str | None:
         return None
 
 
+def _ask_count_path() -> Path:
+    return _home() / "census-asked"
+
+
+# A prompt nobody answers must not become a prompt nobody escapes. Ctrl-C is
+# deliberately not recorded as a decline (see `onboard`), which means an
+# interrupted prompt returns next session — fine once or twice, a nag by the
+# fourth time. After this many unanswered asks, stop asking forever; `distil
+# census on` is still there for anyone who changes their mind.
+MAX_UNANSWERED_ASKS = 3
+
+
+def maybe_ask_consent(*, out=None, inp=None) -> bool | None:
+    """Ask for census consent ONCE, at the end of a session that actually saved
+    something. Returns True (opted in), False (declined), or None (not asked).
+
+    Placed at wrap exit because that is the only moment the question is fair:
+    the user has run the thing, there is a real number on screen, and "share
+    this?" is concrete rather than hypothetical. Until now the sole consent
+    surface was `distil onboard` — so anyone who did `pipx install distil-llm`
+    and went straight to `distil wrap`, which is the natural path, was never
+    asked and could never be counted. The census did not undercount by accident;
+    it undercounted by construction.
+
+    Every guard the onboard prompt established is preserved, because consent
+    code earns nothing by being clever:
+
+      * asked once — a stored "on" or "off" ends it permanently;
+      * DO_NOT_TRACK / DISTIL_NO_TELEMETRY win outright;
+      * both streams must be a TTY, so pipes, CI and headless runs never prompt
+        and therefore never enrol;
+      * Ctrl-C / EOF is NOT an answer — recording "off" there would burn the one
+        chance to ask on a keystroke that meant "not now";
+      * and nothing here may raise: this runs on the wrap teardown path, where an
+        exception would change a user's exit code over telemetry.
+
+    The saved-something condition is new and deliberate. Asking a user who got
+    no value to share their numbers is both a worse question and a worse
+    experience than not asking at all.
+    """
+    import sys
+
+    out = out or sys.stdout
+    inp = inp or sys.stdin
+    try:
+        if hard_disabled() or consent() is not None:
+            return None
+        if not (
+            getattr(inp, "isatty", lambda: False)() and getattr(out, "isatty", lambda: False)()
+        ):
+            return None
+        if _current_saved_tokens() <= 0:
+            return None  # nothing worth sharing yet — ask when there is
+
+        asked = 0
+        try:
+            asked = int(_ask_count_path().read_text(encoding="utf-8").strip() or 0)
+        except (OSError, ValueError):
+            asked = 0
+        if asked >= MAX_UNANSWERED_ASKS:
+            return None
+
+        out.write(
+            "\n  Share an anonymous, content-free census? Numbers only — version, OS,\n"
+            "  tokens and $ saved. Never prompts or responses. Max one JSON per day.\n"
+            "  Preview exactly what would be sent:  distil census show\n"
+        )
+        out.flush()
+        try:
+            answer = input("  Share the anonymous census? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            # Not an answer. Count it so an unanswerable terminal cannot nag
+            # forever, but never treat the silence as a decision.
+            try:
+                _ask_count_path().parent.mkdir(parents=True, exist_ok=True)
+                _ask_count_path().write_text(str(asked + 1), encoding="utf-8")
+            except OSError:
+                pass
+            out.write("\n  no answer recorded — enable anytime: distil census on\n")
+            return None
+
+        if answer in ("y", "yes"):
+            opt_in()
+            out.write("  census on — TELEMETRY.md documents exactly what is sent\n")
+            return True
+        opt_out()
+        out.write("  census off — re-enable anytime: distil census on\n")
+        return False
+    except Exception:  # noqa: BLE001 — consent must never affect a user's exit code
+        return None
+
+
 def enabled() -> bool:
     return not hard_disabled() and consent() == "on"
 

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -1845,6 +1845,13 @@ def wrap_run(
     try:
         from . import census as _census
 
+        # Ask for consent BEFORE the ping, so a first-time yes takes effect in the
+        # same session the user granted it — otherwise their first census would be
+        # a day late, and the number they just agreed to share is the number on
+        # screen. Self-gating: no-ops unless never asked, a TTY, and something was
+        # actually saved. `distil onboard` was the only consent surface, which
+        # meant anyone who installed and went straight to `wrap` was never asked.
+        _census.maybe_ask_consent()
         _census.maybe_ping()
         _census.maybe_heartbeat()  # near-real-time community pulse (≤1/5min, only-if-grew)
     except Exception:  # noqa: BLE001 — census must never affect exit code

--- a/tests/test_census_consent.py
+++ b/tests/test_census_consent.py
@@ -1,0 +1,197 @@
+"""Consent asked at wrap exit — every guard, enumerated.
+
+This is the code that decides whether a user is enrolled in telemetry. The
+failure that matters is not "the prompt didn't show" — it is enrolling someone
+who did not say yes, or recording a decision they did not make. So the guards
+are tested individually rather than sampled, and the ones that could silently
+enrol are tested hardest.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from distil import census
+
+
+class FakeTTY(io.StringIO):
+    """A stream that claims to be a terminal."""
+
+    def __init__(self, tty: bool = True) -> None:
+        super().__init__()
+        self._tty = tty
+
+    def isatty(self) -> bool:  # noqa: D102
+        return self._tty
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("DISTIL_NO_TELEMETRY", raising=False)
+    # Default: a session that actually saved something, so the "nothing to
+    # share" guard does not silently satisfy every test below.
+    monkeypatch.setattr(census, "_current_saved_tokens", lambda: 5_000)
+
+
+def _answer(monkeypatch, text: str) -> None:
+    monkeypatch.setattr("builtins.input", lambda *a, **k: text)
+
+
+def _raises(monkeypatch, exc) -> None:
+    def boom(*a, **k):
+        raise exc
+
+    monkeypatch.setattr("builtins.input", boom)
+
+
+def _tripwire(monkeypatch) -> list:
+    """Record whether the prompt was reached, WITHOUT raising.
+
+    A raising tripwire is useless here: maybe_ask_consent ends in a broad
+    `except Exception` (it must — it runs on the teardown path and may not alter
+    a user's exit code), so an AssertionError from input() is swallowed and the
+    test passes even with the guard deleted. Verified: removing the TTY check
+    left the raising version green. Guards are therefore asserted on OBSERVABLE
+    effects — the prompt never printed, and nobody was enrolled.
+    """
+    calls: list = []
+
+    def spy(*a, **k):
+        calls.append(a)
+        return "y"  # the dangerous answer, so a leak enrols and is caught
+
+    monkeypatch.setattr("builtins.input", spy)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# The happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_yes_opts_in(monkeypatch):
+    _answer(monkeypatch, "y")
+    out = FakeTTY()
+    assert census.maybe_ask_consent(out=out, inp=FakeTTY()) is True
+    assert census.consent() == "on"
+    assert "census on" in out.getvalue()
+
+
+def test_no_opts_out_and_is_remembered(monkeypatch):
+    _answer(monkeypatch, "n")
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is False
+    assert census.consent() == "off"
+    # Asked once: a decision ends it permanently.
+    calls = _tripwire(monkeypatch)
+    out = FakeTTY()
+    assert census.maybe_ask_consent(out=out, inp=FakeTTY()) is None
+    assert not calls, "re-asked after a recorded decision"
+    assert out.getvalue() == ""
+    assert census.consent() == "off", "a recorded decline was overwritten"
+
+
+def test_bare_enter_declines(monkeypatch):
+    """The prompt is [y/N] — the default must be no, not yes."""
+    _answer(monkeypatch, "")
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is False
+    assert census.consent() == "off"
+
+
+@pytest.mark.parametrize("word", ["yes", "Y", "YES", " y "])
+def test_affirmative_spellings(monkeypatch, word):
+    _answer(monkeypatch, word)
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is True
+
+
+@pytest.mark.parametrize("word", ["nope", "later", "sure", "1", "true"])
+def test_anything_not_clearly_yes_is_a_decline(monkeypatch, word):
+    """Ambiguity must never resolve to consent."""
+    _answer(monkeypatch, word)
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is False
+    assert census.consent() == "off"
+
+
+# ---------------------------------------------------------------------------
+# The guards that prevent silent enrolment
+# ---------------------------------------------------------------------------
+
+
+def test_never_prompts_when_not_a_tty(monkeypatch):
+    """Pipes, CI and headless runs must never prompt, and therefore never enrol.
+    input() is a tripwire here: reaching it at all is the failure."""
+    calls = _tripwire(monkeypatch)
+    for out, inp in ((FakeTTY(True), FakeTTY(False)), (FakeTTY(False), FakeTTY(True))):
+        assert census.maybe_ask_consent(out=out, inp=inp) is None
+        assert out.getvalue() == "", "printed a consent prompt to a non-terminal"
+    assert not calls, "reached the prompt in a non-interactive session"
+    assert census.consent() is None
+
+
+@pytest.mark.parametrize("var", ["DO_NOT_TRACK", "DISTIL_NO_TELEMETRY"])
+def test_kill_switches_prevent_the_question(monkeypatch, var):
+    """Someone who set DO_NOT_TRACK has already answered."""
+    monkeypatch.setenv(var, "1")
+    calls = _tripwire(monkeypatch)
+    out = FakeTTY()
+    assert census.maybe_ask_consent(out=out, inp=FakeTTY()) is None
+    assert not calls, f"prompted despite {var}"
+    assert out.getvalue() == ""
+    assert census.consent() is None
+
+
+def test_does_not_ask_when_nothing_was_saved(monkeypatch):
+    """Asking a user who got no value to share their numbers is a worse question
+    and a worse experience than not asking."""
+    monkeypatch.setattr(census, "_current_saved_tokens", lambda: 0)
+    calls = _tripwire(monkeypatch)
+    out = FakeTTY()
+    assert census.maybe_ask_consent(out=out, inp=FakeTTY()) is None
+    assert not calls, "prompted with nothing to share"
+    assert out.getvalue() == ""
+    assert census.consent() is None
+
+
+def test_interrupt_is_not_an_answer(monkeypatch):
+    """Ctrl-C means 'not now', not 'no'. Recording a decline here would burn the
+    one chance to ask on a keystroke that meant nothing of the sort."""
+    for exc in (KeyboardInterrupt, EOFError):
+        _raises(monkeypatch, exc)
+        assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is None
+        assert census.consent() is None, "an interrupt was recorded as a decision"
+
+
+def test_unanswered_prompts_stop_after_a_cap(monkeypatch):
+    """A prompt nobody answers must not become a prompt nobody escapes."""
+    _raises(monkeypatch, KeyboardInterrupt)
+    for _ in range(census.MAX_UNANSWERED_ASKS):
+        assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is None
+    # Past the cap it must go quiet.
+    calls = _tripwire(monkeypatch)
+    out = FakeTTY()
+    assert census.maybe_ask_consent(out=out, inp=FakeTTY()) is None
+    assert not calls, "kept nagging past the cap"
+    assert out.getvalue() == ""
+    assert census.consent() is None, "the cap must not imply a decision"
+
+
+def test_never_raises_on_the_teardown_path(monkeypatch):
+    """This runs at wrap exit. An exception here would change a user's exit code
+    over telemetry."""
+
+    def explode():
+        raise RuntimeError("ledger on fire")
+
+    monkeypatch.setattr(census, "_current_saved_tokens", explode)
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is None
+
+
+def test_a_yes_takes_effect_in_the_same_session(monkeypatch):
+    """Consent is asked before the ping, so the number the user just agreed to
+    share is the number they were looking at — not one a day later."""
+    _answer(monkeypatch, "y")
+    assert census.maybe_ask_consent(out=FakeTTY(), inp=FakeTTY()) is True
+    assert census.enabled() is True, "opting in did not take effect immediately"


### PR DESCRIPTION
The census undercounts **by construction**, and the cause is a missing question rather than a broken counter.

`distil onboard` was the **only** consent surface (`cli.py:1582`). Anyone who ran `pipx install distil-llm` and went straight to `distil wrap` — the natural path, and the one the README showed most prominently until this week — was never asked and could never be counted.

On the live data: **2 opted-in installs** against **11,102 monthly downloads** and **374 unique cloners**.

### Why wrap exit

It's the only moment the question is fair. The user has actually run it, there's a real saving on screen, and *"share this?"* is concrete rather than hypothetical. Placed **before** the ping so a first-time yes takes effect in the same session — otherwise the first census would be a day late and the number they agreed to share wouldn't be the number they saw.

### Guards

Every guard the onboard prompt established, preserved — plus one new:

- asked **once**; a stored `on`/`off` ends it permanently
- `DO_NOT_TRACK` / `DISTIL_NO_TELEMETRY` win outright
- both streams must be a TTY — pipes, CI and headless runs never prompt and therefore **never enrol**
- **Ctrl-C / EOF is not an answer**; recording "off" there would burn the one chance to ask on a keystroke that meant *"not now"*
- unanswered prompts stop after 3 — a prompt nobody answers must not become a prompt nobody escapes
- **new:** nothing is asked unless the session actually saved something. Asking a user who got no value to share their numbers is a worse question *and* a worse experience than not asking
- never raises — this is the wrap teardown path, where an exception would change a user's exit code over telemetry

### The tests were wrong first, and that is the part worth reading

The guard tests used a tripwire that **raised** from `input()`. `maybe_ask_consent` ends in a broad `except Exception` — it must, per the last guard above — so the tripwire was swallowed and **the tests passed with the TTY guard deleted.** I verified that by deleting it.

A green suite that cannot detect removal of the single most important safety guard is worse than no suite, because it reads as assurance.

They now assert **observable effects** — the prompt never printed, nobody was enrolled — and every guard is mutation-tested:

| guard removed | result |
|---|---|
| TTY check | 1 failed |
| kill switches | 2 failed |
| saved-something | 1 failed |
| none (restored) | 20 passed |

### Verification

**2047 passed** · coverage 95.07% · ruff + mypy clean.

### Note on what this does not fix

`install_id` is a random UUID and `distil census off` deletes it, so a machine that toggles consent mints a new id. There is still no way to distinguish "a friend's laptop" from "my own second environment" — and adding one would mean fingerprinting, which the design deliberately refuses. This makes the opted-in set larger and more representative; it does not make individual installs attributable, and it shouldn't.