### PR TITLE
release(1.37.0): ask for consent at the moment it makes sense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.37.0] — you will be asked, once, at the moment it makes sense
+
+**The census undercounted because nobody was asked.** `distil onboard` was the
+only place that ever requested consent, so anyone who ran `pipx install
+distil-llm` and went straight to `distil wrap` — the natural path, and the one
+the README showed most prominently until this week — was never asked and could
+never be counted. The live numbers made the shape of it obvious: **2 opted-in
+installs against 11,102 monthly downloads and 374 unique cloners.** That is not a
+counter that is broken; it is a question that was never put.
+
+**You will now be asked once, at the end of a session that actually saved
+something.** That is the only moment the question is fair: you have run the
+thing, there is a real number on screen, and "share this?" is concrete rather
+than hypothetical. The prompt sits before the census send, so a first yes counts
+the session you were looking at rather than one a day later.
+
+Every guard the original prompt established is kept, and one is new. Asked once —
+a stored yes or no ends it permanently. `DO_NOT_TRACK` and `DISTIL_NO_TELEMETRY`
+win outright. Both streams must be a terminal, so pipes, CI and headless runs
+never prompt and therefore never enrol. **Ctrl-C is not an answer** — recording a
+decline there would burn the one chance to ask on a keystroke that meant "not
+now" — though unanswered prompts stop after three, because a prompt nobody
+answers must not become a prompt nobody escapes. The new one: **nothing is asked
+if the session saved nothing.** Asking someone who got no value to share their
+numbers is a worse question and a worse experience than staying quiet. And none
+of it can raise: this runs on the wrap teardown path, where an exception would
+change your exit code over telemetry.
+
+**What this does not do is make you identifiable.** `install_id` is a random
+UUID, and `distil census off` deletes it — so a machine that toggles consent
+mints a new one. There is no way to tell one person's second laptop from two
+different people, and there will not be: the fix for a small opted-in set is a
+larger opted-in set, not fingerprinting.
+
+**Docs.** A light theme (page chrome only — diagrams and code blocks stay dark,
+because SVGs loaded through `<img>` cannot inherit page CSS and half-recolouring
+them would look broken rather than deliberate; contrast measured at 7.24:1 body
+and 17.5:1 headings). Per-page **Copy as Markdown**, because these docs are read
+by agents as often as by people. And eight per-framework pages — Anthropic SDK,
+OpenAI SDK, LiteLLM, LangChain, Vercel AI SDK, Agno, Strands, CrewAI — each
+carrying the caveat that actually bites, such as CrewAI resolving `planning_llm`
+separately and silently bypassing the proxy.
+
 ## [1.36.0] — the image transform is certified, and now on by default
 
 1.35.0 shipped vision compression **merged but inert**: the gate demanded a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.36.0
+version: 1.37.0
 date-released: 2026-07-26
 keywords:
   - llm

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.36.0"
+version = "1.37.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.36.0",
+  "version": "1.37.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.36.0"
+version = "1.37.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### The census undercounted because nobody was asked

`distil onboard` was the only consent surface. Anyone who ran `pipx install distil-llm` and went straight to `distil wrap` — the natural path — was never asked and could never be counted.

**2 opted-in installs against 11,102 monthly downloads and 374 unique cloners.** That's not a broken counter; it's a question that was never put.

### What users will notice

A prompt, **once**, at the end of a session that actually saved something. That's the only moment the question is fair — you've run it, there's a real number on screen, and *"share this?"* is concrete rather than hypothetical. It sits before the send, so a first yes counts the session you were looking at.

Guards: asked once · `DO_NOT_TRACK`/`DISTIL_NO_TELEMETRY` win · both streams must be a TTY so pipes and CI **never enrol** · Ctrl-C is not an answer · unanswered prompts stop after three · **never asks a session that saved nothing** · never raises on the teardown path.

### What it deliberately does not do

`install_id` stays a random UUID that `census off` deletes. Nobody becomes identifiable, and one machine toggling consent still looks like two. **The fix for a small opted-in set is a larger opted-in set, not fingerprinting.**

### Also carries #56

Light theme, per-page Copy as Markdown, eight per-framework pages. Not released on its own because docs ship via Pages rather than the wheel — a release for them alone would have published a byte-identical package under a new version number.

### Gates

**2047 passed** · coverage 95.07% · `verify` PASS · `validate` 60/60 · `bench` GATE PASS · packaging smoke 12 passed (all six version locations consistent) · ruff + mypy clean · changelog swept for stray characters.