### PR TITLE
fix(test): close the connection-refused placeholder port right before use

### DIFF
--- a/tests/test_gateway_cov.py
+++ b/tests/test_gateway_cov.py
@@ -365,12 +365,16 @@ def test_gateway_streaming_request_uses_streamrelay() -> None:
 
 def test_gateway_passthrough_connection_refused_502() -> None:
     """Gateway _passthrough: refused upstream connection → 502."""
+    # Release the placeholder as late as possible (see test_proxy_cov.py's
+    # test_proxy_connection_refused_502 for why): an earlier release widens a real
+    # race on shared CI runners where something else grabs the freed port before
+    # the gateway connects to it, turning an expected fast 502 into a client hang.
     placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
     dead_port = placeholder.server_address[1]
-    placeholder.server_close()
 
     srv, _ = _make_gateway(dead_port)
     try:
+        placeholder.server_close()
         # GET to non-admin path → _passthrough → URLError → 502
         status, _, data = _req("GET", srv.server_address[1], "/v1/models")
         assert status == 502

--- a/tests/test_gateway_cov.py
+++ b/tests/test_gateway_cov.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import http.client
 import json
-import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -366,23 +365,22 @@ def test_gateway_streaming_request_uses_streamrelay() -> None:
 
 def test_gateway_passthrough_connection_refused_502() -> None:
     """Gateway _passthrough: refused upstream connection → 502."""
-    # Reserve the port by binding without listening (see test_proxy_cov.py's
-    # test_proxy_connection_refused_502 for why): a bound-but-not-listening socket
-    # gets an immediate RST on any connect attempt while we hold it, so nothing else
-    # on a shared CI host can steal the port out from under us mid-test.
-    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    placeholder.bind(("127.0.0.1", 0))
-    dead_port = placeholder.getsockname()[1]
+    # Release the placeholder as late as possible (see test_proxy_cov.py's
+    # test_proxy_connection_refused_502 for why, and why bind-without-listen isn't
+    # used instead — it isn't portable, macOS runners don't RST it the way Linux does).
+    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    dead_port = placeholder.server_address[1]
     try:
         srv, _ = _make_gateway(dead_port)
         try:
+            placeholder.server_close()
             # GET to non-admin path → _passthrough → URLError → 502
             status, _, data = _req("GET", srv.server_address[1], "/v1/models")
             assert status == 502
         finally:
             srv.shutdown()
     finally:
-        placeholder.close()
+        placeholder.server_close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway_cov.py
+++ b/tests/test_gateway_cov.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -365,21 +366,23 @@ def test_gateway_streaming_request_uses_streamrelay() -> None:
 
 def test_gateway_passthrough_connection_refused_502() -> None:
     """Gateway _passthrough: refused upstream connection → 502."""
-    # Release the placeholder as late as possible (see test_proxy_cov.py's
-    # test_proxy_connection_refused_502 for why): an earlier release widens a real
-    # race on shared CI runners where something else grabs the freed port before
-    # the gateway connects to it, turning an expected fast 502 into a client hang.
-    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
-    dead_port = placeholder.server_address[1]
-
-    srv, _ = _make_gateway(dead_port)
+    # Reserve the port by binding without listening (see test_proxy_cov.py's
+    # test_proxy_connection_refused_502 for why): a bound-but-not-listening socket
+    # gets an immediate RST on any connect attempt while we hold it, so nothing else
+    # on a shared CI host can steal the port out from under us mid-test.
+    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    placeholder.bind(("127.0.0.1", 0))
+    dead_port = placeholder.getsockname()[1]
     try:
-        placeholder.server_close()
-        # GET to non-admin path → _passthrough → URLError → 502
-        status, _, data = _req("GET", srv.server_address[1], "/v1/models")
-        assert status == 502
+        srv, _ = _make_gateway(dead_port)
+        try:
+            # GET to non-admin path → _passthrough → URLError → 502
+            status, _, data = _req("GET", srv.server_address[1], "/v1/models")
+            assert status == 502
+        finally:
+            srv.shutdown()
     finally:
-        srv.shutdown()
+        placeholder.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_cov.py
+++ b/tests/test_proxy_cov.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import http.client
 import json
-import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -296,18 +295,25 @@ def test_proxy_upstream_500_on_compressible_post(error_proxy: int) -> None:
 
 def test_proxy_connection_refused_502() -> None:
     """Connection refused at upstream → proxy returns 502 (URLError path)."""
-    # Reserve a port by binding without listening, rather than binding-then-releasing:
-    # a bound-but-not-listening socket gets an immediate RST (refused) on any connect
-    # attempt while we hold it, so nothing else on a shared CI host can ever steal the
-    # port out from under us mid-test — no release window, no race.
-    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    placeholder.bind(("127.0.0.1", 0))
-    dead_port = placeholder.getsockname()[1]
+    # Bind a server to reserve a port, then release it right before use — the release
+    # must happen as late as possible: the freed port stays free only until *something*
+    # (anything on the shared CI host) grabs it, so every extra bind/thread-spawn we do
+    # before actually using it widens a real race — observed as a client-side timeout
+    # (proxy connects to a port something else now holds and the request just hangs)
+    # rather than the expected fast 502, on a loaded CI runner.
+    #
+    # A bind-without-listen variant (hold the port open the whole test, relying on the
+    # kernel's RST for "nobody's listening") was tried and reverted: it's instant on
+    # Linux, but on macOS runners the same connect instead timed out (URLError read as
+    # a timeout → 504, not 502) — not portable, so back to release-late-and-close-fast.
+    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    dead_port = placeholder.server_address[1]
     try:
         handler = build_handler(f"http://127.0.0.1:{dead_port}")
         proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
         threading.Thread(target=proxy.serve_forever, daemon=True).start()
         try:
+            placeholder.server_close()
             # Non-streaming POST (compressible) → _post_upstream URLError → 502
             body = json.dumps(
                 {"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "hello"}]}
@@ -317,7 +323,7 @@ def test_proxy_connection_refused_502() -> None:
         finally:
             proxy.shutdown()
     finally:
-        placeholder.close()
+        placeholder.server_close()
 
 
 # ---------------------------------------------------------------------------
@@ -516,17 +522,17 @@ def test_streamrelay_http_error_relayed_via_passthrough(error_proxy: int) -> Non
 def test_streamrelay_connection_refused_502() -> None:
     """streamrelay returns 502 when the upstream refuses the connection (lines 85-93).
 
-    See test_proxy_connection_refused_502 above for why the port is reserved by
-    binding without listening rather than binding-then-releasing.
+    See test_proxy_connection_refused_502 above for why the placeholder is released
+    as late as possible rather than held open bind-without-listen style.
     """
-    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    placeholder.bind(("127.0.0.1", 0))
-    dead_port = placeholder.getsockname()[1]
+    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    dead_port = placeholder.server_address[1]
     try:
         handler = build_handler(f"http://127.0.0.1:{dead_port}")
         proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
         threading.Thread(target=proxy.serve_forever, daemon=True).start()
         try:
+            placeholder.server_close()
             # GET → _passthrough → stream_upstream → URLError (refused) → 502
             status, _, data = _request("GET", proxy.server_address[1])
             assert status == 502
@@ -534,7 +540,7 @@ def test_streamrelay_connection_refused_502() -> None:
         finally:
             proxy.shutdown()
     finally:
-        placeholder.close()
+        placeholder.server_close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_cov.py
+++ b/tests/test_proxy_cov.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -295,28 +296,28 @@ def test_proxy_upstream_500_on_compressible_post(error_proxy: int) -> None:
 
 def test_proxy_connection_refused_502() -> None:
     """Connection refused at upstream → proxy returns 502 (URLError path)."""
-    # Bind a server to reserve a port, then release it without serving. The release
-    # must happen as late as possible: the freed port stays free only until *something*
-    # (anything on the shared CI host) grabs it, so every extra bind/thread-spawn we do
-    # before actually using it widens a real race — observed as a client-side timeout
-    # (proxy connects to a port something else now holds and the request just hangs)
-    # rather than the expected fast 502, on a loaded CI runner.
-    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
-    dead_port = placeholder.server_address[1]
-
-    handler = build_handler(f"http://127.0.0.1:{dead_port}")
-    proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
-    threading.Thread(target=proxy.serve_forever, daemon=True).start()
+    # Reserve a port by binding without listening, rather than binding-then-releasing:
+    # a bound-but-not-listening socket gets an immediate RST (refused) on any connect
+    # attempt while we hold it, so nothing else on a shared CI host can ever steal the
+    # port out from under us mid-test — no release window, no race.
+    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    placeholder.bind(("127.0.0.1", 0))
+    dead_port = placeholder.getsockname()[1]
     try:
-        placeholder.server_close()
-        # Non-streaming POST (compressible) → _post_upstream URLError → 502
-        body = json.dumps(
-            {"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "hello"}]}
-        ).encode()
-        status, _, _ = _request("POST", proxy.server_address[1], "/v1/messages", body=body)
-        assert status == 502
+        handler = build_handler(f"http://127.0.0.1:{dead_port}")
+        proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        threading.Thread(target=proxy.serve_forever, daemon=True).start()
+        try:
+            # Non-streaming POST (compressible) → _post_upstream URLError → 502
+            body = json.dumps(
+                {"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "hello"}]}
+            ).encode()
+            status, _, _ = _request("POST", proxy.server_address[1], "/v1/messages", body=body)
+            assert status == 502
+        finally:
+            proxy.shutdown()
     finally:
-        proxy.shutdown()
+        placeholder.close()
 
 
 # ---------------------------------------------------------------------------
@@ -515,24 +516,25 @@ def test_streamrelay_http_error_relayed_via_passthrough(error_proxy: int) -> Non
 def test_streamrelay_connection_refused_502() -> None:
     """streamrelay returns 502 when the upstream refuses the connection (lines 85-93).
 
-    See test_proxy_connection_refused_502 above for why the placeholder is released
-    as late as possible: an early release widens a real (if rare) race on shared CI
-    runners where something else grabs the freed port before the proxy connects to it.
+    See test_proxy_connection_refused_502 above for why the port is reserved by
+    binding without listening rather than binding-then-releasing.
     """
-    placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
-    dead_port = placeholder.server_address[1]
-
-    handler = build_handler(f"http://127.0.0.1:{dead_port}")
-    proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
-    threading.Thread(target=proxy.serve_forever, daemon=True).start()
+    placeholder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    placeholder.bind(("127.0.0.1", 0))
+    dead_port = placeholder.getsockname()[1]
     try:
-        placeholder.server_close()
-        # GET → _passthrough → stream_upstream → URLError (refused) → 502
-        status, _, data = _request("GET", proxy.server_address[1])
-        assert status == 502
-        assert b"upstream" in data.lower()
+        handler = build_handler(f"http://127.0.0.1:{dead_port}")
+        proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        threading.Thread(target=proxy.serve_forever, daemon=True).start()
+        try:
+            # GET → _passthrough → stream_upstream → URLError (refused) → 502
+            status, _, data = _request("GET", proxy.server_address[1])
+            assert status == 502
+            assert b"upstream" in data.lower()
+        finally:
+            proxy.shutdown()
     finally:
-        proxy.shutdown()
+        placeholder.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_cov.py
+++ b/tests/test_proxy_cov.py
@@ -295,15 +295,20 @@ def test_proxy_upstream_500_on_compressible_post(error_proxy: int) -> None:
 
 def test_proxy_connection_refused_502() -> None:
     """Connection refused at upstream → proxy returns 502 (URLError path)."""
-    # Bind a server to reserve a port, then release it without serving.
+    # Bind a server to reserve a port, then release it without serving. The release
+    # must happen as late as possible: the freed port stays free only until *something*
+    # (anything on the shared CI host) grabs it, so every extra bind/thread-spawn we do
+    # before actually using it widens a real race — observed as a client-side timeout
+    # (proxy connects to a port something else now holds and the request just hangs)
+    # rather than the expected fast 502, on a loaded CI runner.
     placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
     dead_port = placeholder.server_address[1]
-    placeholder.server_close()
 
     handler = build_handler(f"http://127.0.0.1:{dead_port}")
     proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     threading.Thread(target=proxy.serve_forever, daemon=True).start()
     try:
+        placeholder.server_close()
         # Non-streaming POST (compressible) → _post_upstream URLError → 502
         body = json.dumps(
             {"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "hello"}]}
@@ -508,15 +513,20 @@ def test_streamrelay_http_error_relayed_via_passthrough(error_proxy: int) -> Non
 
 
 def test_streamrelay_connection_refused_502() -> None:
-    """streamrelay returns 502 when the upstream refuses the connection (lines 85-93)."""
+    """streamrelay returns 502 when the upstream refuses the connection (lines 85-93).
+
+    See test_proxy_connection_refused_502 above for why the placeholder is released
+    as late as possible: an early release widens a real (if rare) race on shared CI
+    runners where something else grabs the freed port before the proxy connects to it.
+    """
     placeholder = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
     dead_port = placeholder.server_address[1]
-    placeholder.server_close()
 
     handler = build_handler(f"http://127.0.0.1:{dead_port}")
     proxy = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     threading.Thread(target=proxy.serve_forever, daemon=True).start()
     try:
+        placeholder.server_close()
         # GET → _passthrough → stream_upstream → URLError (refused) → 502
         status, _, data = _request("GET", proxy.server_address[1])
         assert status == 502


### PR DESCRIPTION
## Summary
- CI red on main: `gate (ubuntu-latest, 3.10)` failed on `test_streamrelay_connection_refused_502` with a client-side `TimeoutError` instead of the expected `502` ([run](https://github.com/dshakes/distil/actions/runs/30314594693/job/90137374987)).
- `_UPSTREAM_TIMEOUT` is 600s, so an 8s client-side hang means the proxy's outbound connect to the "dead" placeholder port actually *succeeded* and never got a response — something else on the shared runner grabbed the freed port in the window between releasing it and the proxy trying to connect to it.
- All three connection-refused tests (`test_proxy_connection_refused_502`, `test_streamrelay_connection_refused_502`, `test_gateway_passthrough_connection_refused_502`) shared this race: they released the placeholder port immediately after capturing it, then did more socket work (binding the server under test, spawning its thread) before ever using the port. Moving the release to right before the request call shrinks that window to effectively nothing, without touching the assertions or the behavior under test.

## Test plan
- [x] Ran the three affected tests 30x back to back locally (all green)
- [x] `uv run pytest -q` — 2028 passed, 7 skipped
- [x] `uvx ruff check distil tests` — all checks passed
- [x] `uvx mypy --python-version 3.12 --ignore-missing-imports distil` — no issues
- [x] `uv run distil bench && uv run distil verify && uv run distil validate` — all PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUYQMByQtoNhGL1HoQ5qq4)_