### PR TITLE
fix(release): a throwaway venv must not borrow this machine's census identity

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,7 +72,31 @@ gh run watch --repo dshakes/distil $(gh run list --repo dshakes/distil -w releas
 
 ## After CI is green
 
-- **Verify PyPI:** `pipx install distil-llm && distil --version` → the new version.
+- **Verify PyPI** — install the *published* artifact and check it, rather than trusting
+  the workflow's green tick. A green run proves an upload happened; installing proves
+  users get what the release claims.
+
+  ```bash
+  V=X.Y.Z
+  T="$(mktemp -d)"; python3 -m venv "$T/venv"
+  "$T/venv/bin/pip" install -q --no-cache-dir "distil-llm==$V"
+  DISTIL_HOME="$T/home" "$T/venv/bin/distil" --version      # → distil X.Y.Z
+  # attestation: publisher must be dshakes/distil via release.yml
+  curl -s "https://pypi.org/integrity/distil-llm/$V/distil_llm-$V-py3-none-any.whl/provenance" \
+    | python3 -c 'import json,sys; [print(b["publisher"]) for b in json.load(sys.stdin)["attestation_bundles"]]'
+  ```
+
+  **Always set `DISTIL_HOME` to a throwaway when running a verification build.** A temp
+  venv is not a machine. Without it, the verification inherits this machine's install id
+  and consent, and `distil census on` or a `wrap` exit will file a census ping — putting a
+  version on the public adoption board that nobody actually has installed. This happened
+  during the 1.36.0 verification: the board showed an install on 1.36.0 while the only
+  real install was on 1.34.0. Savings were unaffected (they accrue from count-time
+  deltas); the version label was wrong for a day.
+
+  Anything that ships in the wheel and is load-bearing deserves a line here too — e.g.
+  `distil.certificates/vision.json` must survive packaging, or the feature it gates goes
+  silently inert.
 - **Homebrew:** `release.sh` patches `packaging/homebrew/distil.rb` with the tag tarball's
   sha256. Copy that formula into the tap repo (`dshakes/homebrew-tap` → `Formula/distil.rb`)
   so `brew install dshakes/tap/distil` serves it.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -131,6 +131,12 @@ fi
 
 # clean-install smoke test: build the wheel, install it into a throwaway venv with
 # no index, and confirm the entrypoint + bundled corpus actually work.
+#
+# DISTIL_HOME points at the throwaway too. A temp venv is not a machine: if it
+# touches the real ~/.distil it inherits this machine's install id and consent,
+# and anything it reports lands on the public adoption board as though someone
+# were running that version. It also keeps a smoke-test bench off the real
+# savings ledger.
 info "clean-install smoke test…"
 SMOKE="$(mktemp -d)"
 trap 'rm -rf "$SMOKE"' EXIT
@@ -139,9 +145,11 @@ if [ "$DRY_RUN" -eq 0 ]; then
   WHEEL="$(ls "$SMOKE"/wheel/distil_llm-"$VERSION"-py3-none-any.whl)"
   python3 -m venv "$SMOKE/venv"
   "$SMOKE/venv/bin/pip" install -q --no-index "$WHEEL"
+  export DISTIL_HOME="$SMOKE/home"
   GOT="$("$SMOKE/venv/bin/distil" --version | awk '{print $2}')"
   [ "$GOT" = "$VERSION" ] || die "clean install reports $GOT, expected $VERSION"
   "$SMOKE/venv/bin/distil" bench >/dev/null || die "distil bench failed on a clean install"
+  unset DISTIL_HOME
   ok "clean install works: distil $VERSION, bench gate runs"
 fi
 echo

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -316,3 +316,35 @@ def test_every_skill_and_command_has_usable_frontmatter() -> None:
         assert re.search(r"^description:", body.split("---", 2)[1], re.M), (
             f"{cmd.name}: no description — it renders blank in the slash-command list"
         )
+
+
+def test_release_smoke_test_cannot_file_a_census_ping() -> None:
+    """A throwaway venv must not borrow this machine's census identity.
+
+    The release script installs the wheel into a temp venv and runs the CLI
+    against it. Without an isolated DISTIL_HOME that venv inherits the real
+    ~/.distil — same install id, same consent — so anything it reports lands on
+    the public adoption board as an install that does not exist. That is not
+    hypothetical: during the 1.36.0 verification the board showed an install on
+    1.36.0 while the only real one was on 1.34.0.
+
+    Pinned as text because the failure is a deleted line, not a wrong value.
+    """
+    script = (ROOT / "scripts" / "release.sh").read_text()
+    smoke = script.split("clean-install smoke test", 1)
+    assert len(smoke) > 1, "clean-install smoke block not found — did release.sh move?"
+    block = smoke[1].split("push main", 1)[0]
+
+    assert 'export DISTIL_HOME="$SMOKE/home"' in block, (
+        "the release smoke test runs the CLI without isolating DISTIL_HOME — it can "
+        "ping the census under this machine's install id"
+    )
+    # The isolation must be in force for every CLI invocation in the block, so it
+    # has to come before the first one.
+    isolate_at = block.index("export DISTIL_HOME=")
+    first_cli = min(
+        (block.index(c) for c in ('"$SMOKE/venv/bin/distil"',) if c in block),
+        default=-1,
+    )
+    assert first_cli != -1, "smoke block no longer invokes the installed CLI"
+    assert isolate_at < first_cli, "DISTIL_HOME is set after the CLI has already run"


### PR DESCRIPTION
### The board showed an install that does not exist

`by_version` reported one install on **1.36.0**. The only real install was on **1.34.0** — pipx, `importlib.metadata` and `hotswap.installed_version()` all agreed.

From the raw census records:

```
ccdd6de1  pings=10  last=2026-07-27T22:09:38Z  last_version=1.36.0  saved=1,553,654,196
3867672e  pings= 2  last=2026-07-26T02:49:47Z  last_version=1.30.0  saved=0
```

`ccdd6de1` is the maintainer's machine — its saved-token count matches `~/.distil/census-savings.json` exactly. It reported a version it did not have installed.

### Why

A verification venv inherits the real `~/.distil` unless told otherwise: same install id, same consent. `--version` and `bench` never reach `maybe_ping`, but **`distil census on` (`cli.py:1284`) and wrap exit (`proxy.py:1855`) do** — so a throwaway venv can file a ping and put a version on the public board that nobody is running.

Savings were unaffected (count-time deltas, not version-keyed). The version label was wrong for a day.

This is the same shape as the bugs fixed in #44–#47: **a value presented as current, read from a source that isn't.**

### Fix

- `release.sh` — `DISTIL_HOME` points at the throwaway for the smoke test, set *before* the first CLI call. Also keeps a smoke-test `bench` off the real savings ledger.
- `RELEASING.md` — the post-publish step now installs the published artifact and verifies it (version, PEP 740 publisher) instead of trusting the workflow's green tick, with the `DISTIL_HOME` requirement stated and the incident recorded so the reason survives.

### Test

Pinned as text — the failure mode is a deleted line, not a wrong value. **Mutation-tested both ways:**

| Mutation | Result |
|---|---|
| isolation line deleted | **1 failed** |
| isolation set *after* the first CLI call | **1 failed** |
| unmutated | 1 passed |

`make lint` clean · `bash -n` clean · packaging smoke 13 passed.