### PR TITLE
feat(retention): measure what survives, not just whether the action matched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
         run: uv run distil verify
       - name: Adversarial real-path gate (invariants on hostile inputs)
         run: uv run distil validate
+      # Fact-level recall on the corpus: zero cost (no LLM, no API key, no network), so
+      # it is a mandatory per-commit gate rather than a nightly. Tier-0/1 are lossless
+      # by construction, so ANY unrecoverable fact is a real regression.
+      - name: Fact-retention gate (recall on the corpus)
+        run: uv run distil retention --max-lost 0
       # Everything above imports distil from the source tree. This builds the wheel,
       # installs it clean, and drives the console scripts + server.json launch spec the
       # way a user's MCP client does — the boundary that shipped a broken registry

--- a/.github/workflows/live-cert.yml
+++ b/.github/workflows/live-cert.yml
@@ -107,3 +107,54 @@ jobs:
           name: live-cert-reports
           path: live-cert-reports/
           retention-days: 30
+
+  # Public-benchmark recall — external validity. Graded against ground truth written by
+  # someone else (HotpotQA supporting_facts, SQuAD v2 answer spans), so a reader can
+  # check the claim against data they already trust rather than our own corpus.
+  #
+  # Not a per-commit gate: it needs the network (HuggingFace datasets-server), and a
+  # required check that depends on a third-party host would make main's health hostage
+  # to their uptime. Runs nightly here instead, and fails loudly — never silently
+  # "passes" by measuring nothing (see `distil retention --dataset`, which exits 1 on a
+  # fetch failure AND on compression that did not engage).
+  public-benchmarks:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dshakes/distil'
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: "3.12"
+      - name: HotpotQA — answer + supporting-fact recall vs a matched-savings baseline
+        id: hotpot
+        continue-on-error: true
+        run: |
+          uv run distil retention --dataset hotpotqa -n 100 --min-recall 0.99 \
+            | tee hotpotqa.txt
+      - name: SQuAD v2 — gold answer-span recall
+        id: squad
+        continue-on-error: true
+        run: |
+          uv run distil retention --dataset squad -n 100 --min-recall 0.99 \
+            | tee squad.txt
+      - name: Summarize
+        run: |
+          {
+            echo "## Public-benchmark recall"
+            for f in hotpotqa squad; do
+              echo "### $f"
+              echo '```'
+              cat "$f.txt" 2>/dev/null || echo "(no output — step failed before writing)"
+              echo '```'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+          # A dataset host being down is a warning; a real recall regression is a failure.
+          # Both arms failing means we measured nothing, which must not read as green.
+          if [ "${{ steps.hotpot.outcome }}" = "failure" ] && [ "${{ steps.squad.outcome }}" = "failure" ]; then
+            echo "::error::both public benchmarks failed — no external validity signal this run"
+            exit 1
+          fi
+          if [ "${{ steps.hotpot.outcome }}" = "failure" ] || [ "${{ steps.squad.outcome }}" = "failure" ]; then
+            echo "::warning::one public benchmark failed (host down, or a real regression) — see the summary"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ the question users actually ask, which is not "did the next action survive?" but
   (paths/URLs/hashes/UUIDs) and error lines are classified `retained` /
   `recoverable` / `lost`. `recoverable` is **verified, not assumed**: the handle must
   appear in that block's own compressed text *and* the fact must appear in that
-  handle's restore bytes. On the corpus: **100% true recall, 87.7% visible, 0 lost** —
-  so being reversible rather than lossy is worth **12.3% recall**, the first time that
+  handle's restore bytes. On the corpus: **100% true recall, 90.2% visible, 0 lost** —
+  so being reversible rather than lossy is worth **9.8% recall**, the first time that
   property has had a number instead of an argument. Now a per-commit CI gate
   (`--max-lost 0`); it is zero-cost, needs no API key and no network.
 - **`distil retention --dataset {hotpotqa,squad}` — public ground truth.** Graded
@@ -50,7 +50,7 @@ the question users actually ask, which is not "did the next action survive?" but
   | page | before | after | saved | facts lost |
   |---|---|---|---|---|
   | Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
-  | Python docs page | 27,136 tok | 3,751 tok | **86.2%** | 0 |
+  | Python docs page | 32,322 tok | 4,229 tok | **86.9%** | 0 |
 
   Deliberately **recall-biased**: only tags that cannot hold article content are
   dropped, plus four unambiguous chrome landmarks (`nav`/`footer`/`aside`/`form`).
@@ -64,6 +64,32 @@ the question users actually ask, which is not "did the next action survive?" but
   Documented tradeoff: on raw HTML most probe-able "artifacts" are `href` URLs, which
   extraction drops as navigation. They stay recoverable, but visible recall for that
   dimension is low by design — now a measured number instead of an unknown.
+### Fixed after cross-audit
+
+All three findings from the PR's independent audit reproduced, so all three are fixed:
+
+- **Unclosed chrome tags swallowed the article.** Chrome skipping keyed off a matching
+  close tag and real HTML often never sends one, so content *before* an unclosed
+  `<aside>` was emitted while the article after it was dropped. An `<article>`/`<main>`
+  landmark now ends any active skip, plus a skipped-data budget as a backstop for
+  `<div>`-built chrome. `script`/`style` stay exempt — their payload is legitimately huge.
+- **Synchronous disk I/O in the request path.** `RestoreStore.expand()` falls back to a
+  disk read for unknown handles, and the meter called it for every `handle=` match — so
+  tool output merely *containing* that string could turn one sampled request into a
+  series of file reads. Matched handles are now intersected with the store's in-memory
+  set.
+- **Short answers false-matched in recovered bytes.** `"12"` matched inside
+  `file-12.csv`. Recoverability now requires token boundaries, and values under four
+  characters require whitespace boundaries.
+
+That last fix then failed the corpus gate, which is how it proved its worth: it exposed
+that `_NUMERIC_RE` had been extracting values ending **mid-token** — `invoices=88` clipped
+from `invoices=88ms`, junk like `T09:14` from inside a timestamp. Extraction now takes the
+whole token including its unit. The probe set is smaller and cleaner (417 facts, not 503),
+which moves the corpus figures to **90.2% visible / 100% true / 0 lost** and the measured
+value of reversibility from 12.3% to **9.8%**. The earlier number was inflated by junk
+probes; this one is honest.
+
 - [ADR 0005](docs/adr/0005-external-validity-and-fact-level-recall.md) and a new
   §5 in [docs/EVALUATION.md](docs/EVALUATION.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,90 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [Unreleased] — recall, and a number a stranger can check
+
+Every quality gate distil shipped until now was graded on **our** corpus against
+**our** oracle. The statistics were rigorous; the external validity was zero — a
+reader had nothing they already trusted to check us against. And none of it answered
+the question users actually ask, which is not "did the next action survive?" but
+"is the number I needed still there?"
+
+### Added
+
+- **`distil retention` — fact-level recall.** Keyed numerics, artifacts
+  (paths/URLs/hashes/UUIDs) and error lines are classified `retained` /
+  `recoverable` / `lost`. `recoverable` is **verified, not assumed**: the handle must
+  appear in that block's own compressed text *and* the fact must appear in that
+  handle's restore bytes. On the corpus: **100% true recall, 87.7% visible, 0 lost** —
+  so being reversible rather than lossy is worth **12.3% recall**, the first time that
+  property has had a number instead of an argument. Now a per-commit CI gate
+  (`--max-lost 0`); it is zero-cost, needs no API key and no network.
+- **`distil retention --dataset {hotpotqa,squad}` — public ground truth.** Graded
+  against answer keys written by someone else, next to a truncation baseline tuned to
+  reproduce distil's own token savings on the same case. HotpotQA (n=100, 14.3%
+  savings): **100% answer recall and 100% gold-sentence recall, vs 91.6% / 82.7% for
+  truncation at 14.1% savings.** Rows load from the HuggingFace datasets-server REST
+  API as plain JSON, so the core stays **stdlib-only** (`dependencies = []` holds) and
+  cache under `$DISTIL_HOME/datasets` for offline reproduction. Runs nightly, not
+  per-commit: a required check gated on a third-party host would make main's health
+  hostage to their uptime.
+- **`distil retention --live` — recall on your own traffic, content-free.** A sampled
+  meter (`--retention RATE`; 0.05 by default under `wrap`, 0 under a bare `proxy`)
+  scores retention **in-process** and persists **counts only** — three integers per
+  dimension, with deliberately no field that could carry content. There is no
+  plaintext session recorder to secure, which is the whole point. Bounded to 64 KiB
+  per request, fail-open, and unlike `--shadow` it costs **no extra tokens** because
+  there is no second upstream call.
+- **Reversible HTML extraction — the web-fetch blind spot.** Building the retention
+  harness exposed a capability gap it could then measure: distil compressed **0.0%** of
+  an HTML tool result. The cause was structural, not a missing heuristic — minified
+  markup arrives as one enormous line, so Tier-1's line-folding had nothing to fold and
+  the JSON/record folds do not recognise markup. Any agent with a fetch or browser tool
+  was paying full price for `<script>`, `<style>`, nav and footer chrome.
+
+  `distil/compress/htmlx.py` extracts the content with stdlib `html.parser` and keeps
+  the exact original behind an expand handle. Measured on real pages:
+
+  | page | before | after | saved | facts lost |
+  |---|---|---|---|---|
+  | Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
+  | Python docs page | 27,136 tok | 3,751 tok | **86.2%** | 0 |
+
+  Deliberately **recall-biased**: only tags that cannot hold article content are
+  dropped, plus four unambiguous chrome landmarks (`nav`/`footer`/`aside`/`form`).
+  `<header>` is kept because it usually wraps the `<h1>`, and `img` alt text is kept
+  because it is often a figure's only description. Unlike a lossy extractor the
+  heuristic is **recoverable** — `distil retention` measures 100% true recall with 0
+  lost on the pages above, so a bad call costs one `distil_expand`, not the content.
+  Skipped in `verbatim` mode (no expand tool to recover with) and on recency-exempt
+  blocks (the agent's latest output stays byte-exact).
+
+  Documented tradeoff: on raw HTML most probe-able "artifacts" are `href` URLs, which
+  extraction drops as navigation. They stay recoverable, but visible recall for that
+  dimension is low by design — now a measured number instead of an unknown.
+- [ADR 0005](docs/adr/0005-external-validity-and-fact-level-recall.md) and a new
+  §5 in [docs/EVALUATION.md](docs/EVALUATION.md).
+
+### Honesty notes
+
+Three defects found while building this, each of which had been reporting numbers in
+distil's favour:
+
+- HotpotQA's comparison questions answer "yes"/"no", which is never a span in the
+  passage. Grading them reported the dataset's answer *format* as 10% compression
+  loss. Answers are now graded **only when present in the uncompressed context**.
+- SQuAD v2's unanswerable questions (55% of the split) were being scored as retained —
+  a free win on a majority of cases. They are excluded and counted separately.
+- A recall number from compression that barely engaged is arithmetic, not evidence, so
+  `--min-recall` now **fails** below 1% savings. This is not hypothetical: distil's
+  compressors correctly decline to touch short prose, so `--shape prose` yields 0%
+  savings and a vacuous 100% recall. The default `--shape json` reflects how a
+  retrieval tool actually returns documents.
+
+Worth knowing: on SQuAD at 84.8% savings, true recall is 100% but **visible recall is
+0%** — every gold answer sits behind a handle. Lossless, but one round trip per
+answer. The report says so instead of printing only the reassuring number.
+
 ## [1.37.0] — you will be asked, once, at the moment it makes sense
 
 **The census undercounted because nobody was asked.** `distil onboard` was the

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test gate bench verify holdout build pyz docker clean lint
+.PHONY: help test gate bench verify retention holdout build pyz docker clean lint
 
 help:  ## Show this help
 	@grep -E '^[a-z]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -6,13 +6,16 @@ help:  ## Show this help
 test:  ## Run the full test suite
 	uv run --with pytest python -m pytest -q
 
-gate: bench verify  ## Run the full CI gate (corpus non-inferiority + byte-fidelity)
+gate: bench verify retention  ## Run the full CI gate (non-inferiority + byte-fidelity + recall)
 
 bench:  ## Corpus-wide non-inferiority gate
 	uv run distil bench
 
 verify:  ## Byte-fidelity gate (reversibility + append-only)
 	uv run distil verify
+
+retention:  ## Fact-level recall gate (zero cost: no LLM, no API key)
+	uv run distil retention --max-lost 0
 
 holdout:  ## Holdout A/B savings with bootstrap CI
 	uv run distil holdout

--- a/README.md
+++ b/README.md
@@ -161,9 +161,29 @@ Don't take the table above on faith. `distil bench` re-certifies savings *and* d
 uvx --from distil-llm distil bench      # certify savings + quality across 7 domains, in seconds
 distil verify                           # byte-fidelity: every compression is exactly reversible
 distil validate                         # adversarial real-path gate: invariants on hostile inputs
+distil retention                        # fact recall: what stays visible vs expand-recoverable
+distil retention --dataset hotpotqa     # graded against a PUBLIC benchmark's ground truth
 ```
 
-Three gates, all in CI: **`bench`** (non-inferiority on the corpus), **`verify`** (byte-fidelity), and **`validate`** — which drives the compressor against *adversarial* inputs (huge/unicode/nested/malformed/marker-injection/secret-looking) and asserts reversibility, reject-if-bigger, recency-exactness, fail-open, and content-free telemetry hold on every one. That last gate exists because a green unit suite kept coexisting with real-traffic bugs; `validate` is the adversarial layer that catches them.
+Four gates, all in CI: **`bench`** (non-inferiority on the corpus), **`verify`** (byte-fidelity), **`retention`** (fact-level recall), and **`validate`** — which drives the compressor against *adversarial* inputs (huge/unicode/nested/malformed/marker-injection/secret-looking) and asserts reversibility, reject-if-bigger, recency-exactness, fail-open, and content-free telemetry hold on every one. That last gate exists because a green unit suite kept coexisting with real-traffic bugs; `validate` is the adversarial layer that catches them.
+
+**Recall, and a number you can check yourself.** The three gates above are graded on *our* corpus against *our* oracle — rigorous, but not checkable by you. `distil retention --dataset hotpotqa` grades against ground truth written by someone else (HotpotQA's gold supporting sentences, amid 8 distractor paragraphs), next to a truncation baseline tuned to distil's own savings on the same case:
+
+| HotpotQA, n=100 | savings | answer recall | gold-sentence recall |
+|---|---|---|---|
+| **distil** (reversible) | 14.3% | **100.0%** | **100.0%** |
+| truncation @ matched savings | 14.1% | 91.6% | 82.7% |
+
+`distil retention` also splits recall into **visible** (in front of the model) and **recoverable** (one `distil_expand` away, verified against the handle's restore bytes). On the corpus that's 87.7% visible → 100% true, so being reversible instead of lossy is worth **12.3% recall** — the moat, as a measurement rather than an argument. `distil retention --live` reports the same on your own traffic; the meter stores counts only, never content.
+
+**And it found a real hole.** The first thing the recall harness caught was not a regression but a missing capability: distil was compressing **0.0%** of HTML tool results — minified markup is one long line, so line-folding had nothing to fold. Agents with a fetch or browser tool were paying full price for `<script>`, `<style>`, and nav chrome. Now:
+
+| real page | before | after | saved | facts lost |
+|---|---|---|---|---|
+| Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
+| Python docs page | 27,136 tok | 3,751 tok | **86.2%** | **0** |
+
+Reversible, which is the part a lossy extractor can't offer: the exact original stays behind the handle, so a bad heuristic call costs one `distil_expand` instead of the content.
 
 To be precise about what each layer proves: the **per-commit** gates grade decision-equivalence with an offline deterministic oracle over the committed corpus (fast, free, runs on every push — but synthetic). A **nightly** [`live-cert`](.github/workflows/live-cert.yml) job re-certifies the same trajectories against a *real* model (`distil certify --runner anthropic`), budget-capped with a hard `--max-live-calls` ceiling so an unattended run can never spend silently. The empirical results above (SWE-bench n=500, live head-to-head n=200) were graded by real models; the per-commit badge alone doesn't claim that.
 

--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ Four gates, all in CI: **`bench`** (non-inferiority on the corpus), **`verify`**
 | **distil** (reversible) | 14.3% | **100.0%** | **100.0%** |
 | truncation @ matched savings | 14.1% | 91.6% | 82.7% |
 
-`distil retention` also splits recall into **visible** (in front of the model) and **recoverable** (one `distil_expand` away, verified against the handle's restore bytes). On the corpus that's 87.7% visible → 100% true, so being reversible instead of lossy is worth **12.3% recall** — the moat, as a measurement rather than an argument. `distil retention --live` reports the same on your own traffic; the meter stores counts only, never content.
+`distil retention` also splits recall into **visible** (in front of the model) and **recoverable** (one `distil_expand` away, verified against the handle's restore bytes). On the corpus that's 90.2% visible → 100% true, so being reversible instead of lossy is worth **9.8% recall** — the moat, as a measurement rather than an argument. `distil retention --live` reports the same on your own traffic; the meter stores counts only, never content.
 
 **And it found a real hole.** The first thing the recall harness caught was not a regression but a missing capability: distil was compressing **0.0%** of HTML tool results — minified markup is one long line, so line-folding had nothing to fold. Agents with a fetch or browser tool were paying full price for `<script>`, `<style>`, and nav chrome. Now:
 
 | real page | before | after | saved | facts lost |
 |---|---|---|---|---|
 | Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
-| Python docs page | 27,136 tok | 3,751 tok | **86.2%** | **0** |
+| Python docs page | 32,322 tok | 4,229 tok | **86.9%** | **0** |
 
 Reversible, which is the part a lossy extractor can't offer: the exact original stays behind the handle, so a bad heuristic call costs one `distil_expand` instead of the content.
 

--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -219,6 +219,25 @@ def _compress_tool_result_text(
     must see its most recent output byte-exact to choose its next action, so those
     stay verbatim with NO fold — even a lossless columnar fold changes the bytes.
     """
+    # Learned policy: if your agents keep expanding this kind of content, keep it
+    # byte-exact (strictly safer — only ever reduces savings, never equivalence).
+    # Hoisted above the HTML step so both digest paths honour it, and evaluated once.
+    keep_byte_exact = _active_keep(text)
+
+    # HTML from a fetch/browser tool. Handled BEFORE the _MIN_LINES gate because
+    # minified markup is a single enormous line, so that gate would fall through to
+    # Tier-0-only and save nothing (measured: 0.0% on a realistic 8.3k-token page).
+    # Requires a handle to stay recoverable, so it is skipped when verbatim (no expand
+    # tool available) and when recent (must stay byte-exact for the next decision).
+    if not verbatim and not is_recent and not keep_byte_exact:
+        from ..compress.htmlx import extract as _html_extract
+
+        stripped = _html_extract(text)
+        if stripped is not None:
+            h = _handle(text)
+            if store._record(h, text):
+                return f"{stripped}\n<< html chrome elided, handle={h} >>"
+
     lines = text.splitlines()
     if len(lines) < _MIN_LINES:
         # Too short to digest — lossless Tier-0 transforms only.
@@ -233,9 +252,7 @@ def _compress_tool_result_text(
         folded = None if is_recent else _lossless_fold(text)
         return folded or _apply_tier0(text)
 
-    # Learned policy: if your agents keep expanding this kind of content, keep it
-    # byte-exact (strictly safer — only ever reduces savings, never equivalence).
-    if _active_keep(text):
+    if keep_byte_exact:
         return _apply_tier0(text)
 
     digested, changed = _tier1_digest(text, intent=_active_intent())

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -814,6 +814,7 @@ def cmd_proxy(args: argparse.Namespace) -> int:
             pricing_model=args.pricing,
             expand=args.expand,
             shadow_rate=args.shadow,
+            retention_rate=getattr(args, "retention", 0.0),
             session_delta=args.session_delta,
         )
     return 0
@@ -1979,6 +1980,7 @@ def cmd_wrap(args: argparse.Namespace) -> int:
         expand=args.expand,
         session_delta=args.session_delta,
         shadow_rate=args.shadow,
+        retention_rate=getattr(args, "retention", 0.0),
     )
     # Upstream-contract tripwire: distil's interception of a known agent rests on
     # that agent honoring `env_var` (undocumented upstream — an agent update can
@@ -2484,6 +2486,73 @@ def cmd_eval(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_retention(args: argparse.Namespace) -> int:
+    """Fact-level recall: which facts stay visible, which are expand-recoverable."""
+
+    from .retention import format_report, run
+
+    if args.live:
+        from .retention import format_live, load_live
+
+        dims, requests = load_live()
+        print(format_live(dims, requests))
+        return 0
+
+    if args.dataset:
+        return _retention_dataset(args)
+
+    entries = load_corpus(args.corpus) if args.corpus else load_corpus()
+    rep = run(entries)
+    if args.json:
+        print(json.dumps(rep.to_dict(), indent=2))
+    else:
+        print(format_report(rep))
+    # A lost fact has no recovery path — the only bucket that can make an agent
+    # answer wrong, so it is what gates.
+    if args.max_lost is not None and rep.lost_facts > args.max_lost:
+        print(f"\nFAIL: {rep.lost_facts} lost facts > --max-lost {args.max_lost}")
+        return 1
+    return 0
+
+
+def _retention_dataset(args: argparse.Namespace) -> int:
+    """Grade against a public benchmark's third-party answer key."""
+
+    from .datasets import DatasetUnavailable, available, load
+    from .retention import DatasetReport, format_dataset_report, score_dataset
+
+    if args.dataset == "list":
+        print("public benchmarks (ground truth written by someone else):\n")
+        for name, description in available():
+            print(f"  {name:<12} {description}")
+        return 0
+
+    try:
+        cases = load(args.dataset, args.n, offline=args.offline)
+    except DatasetUnavailable as exc:
+        # Loud, never a silent pass: a gate that measures nothing must not go green.
+        print(f"FAIL: {exc}")
+        return 1
+
+    rep = score_dataset(cases, args.dataset, shape=args.shape)
+    if args.json:
+        print(json.dumps(rep.to_dict(), indent=2))
+    else:
+        print(format_dataset_report(rep))
+
+    if args.min_recall is not None:
+        # A near-identity transform trivially retains everything. Passing a recall gate
+        # on it would certify nothing, so an unengaged run fails the gate.
+        if not rep.engaged:
+            print(f"\nFAIL: compression did not engage ({rep.savings:.1%}) — recall proves nothing")
+            return 1
+        answer, _ = DatasetReport._answer_recall(rep.scores, with_recovery=True)
+        if answer < args.min_recall:
+            print(f"\nFAIL: answer recall {answer:.1%} < --min-recall {args.min_recall:.1%}")
+            return 1
+    return 0
+
+
 def cmd_online(args: argparse.Namespace) -> int:
     """One self-distilling round: causal labels → retrain → certify → promote."""
     from .online import online_round
@@ -2760,6 +2829,40 @@ def build_parser() -> argparse.ArgumentParser:
     ev.add_argument("--out", help="write the raw curve JSONL to this dir")
     ev.set_defaults(func=cmd_eval)
 
+    rt = sub.add_parser(
+        "retention",
+        help="fact-level recall: retained / expand-recoverable / lost (zero cost, offline)",
+    )
+    rt.add_argument("--corpus", help="custom corpus dir (e.g. ingested benchmark traces)")
+    rt.add_argument("--json", action="store_true", help="machine-readable report")
+    rt.add_argument(
+        "--max-lost", type=int, help="exit 1 if more than this many facts are unrecoverable"
+    )
+    rt.add_argument(
+        "--dataset",
+        help="grade against a public benchmark's ground truth instead of the corpus "
+        "('list' to see them)",
+    )
+    rt.add_argument("-n", type=int, help="number of benchmark cases (default: the dataset's own)")
+    rt.add_argument(
+        "--live",
+        action="store_true",
+        help="fact recall measured on YOUR traffic by the sampled meter (content-free)",
+    )
+    rt.add_argument(
+        "--offline", action="store_true", help="use only cached benchmark rows (no network)"
+    )
+    rt.add_argument(
+        "--min-recall", type=float, help="exit 1 if answer recall falls below this (0-1)"
+    )
+    rt.add_argument(
+        "--shape",
+        default="json",
+        choices=("json", "prose"),
+        help="how retrieved docs reach the agent: json tool result (production) or bare prose",
+    )
+    rt.set_defaults(func=cmd_retention)
+
     bn = sub.add_parser(
         "benchmark",
         help="head-to-head vs competing techniques on the same gate + cost model",
@@ -2914,6 +3017,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="shadow-mode live decision-equivalence: sample this fraction of requests "
         "(e.g. 0.05) and run them uncompressed too, in the background, to measure the "
         "live decision-change rate on real traffic (`distil shadow-stats`). Adds ~RATE cost.",
+    )
+    px.add_argument(
+        "--retention",
+        type=float,
+        default=0.0,
+        metavar="RATE",
+        help="live fact-retention meter: sample this fraction of requests and score how "
+        "many numbers/paths/errors stayed visible vs went behind an expand handle "
+        "(`distil retention --live`). Content-free (counts only) and costs no tokens.",
     )
     px.add_argument(
         "--session-delta",
@@ -3128,6 +3240,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="cache-delta coding: cross-turn dedup + cross-version delta (re-reads after "
         "edits sent as a diff), cache-monotonic and reversible",
+    )
+    wr.add_argument(
+        "--retention",
+        type=float,
+        default=0.05,
+        metavar="RATE",
+        help="live fact-retention meter: sample this fraction of requests and score fact "
+        "recall on your own traffic (`distil retention --live`). On by default at 0.05 — "
+        "unlike --shadow it costs NO extra tokens (in-process scan) and stores only "
+        "counts, never content; --retention 0 disables",
     )
     wr.add_argument(
         "--shadow",

--- a/distil/compress/htmlx.py
+++ b/distil/compress/htmlx.py
@@ -1,0 +1,217 @@
+"""Reversible HTML content extraction — the web-fetch blind spot.
+
+An agent with a fetch or browser tool receives raw HTML, and distil compressed **none
+of it**: measured on a realistic 8.3k-token page, savings were 0.0%. The reason is
+structural rather than a missing heuristic — minified HTML arrives as one enormous
+line, so Tier-1's line-folding has nothing to fold and the JSON/record folds do not
+recognise markup. A page is mostly `<script>`, `<style>`, nav, and footer chrome, so
+that 0% was distil paying full price for tokens the model can never use.
+
+This extracts the content and keeps the original behind an expand handle. Two
+consequences worth stating plainly:
+
+* **Recall-biased on purpose.** Only tags that cannot carry article content are
+  dropped outright (`script`, `style`, `svg`, …) plus four unambiguous chrome
+  landmarks (`nav`, `footer`, `aside`, `form`). `<header>` is deliberately KEPT —
+  it usually holds the `<h1>` — because for a compressor a dropped fact is a wrong
+  answer while a kept-but-unneeded one is merely fewer tokens saved.
+* **Reversible, which lossy extractors are not.** The exact original bytes go into
+  the restore table under the marker's handle, so anything this heuristic gets wrong
+  is one ``distil_expand`` call away rather than gone. That is what lets the
+  extraction be aggressive without being risky, and `distil retention` measures the
+  difference (visible vs recoverable) instead of asserting it.
+
+Output is line-oriented (block-level tags become newlines), which also re-arms the
+downstream line-based machinery — keep-policy error pinning and the retention
+probe's per-line error extraction — on content that previously had no lines at all.
+
+Stdlib only: ``html.parser``. No lxml, no bs4, no readability port.
+"""
+
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+
+# Tags whose contents are never article text. Dropped with their subtree.
+_DROP_SUBTREE = frozenset(
+    {
+        "script",
+        "style",
+        "noscript",
+        "svg",
+        "canvas",
+        "iframe",
+        "object",
+        "embed",
+        "template",
+        "map",
+        "audio",
+        "video",
+        "select",
+        "option",
+        "datalist",
+    }
+)
+
+# Structural chrome. Only landmarks whose semantic meaning is unambiguous — `header`
+# is NOT here (it commonly wraps the title), and neither is `div`/`section`, whose
+# meaning depends entirely on the site.
+_DROP_CHROME = frozenset({"nav", "footer", "aside", "form"})
+
+# Block-level tags become a newline, so the result has lines for the rest of the
+# pipeline (and for a human) to work with.
+_BLOCK = frozenset(
+    {
+        "p",
+        "div",
+        "section",
+        "article",
+        "main",
+        "header",
+        "br",
+        "hr",
+        "li",
+        "ul",
+        "ol",
+        "dl",
+        "dt",
+        "dd",
+        "tr",
+        "td",
+        "th",
+        "table",
+        "thead",
+        "tbody",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "blockquote",
+        "pre",
+        "figure",
+        "figcaption",
+        "title",
+    }
+)
+
+_VOID = frozenset({"br", "hr", "img", "input", "meta", "link", "source", "col", "area", "base"})
+
+_TAG_RE = re.compile(r"<\s*([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>")
+_CLOSE_RE = re.compile(r"</\s*([a-zA-Z][a-zA-Z0-9]*)\s*>")
+_DOCTYPE_RE = re.compile(r"<!doctype\s+html|<html\b|<body\b|<head\b", re.IGNORECASE)
+_WS_RUN = re.compile(r"[ \t\f\v]+")
+_BLANK_RUN = re.compile(r"\n{2,}")
+
+# Below this, extraction is not worth a marker + a restore entry: a fragment that is
+# already mostly text should pass through untouched rather than churn the cache.
+_MIN_CHARS = 400
+_MIN_TAGS = 8
+_MIN_GAIN = 0.15  # require a real win, not a rounding one
+# Fraction of closeable open tags that must actually be closed for a doctype-less
+# fragment to count as markup. Well below 1.0: real-world HTML omits </li>, </p>, </td>.
+_MIN_CLOSE_RATIO = 0.5
+
+
+def looks_like_html(text: str) -> bool:
+    """True if `text` is plausibly an HTML document or a substantial fragment.
+
+    Deliberately conservative: a stray ``<div>`` in a log line or a code sample that
+    mentions markup must not be routed through an HTML extractor.
+    """
+    if len(text) < _MIN_CHARS:
+        return False
+    if _DOCTYPE_RE.search(text):
+        return True
+    # No document landmarks. Tag density alone is NOT enough: a log line reading
+    # "parse failed near <div>" repeated 40 times clears any density bar. Real markup
+    # closes its elements, so require the open tags to be substantially balanced by
+    # closing tags — which prose mentioning a tag name never is.
+    opens = _TAG_RE.findall(text)
+    if len(opens) < _MIN_TAGS:
+        return False
+    closes = _CLOSE_RE.findall(text)
+    voidish = sum(1 for t in opens if t.lower() in _VOID)
+    closeable = len(opens) - voidish
+    return bool(closes) and closeable > 0 and len(closes) >= closeable * _MIN_CLOSE_RATIO
+
+
+class _Extractor(HTMLParser):
+    """Collects visible text, skipping non-content subtrees."""
+
+    def __init__(self) -> None:
+        # convert_charrefs resolves &amp;/&#39; for us, so facts compare equal to the
+        # decoded form a model would read.
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._skip_depth = 0
+        self._skipping: str | None = None
+        self.dropped_tags = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        self.dropped_tags += 1
+        if self._skipping is not None:
+            if tag == self._skipping and tag not in _VOID:
+                self._skip_depth += 1
+            return
+        if tag in _DROP_SUBTREE or tag in _DROP_CHROME:
+            if tag not in _VOID:
+                self._skipping = tag
+                self._skip_depth = 1
+            return
+        if tag in _BLOCK:
+            self.parts.append("\n")
+        if tag == "img":
+            # Alt text is real content and often the only description of a figure.
+            alt = next((v for k, v in attrs if k.lower() == "alt" and v), None)
+            if alt:
+                self.parts.append(f"[image: {alt}]")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if self._skipping is not None:
+            if tag == self._skipping:
+                self._skip_depth -= 1
+                if self._skip_depth <= 0:
+                    self._skipping = None
+            return
+        if tag in _BLOCK:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skipping is None and data.strip():
+            self.parts.append(data)
+
+    def error(self, message: str) -> None:  # pragma: no cover - py<3.10 ABC shim
+        return None
+
+
+def extract(text: str) -> str | None:
+    """Extract readable content from HTML, or None if that is not worthwhile.
+
+    Returns None when the input is not HTML, when parsing fails, or when the result
+    is not meaningfully smaller — so the caller's reject-if-bigger invariant is never
+    the thing that has to catch it.
+    """
+    if not looks_like_html(text):
+        return None
+    parser = _Extractor()
+    try:
+        parser.feed(text)
+        parser.close()
+    except Exception:  # noqa: BLE001 — malformed markup must never break a request
+        return None
+
+    body = "".join(parser.parts)
+    body = _WS_RUN.sub(" ", body)
+    body = "\n".join(line.strip() for line in body.split("\n"))
+    body = _BLANK_RUN.sub("\n", body).strip()
+
+    if not body:
+        return None
+    if len(body) > len(text) * (1.0 - _MIN_GAIN):
+        return None  # not a real win: leave the block alone
+    return body

--- a/distil/compress/htmlx.py
+++ b/distil/compress/htmlx.py
@@ -99,6 +99,18 @@ _BLOCK = frozenset(
 
 _VOID = frozenset({"br", "hr", "img", "input", "meta", "link", "source", "col", "area", "base"})
 
+# Primary content landmarks. Chrome skipping keys off a matching close tag, and real
+# HTML frequently never sends one — so an unclosed <nav>/<aside> would otherwise skip
+# the entire remainder of the document, including the article. These end any active
+# skip: whatever an unclosed sidebar is, it does not legitimately contain the page's
+# <article>/<main>. (Audit finding: content before an unclosed chrome tag was emitted
+# while everything after it was dropped.)
+_CONTENT_LANDMARK = frozenset({"article", "main"})
+# Backstop for pages with no landmark to recover on (chrome built from <div>s). Real
+# nav/footer text is a few hundred characters; this much skipped data means the close
+# tag is missing, so abandon the skip rather than eat the rest of the page.
+_SKIP_DATA_BUDGET = 8_000
+
 _TAG_RE = re.compile(r"<\s*([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>")
 _CLOSE_RE = re.compile(r"</\s*([a-zA-Z][a-zA-Z0-9]*)\s*>")
 _DOCTYPE_RE = re.compile(r"<!doctype\s+html|<html\b|<body\b|<head\b", re.IGNORECASE)
@@ -148,15 +160,28 @@ class _Extractor(HTMLParser):
         self.parts: list[str] = []
         self._skip_depth = 0
         self._skipping: str | None = None
+        self._skipped_chars = 0
         self.dropped_tags = 0
+
+    def _end_skip(self) -> None:
+        self._skipping = None
+        self._skip_depth = 0
+        self._skipped_chars = 0
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
         self.dropped_tags += 1
         if self._skipping is not None:
-            if tag == self._skipping and tag not in _VOID:
+            # A content landmark cannot be inside the sidebar we think we are in: the
+            # chrome tag was never closed. Resume collecting rather than dropping the
+            # rest of the document.
+            if tag in _CONTENT_LANDMARK and self._skipping not in _DROP_SUBTREE:
+                self._end_skip()
+            elif tag == self._skipping and tag not in _VOID:
                 self._skip_depth += 1
-            return
+                return
+            else:
+                return
         if tag in _DROP_SUBTREE or tag in _DROP_CHROME:
             if tag not in _VOID:
                 self._skipping = tag
@@ -176,13 +201,23 @@ class _Extractor(HTMLParser):
             if tag == self._skipping:
                 self._skip_depth -= 1
                 if self._skip_depth <= 0:
-                    self._skipping = None
+                    self._end_skip()
             return
         if tag in _BLOCK:
             self.parts.append("\n")
 
     def handle_data(self, data: str) -> None:
-        if self._skipping is None and data.strip():
+        if self._skipping is not None:
+            # Budget backstop for chrome with no close tag and no landmark after it
+            # (a <div>-built sidebar): stop skipping instead of eating the article.
+            # Never applies to script/style, whose payload is legitimately huge.
+            if self._skipping in _DROP_SUBTREE:
+                return
+            self._skipped_chars += len(data)
+            if self._skipped_chars > _SKIP_DATA_BUDGET:
+                self._end_skip()
+            return
+        if data.strip():
             self.parts.append(data)
 
     def error(self, message: str) -> None:  # pragma: no cover - py<3.10 ABC shim

--- a/distil/compress/tier1.py
+++ b/distil/compress/tier1.py
@@ -189,6 +189,18 @@ class Tier1Reversible:
         restore: dict[str, str] = {}
         for b in blocks:
             if b.kind in _DIGESTIBLE:
+                # 0) HTML from a fetch/browser tool. Runs FIRST because minified markup
+                #    is one long line, which defeats every fold below it (measured: 0%
+                #    savings on a real 8.3k-token page). Extraction yields lines, so the
+                #    line-oriented machinery downstream works again.
+                from .htmlx import extract as _html_extract
+
+                stripped = _html_extract(b.text)
+                if stripped is not None:
+                    h = _handle(b.text)
+                    restore[h] = b.text  # exact original: the heuristic is recoverable
+                    out.append(b.copy_with(f"{stripped}\n<< html chrome elided, handle={h} >>"))
+                    continue
                 # 1) reversible structured compaction: flat columnar fold, then the
                 #    nested-record fold (tool outputs with nested fields), then template mining
                 compact = fold(b.text) or fold_records(b.text) or template_fold(b.text)

--- a/distil/datasets.py
+++ b/distil/datasets.py
@@ -1,0 +1,308 @@
+"""Public ground-truthed benchmarks — external validity, with no new dependencies.
+
+Every other quality signal distil ships is graded against distil's own corpus and
+distil's own ``DECISION:`` markers. That makes the numbers rigorous but *unfalsifiable
+by a stranger*: you cannot check them against data you already trust. This module
+closes that, by loading real public benchmarks whose ground truth was written by
+someone else:
+
+- ``hotpotqa``  — multi-hop QA, 10 paragraphs per question of which 8 are
+  distractors, and ``supporting_facts`` naming the exact gold sentences. The best
+  compression test in public: real noise to prune, and a third-party answer key for
+  what had to survive.
+- ``squad``     — SQuAD v2 extractive QA: one paragraph, a gold answer span, and
+  deliberately unanswerable questions (which we exclude from answer recall and
+  report separately, rather than scoring them as free wins).
+
+Transport
+---------
+Rows come from the HuggingFace *datasets-server* REST API — plain JSON over HTTPS,
+so the loader is stdlib-only (``urllib.request`` + ``json``) and distil's
+``dependencies = []`` promise holds. Installing the ``datasets`` package, Arrow, and
+a model stack merely to read 100 rows would cost more than the whole core.
+
+Rows are cached under ``$DISTIL_HOME/datasets`` as JSONL, so a cited number is
+reproducible offline and a re-run costs no network. Sampling is deterministic given
+``(name, n)``: no seed drift between the run you publish and the run someone checks.
+
+Failure is always loud. A fetch problem raises :class:`DatasetUnavailable` with the
+cause — it never degrades to fewer cases, an empty list, or a silent pass, because a
+quality gate that quietly measures nothing is worse than no gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+_ROWS_API = "https://datasets-server.huggingface.co/rows"
+_MAX_LENGTH = 100  # hard server-side cap on rows per request
+_TIMEOUT = 30.0
+_ATTEMPTS = 3
+_BACKOFF = 1.0
+_RETRY_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+_UA = "distil-llm (+https://github.com/dshakes/distil)"
+
+
+class DatasetUnavailable(RuntimeError):
+    """Raised when a benchmark cannot be loaded. Never swallowed into a pass."""
+
+
+@dataclass
+class GroundTruthCase:
+    """One benchmark question with a third-party answer key.
+
+    `docs` are the retrieved paragraphs exactly as an agent would receive them —
+    one per tool result — so compressing them is the real production operation,
+    not a synthetic proxy.
+    """
+
+    id: str
+    question: str
+    docs: list[tuple[str, str]]  # (title, text), in dataset order
+    answer: str
+    support: list[str] = field(default_factory=list)  # gold sentences that must survive
+    answerable: bool = True
+    dataset: str = ""
+
+
+# ---------------------------------------------------------------------------
+# transport
+# ---------------------------------------------------------------------------
+
+
+def _home() -> Path:
+    return Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil")))
+
+
+def _cache_path(name: str) -> Path:
+    return _home() / "datasets" / f"{name}.jsonl"
+
+
+def _read_cache(name: str) -> list[dict[str, Any]]:
+    path = _cache_path(name)
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                # A truncated final line (interrupted write) is recoverable: keep the
+                # prefix and refetch the remainder rather than discarding the cache.
+                break
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def _write_cache(name: str, rows: list[dict[str, Any]]) -> None:
+    path = _cache_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".jsonl.tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    tmp.replace(path)  # atomic: a crash mid-write never leaves a half cache in place
+
+
+def _get(url: str) -> dict[str, Any]:
+    """One GET with retry/backoff on transient failures. Raises on permanent ones."""
+    last: Exception | None = None
+    for attempt in range(_ATTEMPTS):
+        request = urllib.request.Request(url, headers={"User-Agent": _UA})
+        try:
+            with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:  # noqa: S310
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict):
+                raise DatasetUnavailable(f"unexpected payload type {type(payload).__name__}")
+            return payload
+        except urllib.error.HTTPError as exc:
+            last = exc
+            if exc.code not in _RETRY_STATUS:
+                raise DatasetUnavailable(f"HTTP {exc.code} from datasets-server: {exc.reason}")
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+            last = exc
+        if attempt < _ATTEMPTS - 1:
+            time.sleep(_BACKOFF * (2**attempt))
+    raise DatasetUnavailable(f"datasets-server unreachable after {_ATTEMPTS} attempts: {last}")
+
+
+def _fetch_rows(spec: _Spec, want: int) -> list[dict[str, Any]]:
+    """Fetch `want` rows, paging the 100-row cap, warm-starting from the cache."""
+    rows = _read_cache(spec.name)
+    if len(rows) >= want:
+        return rows[:want]
+
+    while len(rows) < want:
+        length = min(_MAX_LENGTH, want - len(rows))
+        query = urllib.parse.urlencode(
+            {
+                "dataset": spec.hf_dataset,
+                "config": spec.config,
+                "split": spec.split,
+                "offset": len(rows),
+                "length": length,
+            }
+        )
+        payload = _get(f"{_ROWS_API}?{query}")
+        batch = payload.get("rows")
+        if not isinstance(batch, list) or not batch:
+            break  # split exhausted
+        for item in batch:
+            row = item.get("row") if isinstance(item, dict) else None
+            if isinstance(row, dict):
+                rows.append(row)
+        if len(batch) < length:
+            break  # server returned a short page: end of split
+
+    if not rows:
+        raise DatasetUnavailable(f"{spec.name}: datasets-server returned no rows")
+    _write_cache(spec.name, rows)
+    return rows[:want]
+
+
+# ---------------------------------------------------------------------------
+# per-dataset adapters (row -> GroundTruthCase)
+# ---------------------------------------------------------------------------
+
+
+def _hotpotqa(row: dict[str, Any]) -> GroundTruthCase | None:
+    context = row.get("context") or {}
+    titles = context.get("title") or []
+    sentences = context.get("sentences") or []
+    if not titles or len(titles) != len(sentences):
+        return None
+
+    docs = [(str(t), "".join(str(s) for s in sents)) for t, sents in zip(titles, sentences)]
+
+    # supporting_facts names (title, sentence index) — resolve to the gold sentences
+    # themselves so retention is checked against text, not an index we could misread.
+    facts = row.get("supporting_facts") or {}
+    by_title = {str(t): sents for t, sents in zip(titles, sentences)}
+    support: list[str] = []
+    for title, sent_id in zip(facts.get("title") or [], facts.get("sent_id") or []):
+        sents = by_title.get(str(title))
+        if sents is None:
+            continue
+        try:
+            sentence = str(sents[int(sent_id)]).strip()
+        except (IndexError, ValueError, TypeError):
+            continue
+        if sentence:
+            support.append(sentence)
+
+    answer = str(row.get("answer") or "").strip()
+    if not answer or not docs:
+        return None
+    return GroundTruthCase(
+        id=str(row.get("id") or ""),
+        question=str(row.get("question") or ""),
+        docs=docs,
+        answer=answer,
+        support=support,
+        answerable=True,
+        dataset="hotpotqa",
+    )
+
+
+def _squad(row: dict[str, Any]) -> GroundTruthCase | None:
+    context = str(row.get("context") or "").strip()
+    if not context:
+        return None
+    answers = row.get("answers") or {}
+    texts = [str(t).strip() for t in (answers.get("text") or []) if str(t).strip()]
+    # SQuAD v2 ships unanswerable questions on purpose. They cannot measure answer
+    # retention (there is no answer to retain), so they are carried with
+    # answerable=False and reported separately instead of counted as passes.
+    return GroundTruthCase(
+        id=str(row.get("id") or ""),
+        question=str(row.get("question") or ""),
+        docs=[(str(row.get("title") or "context"), context)],
+        answer=texts[0] if texts else "",
+        support=[],
+        answerable=bool(texts),
+        dataset="squad",
+    )
+
+
+@dataclass(frozen=True)
+class _Spec:
+    name: str
+    hf_dataset: str
+    config: str
+    split: str
+    adapt: Callable[[dict[str, Any]], "GroundTruthCase | None"]
+    description: str
+    default_n: int
+
+
+SPECS: dict[str, _Spec] = {
+    "hotpotqa": _Spec(
+        name="hotpotqa",
+        hf_dataset="hotpotqa/hotpot_qa",
+        config="distractor",
+        split="validation",
+        adapt=_hotpotqa,
+        description="multi-hop QA, 10 paragraphs (8 distractors) + gold supporting sentences",
+        default_n=100,
+    ),
+    "squad": _Spec(
+        name="squad",
+        hf_dataset="rajpurkar/squad_v2",
+        config="squad_v2",
+        split="validation",
+        adapt=_squad,
+        description="SQuAD v2 extractive QA: gold answer spans + unanswerable questions",
+        default_n=100,
+    ),
+}
+
+
+def available() -> list[tuple[str, str]]:
+    return [(spec.name, spec.description) for spec in SPECS.values()]
+
+
+def load(name: str, n: int | None = None, *, offline: bool = False) -> list[GroundTruthCase]:
+    """Load `n` cases of a public benchmark.
+
+    Deterministic: the first `n` rows of the split, in dataset order. No shuffling,
+    so the number you publish is the number a reader reproduces.
+
+    Raises DatasetUnavailable on an unknown name, a fetch failure, or — under
+    `offline` — an insufficient cache. Never returns a short list silently.
+    """
+    spec = SPECS.get(name)
+    if spec is None:
+        raise DatasetUnavailable(f"unknown dataset {name!r} (have: {', '.join(sorted(SPECS))})")
+    want = spec.default_n if n is None else n
+    if want <= 0:
+        raise DatasetUnavailable(f"n must be positive, got {want}")
+
+    if offline:
+        rows = _read_cache(spec.name)[:want]
+        if len(rows) < want:
+            raise DatasetUnavailable(
+                f"{spec.name}: offline mode has {len(rows)} cached rows, need {want} "
+                f"(run once without --offline to populate {_cache_path(spec.name)})"
+            )
+    else:
+        rows = _fetch_rows(spec, want)
+
+    cases = [case for case in (spec.adapt(row) for row in rows) if case is not None]
+    if not cases:
+        raise DatasetUnavailable(
+            f"{spec.name}: no rows survived adaptation (upstream shape change?)"
+        )
+    return cases

--- a/distil/hotswap.py
+++ b/distil/hotswap.py
@@ -55,7 +55,7 @@ import subprocess
 import sys
 import threading
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from typing import Any
 
 from ._log import log
@@ -97,13 +97,19 @@ class WorkerConfig:
     expand: bool = False
     session_delta: bool = False
     shadow_rate: float = 0.0
+    retention_rate: float = 0.0
 
     def to_env(self) -> str:
         return json.dumps(asdict(self), separators=(",", ":"))
 
     @classmethod
     def from_env(cls) -> WorkerConfig:
-        return cls(**json.loads(os.environ[_CONFIG_ENV]))
+        # Tolerate unknown keys: a supervisor from a NEWER build may spawn a worker
+        # from an older one mid-upgrade (that is the whole point of hot-swap), and an
+        # unrecognised config field must not take the session down.
+        raw = json.loads(os.environ[_CONFIG_ENV])
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in raw.items() if k in known})
 
 
 def memory_evidence() -> str:
@@ -194,6 +200,7 @@ def worker_main() -> int:  # pragma: no cover — subprocess entry point: exerci
         expand=cfg.expand,
         session_delta=cfg.session_delta,
         shadow_rate=cfg.shadow_rate,
+        retention_rate=cfg.retention_rate,
     )
 
     class _WorkerServer(QuietHTTPServer):

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -312,6 +312,7 @@ def build_handler(
     flush_every: int = 10,
     expand: bool = False,
     shadow_rate: float = 0.0,
+    retention_rate: float = 0.0,
     session_delta: bool = False,
 ) -> type[BaseHTTPRequestHandler]:
     """Return a ``BaseHTTPRequestHandler`` subclass configured for *upstream*.
@@ -432,6 +433,15 @@ def build_handler(
         _shadow_sampler = ShadowSampler(shadow_rate)
         _shadow_ledger = ShadowLedger()
         _shadow_counters = ShadowCounters()
+
+    # Live fact-retention meter: same posture as shadow (sampled, off by default), but
+    # cheaper — it needs no second upstream call, only an in-process scan, and it
+    # persists counts alone.
+    _retention_meter = None
+    if retention_rate and retention_rate > 0:
+        from .retention import LiveMeter
+
+        _retention_meter = LiveMeter(retention_rate)
 
     # First-POST latch for the session traffic marker: only the 0→1 transition
     # matters, so after one write the check is a single list lookup.
@@ -725,6 +735,9 @@ def build_handler(
                             _learn_stats.record_digest(signature(store.expand(h)))
                         except Exception:  # noqa: BLE001 — learning never breaks a request
                             log.debug("learning tally failed", exc_info=True)
+                # Live retention meter: sampled, content-free (counts only), fail-open.
+                if _retention_meter is not None and _retention_meter.enabled:
+                    _retention_meter.observe(original, compressed, store)
                 before_tok = _count_messages(original)
                 after_tok = _count_messages(compressed)
                 saved = max(0, before_tok - after_tok)
@@ -1438,6 +1451,7 @@ def serve(
     pricing_model: str = "claude-opus-4-8",
     expand: bool = False,
     shadow_rate: float = 0.0,
+    retention_rate: float = 0.0,
     session_delta: bool = False,
 ) -> None:
     """Run a blocking :class:`ThreadingHTTPServer` proxy.
@@ -1476,6 +1490,7 @@ def serve(
         savings=savings,
         expand=expand,
         shadow_rate=shadow_rate,
+        retention_rate=retention_rate,
         session_delta=session_delta,
     )
     server = QuietHTTPServer((host, port), handler)
@@ -1485,6 +1500,11 @@ def serve(
         print(
             f"  → shadow-mode live decision-equivalence: sampling {shadow_rate * 100:.0f}% "
             "(distil shadow-stats)"
+        )
+    if retention_rate and retention_rate > 0:
+        print(
+            f"  → live fact-retention meter: sampling {retention_rate * 100:.0f}% "
+            "(content-free; distil retention --live)"
         )
     if expand:
         print(
@@ -1534,6 +1554,7 @@ def wrap_run(
     expand: bool = False,
     session_delta: bool = False,
     shadow_rate: float = 0.0,
+    retention_rate: float = 0.0,
 ) -> int:
     """Run *command* with its API base URL transparently pointed at a Distil proxy.
 
@@ -1609,6 +1630,7 @@ def wrap_run(
                     "expand": expand,
                     "session_delta": session_delta,
                     "shadow_rate": shadow_rate,
+                    "retention_rate": retention_rate,
                 },
             }
         )
@@ -1636,6 +1658,7 @@ def wrap_run(
                     expand=expand,
                     session_delta=session_delta,
                     shadow_rate=shadow_rate,
+                    retention_rate=retention_rate,
                 ),
                 host=host,
             )
@@ -1663,6 +1686,7 @@ def wrap_run(
             expand=expand,
             session_delta=session_delta,
             shadow_rate=shadow_rate,
+            retention_rate=retention_rate,
         )
         server = QuietHTTPServer((host, 0), handler)  # port 0 → OS picks a free port
         base = f"http://{host}:{server.server_address[1]}"

--- a/distil/retention.py
+++ b/distil/retention.py
@@ -1,0 +1,781 @@
+"""Fact-level retention — recall, and the value of being reversible.
+
+Every other gate distil ships answers a *block* question: `verify` proves the bytes
+round-trip, `certify`/`shadow` prove the next action is unchanged. None answers the
+question a user actually asks about a compressor: **of the load-bearing facts in my
+tool output — the numbers, the paths, the error lines — how many are still in front
+of the model?**
+
+This module answers it, offline and at zero cost, with a tri-state per fact:
+
+- ``retained``    — present in the compressed text, verbatim or after a legitimate
+                    format conversion (JSON reshaped into a table/KV row).
+- ``recoverable`` — absent from the compressed text, but provably reachable: the
+                    block's digest marker carries a handle whose restore entry
+                    *contains that fact*. One ``distil_expand`` call away.
+- ``lost``        — absent, with no recovery path. The only bucket that can make an
+                    agent answer wrong.
+
+Two numbers fall out, and the gap between them is the whole product:
+
+    visible recall = retained / total              what the model sees for free
+    true recall    = (retained + recoverable) / total    the information bound
+
+A lossy compressor has one number, because for it recoverable is always zero. The
+gap is exactly what reversibility buys, quantified.
+
+Recall is deliberately the headline, not F1. The loss is asymmetric: a dropped fact
+is a wrong answer, while retained-but-unneeded content is merely fewer tokens saved.
+Precision belongs to the savings number, which distil already reports everywhere.
+
+Recoverability here is **block-scoped and verified** — the handle must appear in
+that block's own compressed text, and the fact must appear in that handle's restore
+bytes. It is never inferred from a marker sitting elsewhere in the prompt, so the
+percentages are absolute, not merely comparative.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:  # pragma: no cover - Windows
+    _HAVE_FCNTL = False
+
+from .compress.keep_policy import _ERR_RE
+from .compress.tier0 import Tier0Lossless
+from .compress.tier1 import Tier1Reversible
+from .corpus import CorpusEntry, load_corpus
+from .tokenizer import DEFAULT as _TOK
+from .trajectory import Block, Kind, Stability
+
+DIMENSIONS = ("numerics", "artifacts", "errors")
+
+# A number with its key context ("retry_limit: 3", "port=8787", '"latency_ms": 12').
+# Bare numbers are skipped: without a key they are unverifiable noise.
+_NUMERIC_RE = re.compile(r"[A-Za-z_][\w.-]{0,24}\"?[ =:]{1,3}\d+(?:\.\d+)?")
+_URL_RE = re.compile(r"https?://[^\s\"'<>)\]]+")
+_PATH_RE = re.compile(r"(?:~/|\.{1,2}/|/)?(?:[\w.-]+/){2,}[\w.@-]+")
+# Requires at least one a-f, so decimal runs (timestamps, row counts) are not
+# mistaken for content hashes.
+_HEX_RE = re.compile(r"\b(?=[0-9a-f]*[a-f])[0-9a-f]{7,64}\b")
+_UUID_RE = re.compile(r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b", re.I)
+_ARTIFACT_RES = (_URL_RE, _PATH_RE, _HEX_RE, _UUID_RE)
+
+_HANDLE_RE = re.compile(r"handle=([0-9a-f]{8})")
+# Collapse punctuation that format conversions rewrite, keeping the characters that
+# make a path/url/hash what it is.
+_NORMALIZE_RE = re.compile(r"[^\w./-]+")
+_NUMERIC_SPLIT_RE = re.compile(r"(.+?)[\"' =:]+(\d+(?:\.\d+)?)$")
+
+_MIN_TARGET_LEN = 4
+_ERROR_PREFIX_LEN = 160
+# Below this, compression is effectively an identity transform and any recall number
+# it produces is arithmetic, not evidence. Gates must refuse to pass on it.
+_MIN_ENGAGED_SAVINGS = 0.01
+_SAVINGS_BUCKETS = ((0.0, 0.25), (0.25, 0.5), (0.5, 0.75), (0.75, 1.01))
+
+_T0 = Tier0Lossless()
+_T1 = Tier1Reversible()
+
+
+@dataclass
+class Tally:
+    """Fact counts for one dimension."""
+
+    total: int = 0
+    retained: int = 0
+    recoverable: int = 0
+
+    @property
+    def lost(self) -> int:
+        return self.total - self.retained - self.recoverable
+
+    @property
+    def visible_recall(self) -> float:
+        """Fraction present without an expand call."""
+        return self.retained / self.total if self.total else 1.0
+
+    @property
+    def recall(self) -> float:
+        """Fraction still reachable — the information bound."""
+        return (self.retained + self.recoverable) / self.total if self.total else 1.0
+
+    def add(self, other: Tally) -> None:
+        self.total += other.total
+        self.retained += other.retained
+        self.recoverable += other.recoverable
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "total": self.total,
+            "retained": self.retained,
+            "recoverable": self.recoverable,
+            "lost": self.lost,
+            "visible_recall": round(self.visible_recall, 4),
+            "recall": round(self.recall, 4),
+        }
+
+
+@dataclass
+class BlockProbe:
+    """Retention outcome for one compressed block."""
+
+    block_id: str
+    savings: float  # fraction of characters removed from this block
+    dims: dict[str, Tally]
+
+
+@dataclass
+class RetentionReport:
+    probes: list[BlockProbe] = field(default_factory=list)
+
+    def aggregate(self) -> dict[str, Tally]:
+        totals = {name: Tally() for name in DIMENSIONS}
+        for p in self.probes:
+            for name, tally in p.dims.items():
+                totals[name].add(tally)
+        return totals
+
+    def overall(self) -> Tally:
+        combined = Tally()
+        for tally in self.aggregate().values():
+            combined.add(tally)
+        return combined
+
+    def by_savings_bucket(self) -> dict[str, Tally]:
+        buckets: dict[str, Tally] = {}
+        for low, high in _SAVINGS_BUCKETS:
+            label = f"{low:.0%}-{min(high, 1.0):.0%}"
+            tally = Tally()
+            for p in self.probes:
+                if low <= p.savings < high:
+                    for dim in p.dims.values():
+                        tally.add(dim)
+            buckets[label] = tally
+        return buckets
+
+    @property
+    def lost_facts(self) -> int:
+        return self.overall().lost
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "blocks_probed": len(self.probes),
+            "overall": self.overall().to_dict(),
+            "by_dimension": {n: t.to_dict() for n, t in self.aggregate().items()},
+            "by_savings_bucket": {k: v.to_dict() for k, v in self.by_savings_bucket().items()},
+        }
+
+
+def extract_targets(text: str) -> dict[str, set[str]]:
+    """Pull probe-able facts out of an ORIGINAL block, per dimension."""
+    targets: dict[str, set[str]] = {name: set() for name in DIMENSIONS}
+    targets["numerics"] = {m for m in _NUMERIC_RE.findall(text) if len(m) >= _MIN_TARGET_LEN}
+    for pattern in _ARTIFACT_RES:
+        targets["artifacts"].update(m for m in pattern.findall(text) if len(m) >= _MIN_TARGET_LEN)
+    for line in text.splitlines():
+        stripped = line.strip()
+        if len(stripped) >= _MIN_TARGET_LEN and _ERR_RE.search(stripped):
+            targets["errors"].add(stripped[:_ERROR_PREFIX_LEN])
+    return targets
+
+
+def _normalize(text: str) -> str:
+    return _NORMALIZE_RE.sub(" ", text).strip()
+
+
+def _survives(dimension: str, value: str, haystack: str, normalized: str) -> bool:
+    """True if `value` is still present, allowing for legitimate reshaping."""
+    if value in haystack:
+        return True
+    norm_value = _normalize(value)
+    if norm_value and norm_value in normalized:
+        return True
+    if dimension == "errors":
+        # A reshaped row drops the JSON key prefix ('"msg": "Error…"' -> a bare
+        # cell); the error substance is what has to survive, not the key.
+        _, _, remainder = norm_value.partition(" ")
+        if len(remainder) >= _MIN_TARGET_LEN and remainder in normalized:
+            return True
+    if dimension == "numerics":
+        # A table separates key from value; count it retained only if BOTH survive,
+        # so a stray matching integer elsewhere cannot fake a hit.
+        match = _NUMERIC_SPLIT_RE.match(value)
+        if match:
+            key, number = match.groups()
+            norm_key = _normalize(key)
+            if norm_key and norm_key in normalized:
+                return bool(re.search(rf"\b{re.escape(number)}\b", normalized))
+    return False
+
+
+def probe_block(original: Block, compressed_text: str, restore: dict[str, str]) -> BlockProbe:
+    """Classify every fact in `original` as retained / recoverable / lost.
+
+    Recoverability is proven, not assumed: the fact must appear in the restore bytes
+    of a handle that this block's own compressed text carries (or of this block's id,
+    for a Tier-0 reshape whose marker carries no handle).
+    """
+    normalized = _normalize(compressed_text)
+    keys = _HANDLE_RE.findall(compressed_text)
+    if original.id in restore:
+        keys.append(original.id)
+    recovery = "\n".join(restore[k] for k in keys if k in restore)
+
+    dims: dict[str, Tally] = {}
+    for name, values in extract_targets(original.text).items():
+        tally = Tally(total=len(values))
+        for value in values:
+            if _survives(name, value, compressed_text, normalized):
+                tally.retained += 1
+            elif recovery and value in recovery:
+                tally.recoverable += 1
+        dims[name] = tally
+
+    savings = 1.0 - (len(compressed_text) / len(original.text)) if original.text else 0.0
+    return BlockProbe(original.id, max(savings, 0.0), dims)
+
+
+def probe_trajectory(entry: CorpusEntry, report: RetentionReport | None = None) -> RetentionReport:
+    """Run the real Tier-1 -> Tier-0 pipeline over one trajectory and score retention.
+
+    Mirrors ``compress.strategies.distil``: the cacheable prefix is left alone and the
+    VOLATILE tail is digested. Only the tail is probed, because it is the only text
+    compression touches.
+    """
+    report = report if report is not None else RetentionReport()
+    for turn in entry.trajectory.turns:
+        volatile = [b for b in turn.blocks if b.stability is Stability.VOLATILE]
+        if not volatile:
+            continue
+        t1 = _T1.compress(volatile)
+        t0 = _T0.compress(t1.blocks)
+        restore = {**t1.restore, **t0.restore}
+        by_id = {b.id: b.text for b in t0.blocks}
+        for original in volatile:
+            compressed_text = by_id.get(original.id, "")
+            report.probes.append(probe_block(original, compressed_text, restore))
+    return report
+
+
+def run(entries: list[CorpusEntry] | None = None) -> RetentionReport:
+    entries = entries if entries is not None else load_corpus()
+    report = RetentionReport()
+    for entry in entries:
+        probe_trajectory(entry, report)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# public-benchmark scoring (third-party ground truth)
+# ---------------------------------------------------------------------------
+
+
+def _phrase_survives(value: str, haystack: str, normalized: str) -> bool:
+    """Strict survival for a gold answer / gold sentence: the WHOLE phrase must be
+    present, verbatim or with punctuation normalized. A partially kept sentence is
+    not retention — a model cannot answer from half a fact."""
+    if value in haystack:
+        return True
+    norm = _normalize(value)
+    return bool(norm) and norm in normalized
+
+
+@dataclass
+class CaseScore:
+    """One benchmark question, scored against its third-party answer key."""
+
+    case_id: str
+    savings: float  # token reduction over the retrieved docs
+    answer_retained: bool | None  # None => ungraded, see `ungraded`
+    answer_recoverable: bool = False
+    ungraded: str = ""  # "unanswerable" | "abstractive" | ""
+    support_total: int = 0
+    support_retained: int = 0
+    support_recoverable: int = 0
+
+
+@dataclass
+class DatasetReport:
+    dataset: str
+    shape: str = "json"
+    scores: list[CaseScore] = field(default_factory=list)
+    baseline: list[CaseScore] = field(default_factory=list)
+    baseline_label: str = "truncation @ matched savings"
+
+    @staticmethod
+    def _answer_recall(scores: list[CaseScore], *, with_recovery: bool) -> tuple[float, int]:
+        graded = [s for s in scores if s.answer_retained is not None]
+        if not graded:
+            return 1.0, 0
+        hits = sum(
+            1 for s in graded if s.answer_retained or (with_recovery and s.answer_recoverable)
+        )
+        return hits / len(graded), len(graded)
+
+    @staticmethod
+    def _support_recall(scores: list[CaseScore], *, with_recovery: bool) -> tuple[float, int]:
+        total = sum(s.support_total for s in scores)
+        if not total:
+            return 1.0, 0
+        hits = sum(
+            s.support_retained + (s.support_recoverable if with_recovery else 0) for s in scores
+        )
+        return hits / total, total
+
+    @staticmethod
+    def _savings(scores: list[CaseScore]) -> float:
+        return sum(s.savings for s in scores) / len(scores) if scores else 0.0
+
+    def ungraded(self, reason: str) -> int:
+        return sum(1 for s in self.scores if s.ungraded == reason)
+
+    @property
+    def savings(self) -> float:
+        return self._savings(self.scores)
+
+    @property
+    def engaged(self) -> bool:
+        """Did compression actually do anything? If not, a recall of 100% is the
+        arithmetic of an identity function and proves nothing about fidelity."""
+        return self.savings >= _MIN_ENGAGED_SAVINGS
+
+    def to_dict(self) -> dict[str, object]:
+        def block(scores: list[CaseScore]) -> dict[str, object]:
+            visible_answer, graded = self._answer_recall(scores, with_recovery=False)
+            true_answer, _ = self._answer_recall(scores, with_recovery=True)
+            visible_support, support_total = self._support_recall(scores, with_recovery=False)
+            true_support, _ = self._support_recall(scores, with_recovery=True)
+            return {
+                "cases": len(scores),
+                "savings": round(self._savings(scores), 4),
+                "answer_graded": graded,
+                "answer_recall_visible": round(visible_answer, 4),
+                "answer_recall": round(true_answer, 4),
+                "support_facts": support_total,
+                "support_recall_visible": round(visible_support, 4),
+                "support_recall": round(true_support, 4),
+            }
+
+        return {
+            "dataset": self.dataset,
+            "shape": self.shape,
+            "compression_engaged": self.engaged,
+            "ungraded_unanswerable": self.ungraded("unanswerable"),
+            "ungraded_abstractive": self.ungraded("abstractive"),
+            "distil": block(self.scores),
+            "baseline": {"label": self.baseline_label, **block(self.baseline)},
+        }
+
+
+def _payload_blocks(case: Any, shape: str) -> list[Block]:
+    """Render retrieved docs the way the agent actually receives them.
+
+    ``json`` (default) is the production shape: a retrieval tool returns an array of
+    records, which is exactly the structure distil compresses (columnar, lossless,
+    behind a handle). ``prose`` concatenates bare text — kept for comparison, but it
+    is not what a RAG agent's tool result looks like, and distil's compressors
+    correctly decline to touch short natural-language prose.
+    """
+    if shape == "prose":
+        return [
+            Block(id=f"doc{i}", kind=Kind.TOOL_OUTPUT, text=text, stability=Stability.VOLATILE)
+            for i, (_title, text) in enumerate(case.docs)
+        ]
+    payload = json.dumps(
+        [{"title": title, "text": text} for title, text in case.docs],
+        indent=2,
+        ensure_ascii=False,
+    )
+    return [
+        Block(id="retrieval", kind=Kind.TOOL_OUTPUT, text=payload, stability=Stability.VOLATILE)
+    ]
+
+
+def _score_case(case: Any, *, shape: str, truncate_to: float | None = None) -> CaseScore:
+    """Compress one benchmark case's retrieved docs and score the answer key.
+
+    `truncate_to` selects the baseline: a character-fraction truncation with NO
+    restore table (what every lossy compressor leaves you), instead of distil's
+    reversible pipeline.
+
+    A gold answer is only graded when it is present in the UNCOMPRESSED context.
+    HotpotQA's comparison questions answer "yes"/"no", which is never a span in the
+    passages — grading those would report an abstractive answer format as compression
+    loss. They are excluded and counted, not silently scored either way.
+    """
+    blocks = _payload_blocks(case, shape)
+    original = "\n".join(b.text for b in blocks)
+    original_norm = _normalize(original)
+
+    if truncate_to is None:
+        t1 = _T1.compress(blocks)
+        t0 = _T0.compress(t1.blocks)
+        compressed, restore = t0.blocks, {**t1.restore, **t0.restore}
+    else:
+        keep = max(0.0, min(1.0, truncate_to))
+        compressed = [b.copy_with(b.text[: int(len(b.text) * keep)]) for b in blocks]
+        restore = {}  # lossy: nothing to recover from, by construction
+
+    text = "\n".join(b.text for b in compressed)
+    normalized = _normalize(text)
+    recovery = "\n".join(restore.values())
+
+    base = sum(_TOK.count(b.text) for b in blocks)
+    kept = sum(_TOK.count(b.text) for b in compressed)
+    savings = (1.0 - kept / base) if base else 0.0
+
+    answer_retained: bool | None = None
+    answer_recoverable = False
+    ungraded = ""
+    if not (getattr(case, "answerable", True) and case.answer):
+        ungraded = "unanswerable"
+    elif not _phrase_survives(case.answer, original, original_norm):
+        ungraded = "abstractive"
+    else:
+        answer_retained = _phrase_survives(case.answer, text, normalized)
+        if not answer_retained and recovery:
+            answer_recoverable = case.answer in recovery
+
+    retained = recoverable = 0
+    gold = [s for s in case.support if _phrase_survives(s, original, original_norm)]
+    for sentence in gold:
+        if _phrase_survives(sentence, text, normalized):
+            retained += 1
+        elif recovery and sentence in recovery:
+            recoverable += 1
+
+    return CaseScore(
+        case_id=str(getattr(case, "id", "")),
+        savings=max(savings, 0.0),
+        answer_retained=answer_retained,
+        answer_recoverable=answer_recoverable,
+        ungraded=ungraded,
+        support_total=len(gold),
+        support_retained=retained,
+        support_recoverable=recoverable,
+    )
+
+
+def score_dataset(cases: list[Any], dataset: str = "", *, shape: str = "json") -> DatasetReport:
+    """Score distil against a public answer key, plus a matched-savings baseline.
+
+    The baseline truncates each document to the character fraction that reproduces
+    distil's own token savings on that case, so the two are compared at equal cost.
+    Both savings figures are reported, so a reader can confirm they actually match.
+    """
+    if shape not in ("json", "prose"):
+        raise ValueError(f"shape must be 'json' or 'prose', got {shape!r}")
+    label = dataset or (getattr(cases[0], "dataset", "") if cases else "")
+    report = DatasetReport(dataset=label, shape=shape)
+    for case in cases:
+        score = _score_case(case, shape=shape)
+        report.scores.append(score)
+        report.baseline.append(_score_case(case, shape=shape, truncate_to=1.0 - score.savings))
+    return report
+
+
+def format_dataset_report(report: DatasetReport) -> str:
+    d, b = report.scores, report.baseline
+    out = [
+        f"public benchmark: {report.dataset}  ({len(d)} cases, third-party ground truth, "
+        f"{report.shape} tool-result shape)",
+        "",
+        f"  {'':<28}{'savings':>9}{'answer':>9}{'support':>9}",
+        "-" * 64,
+    ]
+    for label, scores in (("distil (reversible)", d), (report.baseline_label, b)):
+        answer, _ = DatasetReport._answer_recall(scores, with_recovery=True)
+        support, _ = DatasetReport._support_recall(scores, with_recovery=True)
+        out.append(
+            f"  {label:<28}{DatasetReport._savings(scores):>8.1%}{answer:>9.1%}{support:>9.1%}"
+        )
+    out.append("-" * 64)
+
+    visible_answer, graded = DatasetReport._answer_recall(d, with_recovery=False)
+    true_answer, _ = DatasetReport._answer_recall(d, with_recovery=True)
+    visible_support, support_total = DatasetReport._support_recall(d, with_recovery=False)
+    true_support, _ = DatasetReport._support_recall(d, with_recovery=True)
+
+    out += [
+        "",
+        f"answer recall   {true_answer:.1%}  ({visible_answer:.1%} visible, "
+        f"{graded} gold answers graded)",
+    ]
+    if support_total:
+        out.append(
+            f"support recall  {true_support:.1%}  ({visible_support:.1%} visible, "
+            f"{support_total} gold sentences)"
+        )
+    for reason, note in (
+        ("unanswerable", "marked unanswerable by the dataset — no answer to retain"),
+        ("abstractive", "answer is not a span in the passage (e.g. yes/no) — unprobeable"),
+    ):
+        count = report.ungraded(reason)
+        if count:
+            out.append(f"excluded        {count} {note}")
+
+    base_answer, _ = DatasetReport._answer_recall(b, with_recovery=True)
+    out.append(
+        f"\nat the same savings, a lossy compressor retains {base_answer:.1%} of gold answers "
+        f"— distil is {true_answer - base_answer:+.1%}."
+    )
+    if not report.engaged:
+        out.append(
+            f"\nWARNING: compression barely engaged ({report.savings:.1%} savings) — recall here "
+            "is the arithmetic of a near-identity transform, NOT evidence of fidelity."
+        )
+    elif graded and visible_answer < 0.5 <= true_answer:
+        # Nothing is lost, but the agent pays a round trip for most answers. A user
+        # planning capacity needs that number, not just the reassuring one.
+        out.append(
+            f"\nNOTE: only {visible_answer:.1%} of answers are visible without a tool call — at "
+            "this aggressiveness the agent recovers most detail via distil_expand, which is "
+            "lossless but costs a round trip."
+        )
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# live meter — real traffic, content-free
+# ---------------------------------------------------------------------------
+#
+# The offline probes above grade the corpus and public benchmarks. Neither is YOUR
+# traffic. The obvious way to close that — record real sessions to disk and score them
+# later — would mean writing prompts and tool output in plaintext, and distil's whole
+# privacy posture is that no content ever lands on disk. So the meter scores
+# in-process, where the original and compressed text are both already in memory, and
+# persists COUNTS ONLY. Nothing recoverable, nothing to leak, no recorder to secure.
+#
+# It sits in the request path, so it obeys the same three rules as the rest of the
+# path: sampled (default off, like shadow mode), bounded (a hard char budget per
+# request), and fail-open (an exception here must never cost a user their request).
+
+_LIVE_MAX_CHARS = 65_536  # per request, so one huge tool result cannot stall a proxy
+
+
+def _tool_result_texts(messages: Any) -> list[str]:
+    """Tool-result text from Anthropic (`tool_result` blocks) and OpenAI (`role:tool`)."""
+    out: list[str] = []
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if msg.get("role") == "tool":
+            out.append(content if isinstance(content, str) else _flatten_text(content))
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    out.append(_flatten_text(block.get("content")))
+    return [t for t in out if t]
+
+
+def _flatten_text(node: Any) -> str:
+    if isinstance(node, str):
+        return node
+    if isinstance(node, dict):
+        if node.get("type") == "text":
+            return str(node.get("text", ""))
+        return "\n".join(_flatten_text(v) for v in node.values())
+    if isinstance(node, list):
+        return "\n".join(_flatten_text(item) for item in node)
+    return ""
+
+
+def measure_live(original: Any, compressed: Any, store: Any = None) -> dict[str, Tally]:
+    """Score one real request's fact retention. Returns counts only — never content.
+
+    `store` is the live RestoreStore; a missing fact counts as recoverable only when a
+    handle present in the compressed text expands to bytes that actually contain it —
+    the same verified standard the offline probe uses.
+    """
+    original_text = "\n".join(_tool_result_texts(original))[:_LIVE_MAX_CHARS]
+    dims = {name: Tally() for name in DIMENSIONS}
+    if not original_text:
+        return dims
+
+    compressed_text = _flatten_text(compressed)
+    normalized = _normalize(compressed_text)
+
+    recovery = ""
+    if store is not None:
+        parts: list[str] = []
+        for handle in set(_HANDLE_RE.findall(compressed_text)):
+            try:
+                parts.append(store.expand(handle) or "")
+            except Exception:  # noqa: BLE001 — a missing handle is not a crash
+                continue
+        recovery = "\n".join(parts)
+
+    for name, values in extract_targets(original_text).items():
+        tally = dims[name]
+        tally.total = len(values)
+        for value in values:
+            if _survives(name, value, compressed_text, normalized):
+                tally.retained += 1
+            elif recovery and value in recovery:
+                tally.recoverable += 1
+    return dims
+
+
+class LiveMeter:
+    """Sampled, content-free retention meter for the request path.
+
+    `rate` <= 0 disables it entirely (the default), matching shadow mode: a feature
+    that adds latency to real traffic is opt-in, not opt-out.
+    """
+
+    def __init__(self, rate: float, *, rng: Any = None, path: Path | None = None) -> None:
+        self.rate = max(0.0, min(1.0, rate))
+        self._rng = rng or random.Random()
+        self._path = path
+
+    @property
+    def enabled(self) -> bool:
+        return self.rate > 0
+
+    def should_sample(self) -> bool:
+        return self.enabled and self._rng.random() < self.rate
+
+    def observe(self, original: Any, compressed: Any, store: Any = None) -> None:
+        """Score and persist one request if sampled. Never raises."""
+        try:
+            if not self.should_sample():
+                return
+            dims = measure_live(original, compressed, store)
+            if any(t.total for t in dims.values()):
+                self._append(dims)
+        except Exception:  # noqa: BLE001 — the meter must never break a request
+            pass
+
+    def _append(self, dims: dict[str, Tally]) -> None:
+        path = self._path or (_live_path())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Ints only. There is deliberately no field here that could carry content.
+        record = {
+            "ts": time.time(),
+            "dims": {
+                name: [tally.total, tally.retained, tally.recoverable]
+                for name, tally in dims.items()
+            },
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            # Concurrent wrap sessions and proxy workers append here; lock like
+            # ledger.py and shadow.py do.
+            if _HAVE_FCNTL:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.write(json.dumps(record) + "\n")
+                fh.flush()
+            finally:
+                if _HAVE_FCNTL:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _live_path() -> Path:
+    home = Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil")))
+    return home / "retention.jsonl"
+
+
+def load_live(path: Path | None = None) -> tuple[dict[str, Tally], int]:
+    """Aggregate the live meter's rows. Returns (per-dimension tallies, request count)."""
+    target = path or _live_path()
+    dims = {name: Tally() for name in DIMENSIONS}
+    requests = 0
+    if not target.exists():
+        return dims, 0
+    with target.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+                row = record["dims"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+            requests += 1
+            for name, triple in row.items():
+                if name in dims and isinstance(triple, list) and len(triple) == 3:
+                    total, retained, recoverable = (int(v) for v in triple)
+                    dims[name].add(Tally(total, retained, recoverable))
+    return dims, requests
+
+
+def format_live(dims: dict[str, Tally], requests: int) -> str:
+    combined = Tally()
+    for tally in dims.values():
+        combined.add(tally)
+    if not requests or not combined.total:
+        return (
+            "no live retention samples yet.\n\n"
+            "Start the proxy with --retention-rate 0.05 to sample 5% of real requests "
+            "(content-free: only counts are stored)."
+        )
+    out = [
+        f"live fact retention  ({requests} sampled requests, real traffic)",
+        "",
+        f"  {'dimension':<12}{'recall':>7}{'visible':>10}{'lost':>7}{'facts':>8}",
+        "-" * 66,
+    ]
+    for name, tally in dims.items():
+        out.append(_row(name, tally))
+    out.append("-" * 66)
+    out.append(_row("ALL", combined))
+    out += [
+        "",
+        f"recall {combined.recall:.1%} on your own traffic — {combined.lost} facts lost, "
+        f"{combined.recoverable} recovered via distil_expand.",
+    ]
+    return "\n".join(out)
+
+
+def _row(label: str, tally: Tally) -> str:
+    if not tally.total:
+        return f"  {label:<12}       n/a (0 facts)"
+    bar = "█" * round(tally.recall * 20)
+    return (
+        f"  {label:<12}{tally.recall:>7.1%}{tally.visible_recall:>10.1%}"
+        f"{tally.lost:>7}{tally.total:>8}  {bar}"
+    )
+
+
+def format_report(report: RetentionReport) -> str:
+    overall = report.overall()
+    out = [
+        f"fact-level retention  ({len(report.probes)} compressed blocks probed)",
+        "",
+        f"  {'dimension':<12}{'recall':>7}{'visible':>10}{'lost':>7}{'facts':>8}",
+        "-" * 66,
+    ]
+    for name, tally in report.aggregate().items():
+        out.append(_row(name, tally))
+    out.append("-" * 66)
+    out.append(_row("ALL", overall))
+    out += ["", "by block savings:"]
+    for label, tally in report.by_savings_bucket().items():
+        if tally.total:
+            out.append(_row(label, tally))
+    out += [
+        "",
+        f"recall {overall.recall:.1%} — {overall.retained} of {overall.total} facts stay visible, "
+        f"{overall.recoverable} more are one distil_expand away, {overall.lost} lost.",
+    ]
+    if overall.recoverable:
+        gap = overall.recall - overall.visible_recall
+        out.append(
+            f"reversibility is worth {gap:.1%} recall here: a lossy compressor at the same "
+            "savings would have dropped those facts for good."
+        )
+    return "\n".join(out)

--- a/distil/retention.py
+++ b/distil/retention.py
@@ -62,9 +62,18 @@ from .trajectory import Block, Kind, Stability
 
 DIMENSIONS = ("numerics", "artifacts", "errors")
 
-# A number with its key context ("retry_limit: 3", "port=8787", '"latency_ms": 12').
+# A number with its key context ("retry_limit: 3", "port=8787", "invoices=88ms").
 # Bare numbers are skipped: without a key they are unverifiable noise.
-_NUMERIC_RE = re.compile(r"[A-Za-z_][\w.-]{0,24}\"?[ =:]{1,3}\d+(?:\.\d+)?")
+#
+# The lookarounds and the trailing unit matter more than they look. Without them the
+# match ends mid-token — "invoices=88" clipped out of "invoices=88ms", and junk like
+# "T09:14" carved out of "2026-06-21T09:14:02Z". Both make bad probes: the first loses
+# the unit and would false-match "invoices=889", the second is not a fact at all. They
+# also cannot satisfy a right-boundary test, which is what surfaced this while
+# tightening `_in_recovery` for the audit finding.
+_NUMERIC_RE = re.compile(
+    r"(?<![\w:.-])[A-Za-z_][\w.-]{0,24}\"?[ =:]{1,3}\d+(?:\.\d+)?[A-Za-z%]*(?![\w:.-])"
+)
 _URL_RE = re.compile(r"https?://[^\s\"'<>)\]]+")
 _PATH_RE = re.compile(r"(?:~/|\.{1,2}/|/)?(?:[\w.-]+/){2,}[\w.@-]+")
 # Requires at least one a-f, so decimal runs (timestamps, row counts) are not
@@ -196,6 +205,26 @@ def _normalize(text: str) -> str:
     return _NORMALIZE_RE.sub(" ", text).strip()
 
 
+def _in_recovery(value: str, recovery: str) -> bool:
+    """Is `value` present in the recovered bytes, at token boundaries?
+
+    A bare substring test inflates recoverable recall on short values: the gold answer
+    "12" matches inside "file-12.csv", and "5" matches almost anything. Boundaries are
+    checked with lookarounds rather than ``\\b`` so values that begin or end with
+    punctuation still anchor correctly. (Audit finding: short dataset answers were
+    false-matching against unrelated paths and hashes in other digested documents.)
+    """
+    if not value or not recovery:
+        return False
+    if len(value) < _MIN_TARGET_LEN:
+        # Very short values ("12", "5") still slip through punctuation boundaries —
+        # "12" is a token inside "file-12.csv". Require real whitespace/string edges so
+        # only a standalone occurrence counts. Erring toward NOT crediting recovery is
+        # the safe direction for a metric whose job is to surface loss.
+        return re.search(rf"(?:^|\s){re.escape(value)}(?:\s|$)", recovery) is not None
+    return re.search(rf"(?<!\w){re.escape(value)}(?!\w)", recovery) is not None
+
+
 def _survives(dimension: str, value: str, haystack: str, normalized: str) -> bool:
     """True if `value` is still present, allowing for legitimate reshaping."""
     if value in haystack:
@@ -240,7 +269,7 @@ def probe_block(original: Block, compressed_text: str, restore: dict[str, str]) 
         for value in values:
             if _survives(name, value, compressed_text, normalized):
                 tally.retained += 1
-            elif recovery and value in recovery:
+            elif _in_recovery(value, recovery):
                 tally.recoverable += 1
         dims[name] = tally
 
@@ -447,14 +476,14 @@ def _score_case(case: Any, *, shape: str, truncate_to: float | None = None) -> C
     else:
         answer_retained = _phrase_survives(case.answer, text, normalized)
         if not answer_retained and recovery:
-            answer_recoverable = case.answer in recovery
+            answer_recoverable = _in_recovery(case.answer, recovery)
 
     retained = recoverable = 0
     gold = [s for s in case.support if _phrase_survives(s, original, original_norm)]
     for sentence in gold:
         if _phrase_survives(sentence, text, normalized):
             retained += 1
-        elif recovery and sentence in recovery:
+        elif _in_recovery(sentence, recovery):
             recoverable += 1
 
     return CaseScore(
@@ -611,8 +640,15 @@ def measure_live(original: Any, compressed: Any, store: Any = None) -> dict[str,
 
     recovery = ""
     if store is not None:
+        # Only handles this store already holds IN MEMORY. RestoreStore.expand() falls
+        # back to a synchronous disk read for unknown handles, and this runs in the
+        # request path — a long transcript, or tool output that merely CONTAINS the text
+        # "handle=deadbeef", would turn one sampled request into many file reads. The
+        # in-memory set is also the only recoverability we can prove for this turn.
+        # (Audit finding: synchronous disk I/O in the hot path.)
+        known = getattr(store, "handles", None) or frozenset()
         parts: list[str] = []
-        for handle in set(_HANDLE_RE.findall(compressed_text)):
+        for handle in set(_HANDLE_RE.findall(compressed_text)) & set(known):
             try:
                 parts.append(store.expand(handle) or "")
             except Exception:  # noqa: BLE001 — a missing handle is not a crash
@@ -625,7 +661,7 @@ def measure_live(original: Any, compressed: Any, store: Any = None) -> dict[str,
         for value in values:
             if _survives(name, value, compressed_text, normalized):
                 tally.retained += 1
-            elif recovery and value in recovery:
+            elif _in_recovery(value, recovery):
                 tally.recoverable += 1
     return dims
 

--- a/distil/retention.py
+++ b/distil/retention.py
@@ -40,6 +40,7 @@ import json
 import os
 import random
 import re
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -741,10 +742,26 @@ def format_live(dims: dict[str, Tally], requests: int) -> str:
     return "\n".join(out)
 
 
+def _bar_char() -> str:
+    """The block glyph where the console can encode it, ASCII where it cannot.
+
+    U+2588 is absent from cp1252, so printing it to a stock Windows console raises
+    UnicodeEncodeError — which took down the retention gate on the windows-latest CI
+    leg while every POSIX leg passed. An em dash survives there (cp1252 has one), so
+    the rest of this module's output is safe; only the bar needed degrading.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+    try:
+        "█".encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return "#"
+    return "█"
+
+
 def _row(label: str, tally: Tally) -> str:
     if not tally.total:
         return f"  {label:<12}       n/a (0 facts)"
-    bar = "█" * round(tally.recall * 20)
+    bar = _bar_char() * round(tally.recall * 20)
     return (
         f"  {label:<12}{tally.recall:>7.1%}{tally.visible_recall:>10.1%}"
         f"{tally.lost:>7}{tally.total:>8}  {bar}"

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -190,7 +190,7 @@ must appear in that handle's restore bytes. Two numbers fall out —
     true recall    = (retained + recoverable) / total     (the information bound)
 
 — and the gap between them is what reversibility buys. On the committed corpus:
-**100% true recall, 87.7% visible, 0 lost** — reversibility is worth 12.3% recall.
+**100% true recall, 90.2% visible, 0 lost** — reversibility is worth 9.8% recall.
 
 ```
 distil retention                 # corpus (zero cost, offline) — a CI gate
@@ -258,7 +258,7 @@ exact original behind an expand handle:
 | real page | before | after | saved | facts lost |
 |---|---|---|---|---|
 | Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
-| Python docs page | 27,136 tok | 3,751 tok | **86.2%** | **0** |
+| Python docs page | 32,322 tok | 4,229 tok | **86.9%** | **0** |
 
 Recall-biased on purpose: `<header>` is kept (it usually wraps the `<h1>`), `img` alt
 text is kept, and `div`/`section` are never dropped. Being reversible is what licenses

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -158,7 +158,120 @@ another. An anytime-valid drift monitor
 moved far enough from the certified distribution that the certificate should
 be considered stale and re-run.
 
-## 5. How to reproduce
+## 5. Fact-level recall, and grading against someone else's answer key
+
+Sections 1–4 all measure the same kind of thing: whether the agent's *next action*
+survives compression, graded on distil's own corpus against planted `DECISION:`
+markers. That is the right invariant to certify, but it is not the question users
+ask, and it is not checkable by an outsider. Two additions close both gaps
+([ADR 0005](adr/0005-external-validity-and-fact-level-recall.md)).
+
+### 5.1 Three states, and why recall is the headline
+
+A compressor's error is asymmetric. Dropping a fact produces a wrong answer;
+keeping content you did not need merely saves fewer tokens. So we report **recall**
+and let the savings number carry the other direction, rather than blending both into
+an F1 that hides which way the error ran.
+
+Every fact — keyed numerics, artifacts (paths/URLs/hashes/UUIDs), error lines — lands
+in one of three buckets:
+
+| Bucket | Meaning |
+|---|---|
+| `retained` | in the text the model sees, verbatim or after a format conversion |
+| `recoverable` | absent, but provably reachable via `distil_expand` |
+| `lost` | absent with no recovery path — the only bucket that can cause a wrong answer |
+
+`recoverable` exists only because distil is reversible, and it is **verified, not
+assumed**: the handle must appear in that block's own compressed text, *and* the fact
+must appear in that handle's restore bytes. Two numbers fall out —
+
+    visible recall = retained / total                    (free, no tool call)
+    true recall    = (retained + recoverable) / total     (the information bound)
+
+— and the gap between them is what reversibility buys. On the committed corpus:
+**100% true recall, 87.7% visible, 0 lost** — reversibility is worth 12.3% recall.
+
+```
+distil retention                 # corpus (zero cost, offline) — a CI gate
+distil retention --live          # YOUR traffic, from the sampled meter
+```
+
+The live meter scores **in-process** and stores **counts only** — three integers per
+dimension, with deliberately no field that could carry content, so no plaintext
+session recorder exists to secure. It is sampled (`--retention RATE`, default 0.05
+under `wrap`, 0 under a bare `proxy`), bounded (64 KiB per request), and fail-open. It
+costs no extra tokens: unlike shadow mode there is no second upstream call.
+
+### 5.2 Public benchmarks — external validity
+
+```
+distil retention --dataset list
+distil retention --dataset hotpotqa -n 100
+```
+
+Graded against ground truth written by someone else: HotpotQA's `supporting_facts`
+(the exact gold sentences, amid 8 distractor paragraphs) and SQuAD v2's answer spans.
+Rows come from the HuggingFace datasets-server REST API as plain JSON, so the loader
+stays stdlib-only and `dependencies = []` holds; they cache under `$DISTIL_HOME/datasets`
+so a published number reproduces offline.
+
+A recall number alone proves nothing — an identity transform scores 100%. So each run
+also scores a **truncation baseline tuned to reproduce distil's own token savings on
+that same case**, and prints both savings figures so the match is auditable:
+
+| HotpotQA, n=100 | savings | answer recall | support recall |
+|---|---|---|---|
+| distil (reversible) | 14.3% | **100.0%** | **100.0%** |
+| truncation @ matched savings | 14.1% | 91.6% | 82.7% |
+
+Three honesty rules the command enforces, each of which caught a real defect while
+this was being built:
+
+- **Only probeable answers are graded.** HotpotQA's comparison questions answer
+  "yes"/"no", which is never a span in the passage. Grading them reported the
+  dataset's answer *format* as 10% compression loss. Answers now count only when
+  present in the **uncompressed** context; the rest are excluded and counted.
+- **Unanswerable questions are excluded, not passed.** SQuAD v2 ships them
+  deliberately; scoring them as retained would be a free win on 55% of the split.
+- **A run where compression did not engage fails.** Below 1% savings the recall
+  number is arithmetic, not evidence — so `--min-recall` refuses to pass on it. This
+  matters because distil's compressors correctly decline to touch short prose:
+  `--shape prose` yields 0% savings and a vacuous 100%. The default `--shape json`
+  reflects how a retrieval tool actually returns documents.
+
+Note also what SQuAD exposes: at 84.8% savings true recall is 100% but **visible
+recall is 0%** — every answer sits behind a handle. Lossless, but one round trip per
+answer. The report says so rather than printing only the reassuring number.
+
+### 5.3 What the harness found: HTML was compressing 0%
+
+A recall metric earns its keep by finding things, and the first thing this one found was
+a capability gap rather than a regression. distil compressed **0.0%** of an HTML tool
+result — structurally, because minified markup is a single enormous line, so Tier-1's
+line-folding had nothing to fold and the JSON/record folds do not recognise markup. Any
+agent with a fetch or browser tool paid full price for `<script>`, `<style>`, and chrome.
+
+`distil/compress/htmlx.py` now extracts the content (stdlib `html.parser`) and keeps the
+exact original behind an expand handle:
+
+| real page | before | after | saved | facts lost |
+|---|---|---|---|---|
+| Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
+| Python docs page | 27,136 tok | 3,751 tok | **86.2%** | **0** |
+
+Recall-biased on purpose: `<header>` is kept (it usually wraps the `<h1>`), `img` alt
+text is kept, and `div`/`section` are never dropped. Being reversible is what licenses
+the aggressiveness — a lossy extractor's mistake is permanent, this one costs one
+`distil_expand`. Skipped under `--verbatim` (nothing to recover with) and on the
+recency-exempt latest tool result.
+
+One measured tradeoff, stated rather than buried: on raw HTML most probe-able artifacts
+are `href` URLs, which extraction drops as navigation. True recall stays 100% because
+they are recoverable, but **visible** recall on that dimension is low (4.8% overall on
+the Wikipedia page). That is a tunable with a number attached now, not an unknown.
+
+## 6. How to reproduce
 
 - `distil shadow-stats` — live decision-equivalence, raw/baseline/adjusted
   decomposition, from real traffic collected by `distil wrap --shadow`.

--- a/docs/adr/0005-external-validity-and-fact-level-recall.md
+++ b/docs/adr/0005-external-validity-and-fact-level-recall.md
@@ -68,7 +68,7 @@ rather than blending both into an F1 that hides which direction the error ran.
 Facts are classified `retained` / `recoverable` / `lost`. `recoverable` means the fact is
 absent from what the model sees but reachable via `distil_expand`. This distinction only
 exists because distil is reversible, and it is the first time that property has had a
-number: on the corpus, reversibility is worth **12.3% recall** (87.7% visible → 100%).
+number: on the corpus, reversibility is worth **9.8% recall** (90.2% visible → 100%).
 
 Crucially, recoverability is **verified, not inferred**: the handle must appear in *that
 block's own* compressed text, and the fact must appear in *that handle's* restore bytes.
@@ -122,7 +122,8 @@ fetch or browser tool was paying full price for `<script>`, `<style>`, and chrom
 `compress/htmlx.py` extracts content with stdlib `html.parser` (no lxml, no bs4, no
 readability port — the core stays dependency-free) and records the exact original under
 the marker's handle. Real pages: Wikipedia 281,093 → 14,260 tokens (**94.9%**), Python
-docs 27,136 → 3,751 (**86.2%**), **0 facts lost** in both.
+docs 32,322 → 4,229 (**86.9%**), **0 facts lost** in both. Both measured end-to-end
+through the adapter (the envelope a user actually sends), not on the extractor alone.
 
 The extraction is deliberately **recall-biased**, for the same asymmetry as §3: only
 tags that cannot hold article content are dropped outright, plus four unambiguous
@@ -148,10 +149,52 @@ without one, tag density alone is insufficient — a log line reading `parse fai
 doctype-less fragment must also show closing tags substantially balancing its open
 ones. This was a real false positive caught by its own test, not a hypothetical.
 
+### 8. Findings from cross-audit, and what they changed
+
+The PR's independent cross-audit raised three findings. All three reproduced, so all
+three are fixed — and one of them exposed a defect in the metric itself that had been
+flattering us.
+
+**Unclosed chrome tags swallowed the article.** Chrome skipping keyed off a matching
+close tag, and real HTML frequently never sends one. Content *before* an unclosed
+`<aside>` was emitted while everything after it — the actual article — was dropped.
+(The fully-swallowed case was benign: extraction returned empty, declined, and the
+block passed through uncompressed. The partial case was not.) Fixed with two bounds: an
+`<article>`/`<main>` landmark ends any active skip, since an unclosed sidebar cannot
+legitimately contain the page's main content; and a skipped-data budget abandons the
+skip on `<div>`-built chrome where no landmark follows. `script`/`style` are exempt from
+the budget — their payload is legitimately huge.
+
+**Synchronous disk I/O in the request path.** `RestoreStore.expand()` falls back to a
+disk read for handles it does not hold in memory, and the live meter called it for every
+`handle=` match in the compressed text. A long transcript — or tool output that merely
+*contains* the string `handle=deadbeef`, which distil's own adversarial harness plants —
+would turn one sampled request into a series of file reads. The meter now intersects
+matched handles with the store's in-memory set, which removes the disk path entirely and
+is also the only recoverability provable for the current turn.
+
+**Short answers false-matched in the recovered bytes.** `case.answer in recovery` is a
+bare substring test: the gold answer `"12"` matches inside `file-12.csv`, and `"5"`
+matches almost anything. Recoverability now requires token boundaries, and values
+shorter than four characters require whitespace boundaries — erring toward *not*
+crediting recovery, which is the safe direction for a metric whose job is to surface
+loss.
+
+That third fix then failed the corpus gate, which is how it earned its keep: tightening
+the match revealed that `_NUMERIC_RE` had been extracting values that end **mid-token** —
+`invoices=88` clipped out of `invoices=88ms`, and junk like `T09:14` carved out of a
+timestamp. Those are strictly worse probes (the first loses its unit and would
+false-match `invoices=889`; the second is not a fact at all), and they could not satisfy
+a right-boundary test. Extraction now captures the whole token including its unit and
+refuses to start or end mid-token. The probe set is smaller and cleaner as a result —
+417 facts rather than 503 — which moved the corpus figures to **90.2% visible / 100%
+true / 0 lost**, and the measured value of reversibility from 12.3% to **9.8%**. The
+earlier number was inflated by junk probes; this one is the honest one.
+
 ## Consequences
 
 - distil can state a quality claim checkable against data the reader already trusts.
-- The reversibility moat has a measured value (+12.3% recall on the corpus, +8.4% answer
+- The reversibility moat has a measured value (+9.8% recall on the corpus, +8.4% answer
   / +17.3% support vs matched-savings truncation on HotpotQA) instead of an argument.
 - New maintenance surface: two third-party dataset shapes. Adapters return `None` on
   anything unexpected and the loader raises rather than reporting a short run, so an

--- a/docs/adr/0005-external-validity-and-fact-level-recall.md
+++ b/docs/adr/0005-external-validity-and-fact-level-recall.md
@@ -1,0 +1,168 @@
+# ADR 0005 — External validity, and measuring recall instead of only equivalence
+
+- Status: Accepted
+- Date: 2026-07-29
+- Deciders: distil maintainers
+- Extends [ADR 0004](0004-stack-ranked-capability-gaps.md)
+
+## Context
+
+Every quality signal distil shipped before this ADR shares two properties:
+
+1. It is graded **against our own corpus** (7 hand-built trajectories) using **our own
+   oracle** (planted `DECISION:` markers), or against live traffic using our own
+   decision signature.
+2. It answers a **block-level** question — `verify` proves bytes round-trip,
+   `certify`/`shadow` prove the next action is unchanged.
+
+Both properties are defensible and the statistics are genuinely rigorous (TOST
+non-inferiority, conformal bounds, bootstrap holdout CIs). But together they leave two
+holes that no amount of added rigour inside the existing frame can close.
+
+**Hole 1 — the numbers are unfalsifiable by a stranger.** A reader cannot check
+"non-inferior on the distil corpus" against anything they already trust. Our corpus, our
+markers, our verdict. That is not an accusation of dishonesty; it is a structural limit
+on how much an outside reader can rationally update on our claims.
+
+**Hole 2 — nobody asks whether the *next action* survived.** They ask whether *the
+number they needed is still there*. "Decision-equivalent" is the right invariant for
+certification and the wrong answer to "did compression eat my stack trace?" We had no
+recall metric at all — not a low one, none — and `verify_reversible` was measuring
+something subtly different: *can these bytes be reconstructed from the restore table*,
+at block granularity, which is true by construction for Tier-0/1 and therefore always
+100%. A metric that cannot fail is not a gate.
+
+## Decision
+
+### 1. Grade against public ground truth, over the network, with no new dependencies
+
+`distil retention --dataset {hotpotqa,squad}` loads real public benchmarks whose answer
+keys were written by someone else — HotpotQA's `supporting_facts` (the exact gold
+sentences, amid 8 distractor paragraphs) and SQuAD v2's answer spans.
+
+Rows come from the HuggingFace **datasets-server REST API** — plain JSON over HTTPS —
+not the `datasets` package. This preserves `dependencies = []`: pulling in Arrow and a
+model stack to read 100 rows would cost more than distil's entire core. Rows cache to
+`$DISTIL_HOME/datasets` so a published number reproduces offline, and ordering is the
+split's own order with no shuffle, so "n=100" means the same 100 cases for everyone.
+
+**Rejected: vendoring the datasets.** Redistribution terms differ per dataset and a
+committed copy silently ages. Fetch-and-cache keeps provenance honest.
+
+### 2. Compare at matched savings, or do not compare
+
+A recall number alone is meaningless — an identity transform scores 100%. Every dataset
+run therefore also scores a **truncation baseline tuned to reproduce distil's own token
+savings on that same case**, and prints both savings figures so a reader can confirm
+they match. On HotpotQA (n=100, 14.3% savings): distil 100% answer recall / 100% support
+recall, truncation at 14.1% savings 91.6% / 82.7%.
+
+### 3. Recall is the headline; precision belongs to the savings number
+
+The loss is asymmetric. A dropped fact is a wrong answer; retained-but-unneeded content
+is merely fewer tokens saved. So we report recall and let savings carry the other side,
+rather than blending both into an F1 that hides which direction the error ran.
+
+### 4. Three states, not two — and recoverability must be *proven*
+
+Facts are classified `retained` / `recoverable` / `lost`. `recoverable` means the fact is
+absent from what the model sees but reachable via `distil_expand`. This distinction only
+exists because distil is reversible, and it is the first time that property has had a
+number: on the corpus, reversibility is worth **12.3% recall** (87.7% visible → 100%).
+
+Crucially, recoverability is **verified, not inferred**: the handle must appear in *that
+block's own* compressed text, and the fact must appear in *that handle's* restore bytes.
+Approaches that infer recoverability from a retrieval marker appearing anywhere in the
+prompt overcount, and can only claim comparative validity. Ours is absolute, and two
+tests pin it (`test_handle_without_the_fact_is_lost_not_recoverable`,
+`test_foreign_handle_is_not_credited`).
+
+We also report **visible recall** alongside true recall, because "lossless via a tool
+call" still costs a round trip. On SQuAD (84.8% savings) true recall is 100% but visible
+recall is 0% — every answer sits behind a handle. That is honest and actionable, and the
+report says so explicitly rather than printing only the reassuring number.
+
+### 5. The live meter scores real traffic without ever writing content
+
+Corpus and public benchmarks are still not *your* traffic. The obvious fix — record real
+sessions and score them offline — would mean prompts and tool output in plaintext on
+disk, breaking the content-free posture that the census, ledger, and shadow ledger all
+maintain. **We will not add a plaintext session recorder.**
+
+Instead the meter scores **in-process**, where original and compressed text are both
+already in memory, and persists **counts only** (three integers per dimension). There is
+deliberately no field in the record that could carry content, and a test plants a unique
+marker in tool output and asserts it never reaches disk.
+
+Request-path rules, matching shadow mode: **sampled** (`--retention RATE`), **bounded**
+(64 KiB scanned per request), **fail-open** (any exception is swallowed). It defaults to
+`0.05` under `wrap` and `0` under a bare `proxy` — unlike `--shadow` it costs no extra
+tokens, because there is no second upstream call.
+
+### 6. Gate placement follows cost, and silence is never success
+
+| Gate | Where | Why |
+|---|---|---|
+| `distil retention --max-lost 0` | per-commit CI | zero cost, no network; Tier-0/1 are lossless by construction, so any lost fact is a real regression |
+| `distil retention --dataset …` | nightly | needs a third-party host; a required check gated on someone else's uptime makes main's health hostage to it |
+
+The dataset command exits non-zero on a fetch failure, on an upstream schema change, and
+on **compression that did not engage** (<1% savings) — because a recall number produced
+by a near-identity transform is arithmetic, not evidence. Nightly fails hard if *both*
+benchmarks fail, since that means no external-validity signal was collected at all.
+
+### 7. HTML gets a reversible transform, because the harness found it had none
+
+Building the above exposed a capability gap the harness could then measure: distil
+compressed **0.0%** of an HTML tool result. The cause is structural rather than a
+missing heuristic — minified markup is one enormous line, so Tier-1's line-folding has
+nothing to fold and the JSON/record folds do not recognise markup. Every agent with a
+fetch or browser tool was paying full price for `<script>`, `<style>`, and chrome.
+
+`compress/htmlx.py` extracts content with stdlib `html.parser` (no lxml, no bs4, no
+readability port — the core stays dependency-free) and records the exact original under
+the marker's handle. Real pages: Wikipedia 281,093 → 14,260 tokens (**94.9%**), Python
+docs 27,136 → 3,751 (**86.2%**), **0 facts lost** in both.
+
+The extraction is deliberately **recall-biased**, for the same asymmetry as §3: only
+tags that cannot hold article content are dropped outright, plus four unambiguous
+chrome landmarks (`nav`/`footer`/`aside`/`form`). `<header>` is *kept* — it usually
+wraps the `<h1>` — and `img` alt text is kept because it is often a figure's only
+description. `div`/`section` are never dropped: their meaning is site-specific.
+
+Being reversible is what licenses that aggressiveness. A lossy extractor's mistake is
+permanent; ours costs one `distil_expand`. Skipped in `verbatim` mode (no expand tool
+exists to recover with, so an unrecoverable elision is forbidden) and on recency-exempt
+blocks (the agent's most recent output must stay byte-exact).
+
+**Rejected: keeping `href` URLs inline.** On raw HTML most probe-able artifacts are
+link URLs; retaining them would cut savings hard on link-dense pages, and they remain
+recoverable. The consequence is honest and now *measured* rather than assumed: visible
+recall on the artifact dimension is low for HTML (4.8% overall on the Wikipedia page)
+while true recall is 100%. If evidence from real expand signals says agents need those
+links, the meter will show it and the default can change on data.
+
+**Detection is conservative.** A doctype/`<html>`/`<body>` landmark accepts outright;
+without one, tag density alone is insufficient — a log line reading `parse failed near
+<div>` repeated 40 times clears any density bar. Markup closes its elements, so a
+doctype-less fragment must also show closing tags substantially balancing its open
+ones. This was a real false positive caught by its own test, not a hypothetical.
+
+## Consequences
+
+- distil can state a quality claim checkable against data the reader already trusts.
+- The reversibility moat has a measured value (+12.3% recall on the corpus, +8.4% answer
+  / +17.3% support vs matched-savings truncation on HotpotQA) instead of an argument.
+- New maintenance surface: two third-party dataset shapes. Adapters return `None` on
+  anything unexpected and the loader raises rather than reporting a short run, so an
+  upstream schema change fails loudly.
+- Two findings worth recording, both discovered by building this and both initially
+  wrong in our favour:
+  - HotpotQA's yes/no comparison answers are never spans in the passage. Grading them
+    naively reported the dataset's answer *format* as 10% compression loss. Answers are
+    now graded only when present in the **uncompressed** context.
+  - distil's compressors correctly decline to touch short natural-language prose, so a
+    bare-prose framing of these benchmarks yields 0% savings and a vacuous 100% recall.
+    The default `--shape json` reflects how a retrieval tool actually returns documents
+    (a JSON array, which is what distil compresses); `--shape prose` remains available
+    and warns when compression did not engage.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,273 @@
+"""Public-benchmark loader — transport, cache, and honest failure.
+
+No test here touches the network: the rows API is stubbed and the cache is redirected
+to a tmp DISTIL_HOME. What is pinned is the behaviour that makes a published number
+trustworthy — deterministic ordering, an atomic cache, retry only on transient
+failures, and a loud raise instead of a short result on anything unexpected.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from distil import datasets as ds
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+
+
+def _hotpot_row(idx: int) -> dict[str, Any]:
+    return {
+        "id": f"case{idx}",
+        "question": "Who directed it?",
+        "answer": "Tim Burton",
+        "supporting_facts": {"title": ["Ed Wood"], "sent_id": [1]},
+        "context": {
+            "title": ["Ed Wood", "Distractor"],
+            "sentences": [
+                ["Ed Wood is a film. ", "It was directed by Tim Burton. "],
+                ["Unrelated filler text. "],
+            ],
+        },
+    }
+
+
+def _squad_row(idx: int, *, answerable: bool = True) -> dict[str, Any]:
+    return {
+        "id": f"sq{idx}",
+        "title": "Normans",
+        "context": "The Normans came from France in the 10th century.",
+        "question": "Where did the Normans come from?",
+        "answers": {"text": ["France"], "answer_start": [28]} if answerable else {"text": []},
+    }
+
+
+def _stub_rows(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, Any]]) -> list[str]:
+    """Serve `rows` through a fake rows API, recording each URL requested."""
+    seen: list[str] = []
+
+    def fake_get(url: str) -> dict[str, Any]:
+        seen.append(url)
+        offset = int(url.split("offset=")[1].split("&")[0])
+        length = int(url.split("length=")[1].split("&")[0])
+        page = rows[offset : offset + length]
+        return {"rows": [{"row": r} for r in page]}
+
+    monkeypatch.setattr(ds, "_get", fake_get)
+    return seen
+
+
+def test_hotpotqa_resolves_gold_sentences(monkeypatch: pytest.MonkeyPatch) -> None:
+    """supporting_facts is (title, sentence index); the loader must resolve it to the
+    actual sentence text, so retention is checked against text we can see."""
+    _stub_rows(monkeypatch, [_hotpot_row(0)])
+    (case,) = ds.load("hotpotqa", 1)
+    assert case.answer == "Tim Burton"
+    assert case.support == ["It was directed by Tim Burton."]
+    assert len(case.docs) == 2  # the distractor is kept: pruning it is distil's job
+    assert case.docs[0][0] == "Ed Wood"
+
+
+def test_hotpotqa_skips_unresolvable_supporting_facts(monkeypatch: pytest.MonkeyPatch) -> None:
+    row = _hotpot_row(0)
+    row["supporting_facts"] = {"title": ["Nonexistent"], "sent_id": [99]}
+    _stub_rows(monkeypatch, [row])
+    (case,) = ds.load("hotpotqa", 1)
+    assert case.support == []  # dropped, not crashed, not fabricated
+
+
+def test_squad_marks_unanswerable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_rows(monkeypatch, [_squad_row(0), _squad_row(1, answerable=False)])
+    answerable, unanswerable = ds.load("squad", 2)
+    assert answerable.answerable is True and answerable.answer == "France"
+    assert unanswerable.answerable is False and unanswerable.answer == ""
+
+
+def test_paging_respects_the_server_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rows API rejects length > 100, so 150 cases must arrive as two pages."""
+    seen = _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(150)])
+    cases = ds.load("hotpotqa", 150)
+    assert len(cases) == 150
+    assert len(seen) == 2
+    assert "length=100" in seen[0] and "offset=0" in seen[0]
+    assert "offset=100" in seen[1] and "length=50" in seen[1]
+
+
+def test_order_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A published number must be reproducible: same n, same cases, same order."""
+    _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(20)])
+    first = [c.id for c in ds.load("hotpotqa", 10)]
+    second = [c.id for c in ds.load("hotpotqa", 10)]
+    assert first == second == [f"case{i}" for i in range(10)]
+
+
+def test_cache_makes_the_second_run_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(5)])
+    ds.load("hotpotqa", 5)
+    assert len(seen) == 1
+    ds.load("hotpotqa", 5)  # served from cache
+    assert len(seen) == 1
+    assert ds.load("hotpotqa", 5, offline=True)[0].id == "case0"
+
+
+def test_offline_without_enough_cache_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(3)])
+    ds.load("hotpotqa", 3)
+    with pytest.raises(ds.DatasetUnavailable, match="offline mode has 3 cached rows, need 10"):
+        ds.load("hotpotqa", 10, offline=True)
+
+
+def test_truncated_cache_line_is_survivable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An interrupted write must not poison the cache: keep the intact prefix."""
+    _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(4)])
+    ds.load("hotpotqa", 4)
+    path = tmp_path / "datasets" / "hotpotqa.jsonl"
+    path.write_text(path.read_text(encoding="utf-8")[:-40] + "\n{partial", encoding="utf-8")
+    assert len(ds._read_cache("hotpotqa")) < 4  # prefix kept, junk line ignored
+
+
+def test_unknown_dataset_raises() -> None:
+    with pytest.raises(ds.DatasetUnavailable, match="unknown dataset"):
+        ds.load("nope", 1)
+
+
+def test_nonpositive_n_raises() -> None:
+    with pytest.raises(ds.DatasetUnavailable, match="n must be positive"):
+        ds.load("squad", 0)
+
+
+def test_empty_upstream_raises_not_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The failure mode that must never be silent: measuring zero cases."""
+    monkeypatch.setattr(ds, "_get", lambda url: {"rows": []})
+    with pytest.raises(ds.DatasetUnavailable, match="no rows"):
+        ds.load("hotpotqa", 10)
+
+
+def test_shape_change_upstream_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If every row fails to adapt, the schema moved — say so, do not report 0 cases."""
+    monkeypatch.setattr(ds, "_get", lambda url: {"rows": [{"row": {"unexpected": 1}}]})
+    with pytest.raises(ds.DatasetUnavailable, match="no rows survived adaptation"):
+        ds.load("hotpotqa", 1)
+
+
+def test_permanent_http_error_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def boom(request: Any, timeout: float = 0) -> Any:
+        calls["n"] += 1
+        raise urllib.error.HTTPError("u", 404, "Not Found", None, None)
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", boom)
+    with pytest.raises(ds.DatasetUnavailable, match="HTTP 404"):
+        ds.load("hotpotqa", 1)
+    assert calls["n"] == 1  # 404 is not retried
+
+
+def test_transient_error_is_retried_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+    payload = json.dumps({"rows": [{"row": _hotpot_row(0)}]}).encode()
+
+    class _Response:
+        def read(self) -> bytes:
+            return payload
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    def flaky(request: Any, timeout: float = 0) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError("u", 503, "Unavailable", None, None)
+        return _Response()
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", flaky)
+    monkeypatch.setattr(ds.time, "sleep", lambda s: None)
+    assert ds.load("hotpotqa", 1)[0].id == "case0"
+    assert calls["n"] == 2
+
+
+def test_exhausted_retries_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    def always_down(request: Any, timeout: float = 0) -> Any:
+        raise urllib.error.URLError("no route to host")
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", always_down)
+    monkeypatch.setattr(ds.time, "sleep", lambda s: None)
+    with pytest.raises(ds.DatasetUnavailable, match="unreachable after 3 attempts"):
+        ds.load("squad", 1)
+
+
+def test_non_dict_payload_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        def read(self) -> bytes:
+            return b"[1, 2, 3]"
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    monkeypatch.setattr(ds.urllib.request, "urlopen", lambda r, timeout=0: _Response())
+    with pytest.raises(ds.DatasetUnavailable, match="unexpected payload"):
+        ds.load("squad", 1)
+
+
+def test_short_page_ends_paging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Upstream returning fewer rows than asked means end-of-split, not an error."""
+    _stub_rows(monkeypatch, [_hotpot_row(i) for i in range(7)])
+    assert len(ds.load("hotpotqa", 100)) == 7
+
+
+def test_blank_cache_lines_are_ignored(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _stub_rows(monkeypatch, [_hotpot_row(0)])
+    ds.load("hotpotqa", 1)
+    path = tmp_path / "datasets" / "hotpotqa.jsonl"
+    path.write_text("\n\n" + path.read_text(encoding="utf-8") + "\n\n", encoding="utf-8")
+    assert len(ds._read_cache("hotpotqa")) == 1
+
+
+def test_bad_sent_id_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer sentence index must be dropped, not raise."""
+    row = _hotpot_row(0)
+    row["supporting_facts"] = {"title": ["Ed Wood"], "sent_id": ["not-an-int"]}
+    _stub_rows(monkeypatch, [row])
+    assert ds.load("hotpotqa", 1)[0].support == []
+
+
+def test_hotpot_row_missing_answer_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    good, bad = _hotpot_row(0), _hotpot_row(1)
+    bad["answer"] = ""
+    _stub_rows(monkeypatch, [good, bad])
+    assert [c.id for c in ds.load("hotpotqa", 2)] == ["case0"]
+
+
+def test_hotpot_mismatched_context_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    good, bad = _hotpot_row(0), _hotpot_row(1)
+    bad["context"] = {"title": ["A", "B"], "sentences": [["only one"]]}
+    _stub_rows(monkeypatch, [good, bad])
+    assert [c.id for c in ds.load("hotpotqa", 2)] == ["case0"]
+
+
+def test_squad_row_without_context_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    good, bad = _squad_row(0), _squad_row(1)
+    bad["context"] = "   "
+    _stub_rows(monkeypatch, [good, bad])
+    assert [c.id for c in ds.load("squad", 2)] == ["sq0"]
+
+
+def test_available_lists_every_spec() -> None:
+    names = {name for name, _ in ds.available()}
+    assert names == set(ds.SPECS)
+    assert all(description for _, description in ds.available())

--- a/tests/test_htmlx.py
+++ b/tests/test_htmlx.py
@@ -112,6 +112,63 @@ def test_nested_dropped_subtree_does_not_swallow_the_rest() -> None:
     assert "inner" not in out
 
 
+def test_unclosed_chrome_does_not_swallow_the_article() -> None:
+    """Audit finding. Chrome skipping keyed off a matching close tag, and real HTML
+    often never sends one — so content BEFORE an unclosed <aside> was emitted while the
+    actual article after it was silently dropped. A content landmark ends the skip."""
+    html = (
+        "<!DOCTYPE html><html><body>"
+        "<article><h1>Kept Title</h1><p>Intro paragraph.</p></article>"
+        "<aside>sidebar"  # never closed
+        "<article><h2>Second Section</h2>"
+        + "<p>Body fact=42 that must survive.</p>" * 40
+        + "</article></body></html>"
+    )
+    out = extract(html)
+    assert out is not None
+    assert "Kept Title" in out
+    assert "Second Section" in out  # was lost before the fix
+    assert "fact=42" in out
+
+
+def test_unclosed_chrome_without_a_landmark_hits_the_budget() -> None:
+    """Backstop for <div>-built chrome, where no <article>/<main> follows to recover on:
+    the skip is abandoned once it has eaten more than a plausible nav's worth of text."""
+    html = (
+        "<!DOCTYPE html><html><body><nav>"
+        + ("<span>navjunk</span>" * 60)
+        + ("<div><p>Real body fact=7 in a div-built page.</p></div>" * 400)
+        + "</body></html>"
+    )
+    out = extract(html)
+    assert out is not None and "fact=7" in out
+
+
+def test_well_formed_chrome_is_still_dropped() -> None:
+    """The fixes must not cost the savings: closed nav/footer still go."""
+    html = _page("<h1>T</h1>" + "<p>Article body sentence.</p>" * 40)
+    out = extract(html)
+    assert out is not None
+    assert "NavLink" not in out and "footjunk" not in out
+    assert "Article body" in out
+
+
+def test_script_payload_is_never_budget_capped() -> None:
+    """A huge <script> is legitimately huge — the budget backstop must not resume
+    collecting inside it and leak minified JS into the output."""
+    html = (
+        "<!DOCTYPE html><html><head><script>"
+        + ("var averylongvariablename=1;" * 4000)
+        + "</script></head><body><article>"
+        + "<p>Body text here.</p>" * 30
+        + "</article></body></html>"
+    )
+    out = extract(html)
+    assert out is not None
+    assert "averylongvariablename" not in out
+    assert "Body text" in out
+
+
 def test_declines_when_not_worthwhile() -> None:
     """Markup that is already almost all text is not worth a marker + restore entry."""
     html = "<div><p>" + ("Almost entirely readable prose content here. " * 40) + "</p></div>"

--- a/tests/test_htmlx.py
+++ b/tests/test_htmlx.py
@@ -1,0 +1,234 @@
+"""Reversible HTML extraction.
+
+The transform is lossy-but-recoverable, which makes two properties load-bearing: it
+must be *recall-biased* (never drop something that could be article content) and it
+must be *reversible* (the exact original recoverable from the handle). It must also
+decline politely — on non-HTML, on fragments too small to be worth a restore entry,
+and on anything it cannot parse.
+"""
+
+from __future__ import annotations
+
+import json
+
+from distil.adapters.anthropic import compress_messages
+from distil.compress.htmlx import extract, looks_like_html
+from distil.compress.tier1 import Tier1Reversible
+from distil.tokenizer import DEFAULT as TOK
+from distil.trajectory import Block, Kind, Stability
+
+
+def _page(body: str, *, head: str = "", chrome: bool = True) -> str:
+    noise = (
+        "<script>var x=1;" + ("/*pad*/" * 200) + "</script>"
+        "<style>" + (".c{color:red}" * 200) + "</style>"
+    )
+    nav = "<nav>" + ('<a href="/x">NavLink</a>' * 100) + "</nav>" if chrome else ""
+    foot = "<footer>" + ("<span>footjunk</span>" * 200) + "</footer>" if chrome else ""
+    return (
+        f"<!DOCTYPE html><html><head>{head}{noise}</head>"
+        f"<body>{nav}<article>{body}</article>{foot}</body></html>"
+    )
+
+
+# --------------------------------------------------------------------------- detection
+
+
+def test_detects_documents() -> None:
+    assert looks_like_html(_page("<p>hello world and some more text to clear the floor</p>"))
+
+
+def test_rejects_short_input() -> None:
+    assert looks_like_html("<html><body><p>hi</p></body></html>") is False
+
+
+def test_rejects_prose_and_logs() -> None:
+    assert not looks_like_html("Just a long paragraph of prose. " * 40)
+    log = "\n".join(f"2026-07-29 INFO worker-{i} latency_ms={i} ok" for i in range(60))
+    assert not looks_like_html(log)
+
+
+def test_rejects_a_stray_tag_in_a_log() -> None:
+    """A log line mentioning markup must not be routed through an HTML extractor."""
+    log = "\n".join(f"2026-07-29 ERROR parse failed near <div> at line {i}" for i in range(40))
+    assert not looks_like_html(log)
+
+
+def test_tag_density_accepts_a_real_fragment() -> None:
+    fragment = "<ul>" + "".join(f"<li>Item number {i} with text</li>" for i in range(30)) + "</ul>"
+    assert looks_like_html(fragment)
+
+
+# --------------------------------------------------------------------------- extraction
+
+
+def test_strips_noise_keeps_content() -> None:
+    html = _page("<h1>Real Title</h1><p>Body sentence with latency_ms=42 in it.</p>" * 20)
+    out = extract(html)
+    assert out is not None
+    assert "Real Title" in out and "latency_ms=42" in out
+    assert "/*pad*/" not in out and "color:red" not in out
+    assert "NavLink" not in out and "footjunk" not in out
+
+
+def test_header_is_kept_because_it_holds_titles() -> None:
+    """Recall bias: `header` is ambiguous chrome and commonly wraps the h1, so unlike
+    nav/footer/aside it must NOT be dropped."""
+    html = _page("<header><h1>The Headline</h1></header><p>Body text here.</p>" * 20)
+    out = extract(html)
+    assert out is not None and "The Headline" in out
+
+
+def test_image_alt_text_survives() -> None:
+    """Alt text is often the only description of a figure — real content."""
+    html = _page('<p>Intro text.</p><img src="/a.png" alt="Chart of latency by region">' * 20)
+    out = extract(html)
+    assert out is not None and "Chart of latency by region" in out
+
+
+def test_entities_are_decoded() -> None:
+    html = _page("<p>Fish &amp; Chips cost &lt;5 &#39;quid&#39; today.</p>" * 20)
+    out = extract(html)
+    assert out is not None
+    assert "Fish & Chips" in out and "<5" in out and "'quid'" in out
+
+
+def test_output_is_line_oriented() -> None:
+    """Block tags become newlines, which re-arms the line-based machinery downstream."""
+    html = _page("".join(f"<p>Paragraph number {i} of the body.</p>" for i in range(40)))
+    out = extract(html)
+    assert out is not None and out.count("\n") > 20
+
+
+def test_nested_dropped_subtree_does_not_swallow_the_rest() -> None:
+    """A nested same-named tag inside a dropped subtree must not unbalance the skip."""
+    html = _page(
+        "<p>Before the noise.</p><nav><div><nav>inner</nav></div></nav>"
+        "<p>After the noise, still content with fact=7.</p>" * 20
+    )
+    out = extract(html)
+    assert out is not None
+    assert "After the noise" in out and "fact=7" in out
+    assert "inner" not in out
+
+
+def test_declines_when_not_worthwhile() -> None:
+    """Markup that is already almost all text is not worth a marker + restore entry."""
+    html = "<div><p>" + ("Almost entirely readable prose content here. " * 40) + "</p></div>"
+    assert extract(html) is None
+
+
+def test_declines_on_non_html() -> None:
+    assert extract("Just prose, no markup at all. " * 40) is None
+
+
+def test_empty_body_declines() -> None:
+    html = "<!DOCTYPE html><html><head><script>" + ("x=1;" * 400) + "</script></head></html>"
+    assert extract(html) is None
+
+
+def test_malformed_markup_is_survived() -> None:
+    """Never raise: unclosed tags, stray brackets, truncated documents."""
+    for junk in (
+        "<!DOCTYPE html><html><body><p>unclosed" + ("<div>" * 500),
+        "<html><body>" + ("<<<>>>" * 300) + "<p>text</p>",
+        "<!DOCTYPE html><html><body><p>" + ("a" * 2000),
+    ):
+        extract(junk)  # must not raise
+
+
+# --------------------------------------------------------------------------- integration
+
+
+def test_tier1_digests_html_reversibly() -> None:
+    html = _page("<h1>T</h1><p>Body with fact=99 inside.</p>" * 30)
+    block = Block(id="b", kind=Kind.TOOL_OUTPUT, text=html, stability=Stability.VOLATILE)
+    result = Tier1Reversible().compress([block])
+    out = result.blocks[0].text
+    assert "handle=" in out
+    assert len(out) < len(html)
+    assert list(result.restore.values()) == [html]  # byte-exact original
+
+
+def test_live_path_saves_and_stays_recoverable() -> None:
+    """The measured gap this closes: 0% savings on HTML through the real adapter."""
+    html = _page("<h1>Real Title</h1><p>Body sentence with latency_ms=42.</p>" * 40)
+
+    def tr(text: str) -> dict:
+        return {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t", "content": text}],
+        }
+
+    messages = [tr(html)] + [tr(f"later tool result {i}") for i in range(4)]
+    compressed, store = compress_messages(messages)
+
+    before = TOK.count(json.dumps(messages[0]))
+    after = TOK.count(json.dumps(compressed[0]))
+    assert after < before * 0.4  # measured ~91% on this shape
+
+    handles = list(store.handles)
+    assert len(handles) == 1
+    assert store.expand(handles[0]) == html  # exact original, one expand away
+
+    seen = json.dumps(compressed[0])
+    assert "Real Title" in seen and "latency_ms=42" in seen
+    assert "/*pad*/" not in seen and "NavLink" not in seen
+
+
+def test_recent_tool_result_stays_byte_exact() -> None:
+    """The recency rule outranks the transform: the agent's latest output is untouched."""
+    html = _page("<h1>T</h1><p>Body fact=1.</p>" * 40)
+
+    def tr(text: str) -> dict:
+        return {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t", "content": text}],
+        }
+
+    compressed, store = compress_messages([tr(html)])
+    assert json.dumps(compressed[0]) == json.dumps(tr(html))
+    assert not list(store.handles)
+
+
+def test_verbatim_mode_never_extracts() -> None:
+    """Verbatim means no expand tool is available, so an unrecoverable elision is
+    forbidden — even a big win."""
+    html = _page("<h1>T</h1><p>Body fact=1.</p>" * 40)
+
+    def tr(text: str) -> dict:
+        return {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t", "content": text}],
+        }
+
+    messages = [tr(html)] + [tr(f"later {i}") for i in range(4)]
+    compressed, store = compress_messages(messages, verbatim=True)
+    assert "html chrome elided" not in json.dumps(compressed[0])
+    assert not list(store.handles)
+
+
+def test_retention_on_html_loses_nothing() -> None:
+    """Grade the new transform with the retention probe: facts may move behind a
+    handle, but none may be lost."""
+    from distil.retention import measure_live
+
+    html = _page(
+        "<h1>Report</h1>"
+        + "".join(
+            f"<p>Row {i}: latency_ms={i * 3} path=/srv/data/file-{i}.csv</p>" for i in range(60)
+        )
+        + "<p>ERROR: upstream refused connection</p>"
+    )
+
+    def tr(text: str) -> dict:
+        return {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t", "content": text}],
+        }
+
+    messages = [tr(html)] + [tr(f"later tool result {i}") for i in range(4)]
+    compressed, store = compress_messages(messages)
+    dims = measure_live(messages, compressed, store)
+    assert sum(t.total for t in dims.values()) > 0
+    assert sum(t.lost for t in dims.values()) == 0  # nothing unrecoverable

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -9,6 +9,8 @@ conversions Tier-0 legitimately performs.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from distil.retention import (
@@ -290,6 +292,32 @@ def test_dataset_report_serializes_both_arms() -> None:
     assert payload["dataset"] == "hotpotqa" and payload["shape"] == "json"
     assert payload["compression_engaged"] is True
     assert set(payload["distil"]) == set(payload["baseline"]) - {"label"}
+
+
+def test_report_encodes_on_a_windows_console() -> None:
+    """U+2588 is not in cp1252, so printing the bar to a stock Windows console raised
+    UnicodeEncodeError and took down the retention CI gate on windows-latest while
+    every POSIX leg passed. Every rendered surface must survive that encoding."""
+    import io
+    import sys
+
+    from distil.retention import LiveMeter, _bar_char, format_live, load_live
+
+    real = sys.stdout
+    try:
+        sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        assert _bar_char() == "#"  # degrades rather than raising
+        corpus = format_report(run())
+        dims, requests = load_live(Path(__file__).parent / "does-not-exist.jsonl")
+        live = format_live(dims, requests)
+    finally:
+        sys.stdout = real
+
+    for rendered in (corpus, live):
+        rendered.encode("cp1252")  # raises if any glyph is unencodable
+
+    assert _bar_char() == "█"  # and keeps the block glyph where it is supported
+    assert LiveMeter(0.0).enabled is False
 
 
 def test_corpus_is_lossless_and_gains_from_reversibility() -> None:

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,314 @@
+"""Fact-level retention probe — the metric must be able to FAIL.
+
+A recall gate that can only ever report 100% is theater. These tests pin the three
+things that make the number real: it detects genuine loss, it does not credit a
+handle whose restore bytes lack the fact (the block-scoped, *verified* recoverability
+that distil claims over marker-presence heuristics), and it tolerates the format
+conversions Tier-0 legitimately performs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distil.retention import (
+    RetentionReport,
+    extract_targets,
+    format_report,
+    probe_block,
+    run,
+)
+from distil.trajectory import Block, Kind, Stability
+
+
+def _vol(text: str, bid: str = "b1") -> Block:
+    return Block(id=bid, kind=Kind.TOOL_OUTPUT, text=text, stability=Stability.VOLATILE)
+
+
+ORIGINAL = (
+    'status: ok\n"latency_ms": 1234\n'
+    "/var/log/app/worker.log\n"
+    "ERROR: connection refused to db-primary\n"
+)
+
+
+def test_verbatim_is_fully_retained() -> None:
+    probe = probe_block(_vol(ORIGINAL), ORIGINAL, {})
+    for dim, tally in probe.dims.items():
+        assert tally.total > 0, dim
+        assert tally.lost == 0
+        assert tally.visible_recall == 1.0
+
+
+def test_truncation_loses_facts() -> None:
+    """The gate's teeth: lossy compression with no restore table must report loss."""
+    probe = probe_block(_vol(ORIGINAL), "status: ok\n", {})
+    overall_lost = sum(t.lost for t in probe.dims.values())
+    assert overall_lost > 0
+    assert probe.dims["errors"].lost == 1
+    assert probe.dims["errors"].recall == 0.0
+
+
+def test_handle_without_the_fact_is_lost_not_recoverable() -> None:
+    """Recoverability is verified against the restore BYTES, never inferred from a
+    marker. A handle whose original lacks the fact must not launder it."""
+    compressed = "<< +3 lines, handle=deadbeef >>"
+    probe = probe_block(_vol(ORIGINAL), compressed, {"deadbeef": "unrelated content"})
+    assert probe.dims["errors"].recoverable == 0
+    assert probe.dims["errors"].lost == 1
+
+    # Same marker, restore bytes that DO contain the fact -> recoverable, not lost.
+    probe = probe_block(_vol(ORIGINAL), compressed, {"deadbeef": ORIGINAL})
+    assert probe.dims["errors"].recoverable == 1
+    assert probe.dims["errors"].lost == 0
+    assert probe.dims["errors"].recall == 1.0
+    assert probe.dims["errors"].visible_recall == 0.0
+
+
+def test_foreign_handle_is_not_credited() -> None:
+    """Recoverability is block-scoped: a handle this block does not carry cannot
+    make its missing facts recoverable, even if the restore entry exists."""
+    probe = probe_block(_vol(ORIGINAL), "status: ok\n", {"deadbeef": ORIGINAL})
+    assert sum(t.recoverable for t in probe.dims.values()) == 0
+    assert probe.dims["errors"].lost == 1
+
+
+def test_tier0_reshape_counts_as_retained() -> None:
+    """A JSON->table conversion keeps key and value in different cells; both present
+    means the fact survived, so it must not be scored as loss."""
+    probe = probe_block(_vol('{"latency_ms": 1234}'), "«cols=latency_ms«\n1234", {})
+    assert probe.dims["numerics"].retained == 1
+
+
+def test_numeric_needs_key_and_value() -> None:
+    """A stray matching integer must not fake a hit when its key is gone."""
+    probe = probe_block(_vol('"latency_ms": 1234'), "unrelated 1234", {})
+    assert probe.dims["numerics"].retained == 0
+    assert probe.dims["numerics"].lost == 1
+
+
+def test_bare_numbers_are_not_probed() -> None:
+    """Numbers with no key context are unverifiable noise, not facts."""
+    assert extract_targets("1234 5678 9012")["numerics"] == set()
+
+
+def test_empty_report_is_neutral() -> None:
+    empty = RetentionReport()
+    assert empty.overall().recall == 1.0
+    assert empty.lost_facts == 0
+    assert "0 compressed blocks probed" in format_report(empty)
+
+
+def test_error_survives_losing_its_json_key() -> None:
+    """'"msg": "ERROR: refused"' reshaped to a bare cell still carries the substance."""
+    probe = probe_block(_vol('"msg": "ERROR: connection refused"'), "ERROR connection refused", {})
+    assert probe.dims["errors"].retained == 1
+
+
+def test_block_id_restore_key_is_credited() -> None:
+    """Tier-0 keys its restore table by block id, not by an in-text handle."""
+    probe = probe_block(_vol(ORIGINAL, bid="blk7"), "status: ok\n", {"blk7": ORIGINAL})
+    assert probe.dims["errors"].recoverable == 1
+    assert probe.dims["errors"].lost == 0
+
+
+def test_turn_without_volatile_blocks_is_skipped() -> None:
+    from distil.corpus import CorpusEntry
+    from distil.retention import probe_trajectory
+    from distil.trajectory import Trajectory, Turn
+
+    stable = Block(id="s", kind=Kind.SYSTEM, text="fixed", stability=Stability.STABLE)
+    traj = Trajectory(id="t", model="claude-sonnet-4-5", turns=[Turn(index=0, blocks=[stable])])
+    report = probe_trajectory(CorpusEntry("f.json", "test", "t", traj))
+    assert report.probes == []
+
+
+class _Case:
+    """A GroundTruthCase stand-in (no network, no dataset dependency)."""
+
+    def __init__(
+        self,
+        docs: list[tuple[str, str]],
+        answer: str,
+        support: list[str] | None = None,
+        answerable: bool = True,
+    ) -> None:
+        self.id = "c1"
+        self.question = "q?"
+        self.docs = docs
+        self.answer = answer
+        self.support = support or []
+        self.answerable = answerable
+        self.dataset = "synthetic"
+
+
+def _rows(n: int, marker: str = "") -> list[tuple[str, str]]:
+    return [(f"doc{i}", f"Paragraph {i} filler sentence about things. {marker}") for i in range(n)]
+
+
+def test_unanswerable_is_excluded_not_counted_as_a_pass() -> None:
+    from distil.retention import score_dataset
+
+    rep = score_dataset([_Case(_rows(3), "", answerable=False)], "t")
+    assert rep.ungraded("unanswerable") == 1
+    assert rep._answer_recall(rep.scores, with_recovery=True) == (1.0, 0)  # 0 graded
+
+
+def test_abstractive_answer_is_excluded_not_scored_as_loss() -> None:
+    """HotpotQA's yes/no answers are never spans in the passage. Grading them would
+    report the dataset's answer FORMAT as compression loss — the defect this pins."""
+    from distil.retention import score_dataset
+
+    rep = score_dataset([_Case(_rows(3), "yes")], "t")
+    assert rep.ungraded("abstractive") == 1
+    assert rep.scores[0].answer_retained is None
+
+
+def test_answer_present_in_context_is_graded() -> None:
+    from distil.retention import score_dataset
+
+    case = _Case([("d", "The director was Tim Burton.")], "Tim Burton")
+    # Graded (not excluded as abstractive), and reachable either way.
+    rep = score_dataset([case], "t")
+    assert rep.ungraded("abstractive") == 0
+    assert rep.scores[0].answer_retained is not None
+    assert rep._answer_recall(rep.scores, with_recovery=True) == (1.0, 1)
+
+    # Under `prose` there is nothing to compress, so it must be VISIBLY retained.
+    prose = score_dataset([case], "t", shape="prose")
+    assert prose.scores[0].answer_retained is True
+
+
+def test_support_is_gated_on_presence_in_the_original() -> None:
+    """A gold sentence that was never in the context cannot be 'lost' by compression."""
+    from distil.retention import score_dataset
+
+    case = _Case([("d", "Real sentence here.")], "Real", support=["Absent sentence."])
+    rep = score_dataset([case], "t")
+    assert rep.scores[0].support_total == 0
+
+
+def test_unengaged_compression_is_flagged_not_celebrated() -> None:
+    """Short prose does not compress; a 100% recall on an identity transform must warn."""
+    from distil.retention import format_dataset_report, score_dataset
+
+    rep = score_dataset([_Case([("d", "Tiny prose.")], "Tiny")], "t", shape="prose")
+    assert not rep.engaged
+    assert "WARNING: compression barely engaged" in format_dataset_report(rep)
+
+
+def test_json_shape_engages_compression() -> None:
+    """The production shape (a retrieval tool's JSON array) is what distil compresses."""
+    from distil.retention import score_dataset
+
+    rep = score_dataset([_Case(_rows(12), "filler")], "t", shape="json")
+    assert rep.engaged
+    assert rep.savings > 0.0
+
+
+def test_baseline_savings_match_distil() -> None:
+    """The comparison is only fair at equal cost — pin that the baseline is not cheaper."""
+    from distil.retention import DatasetReport, score_dataset
+
+    rep = score_dataset([_Case(_rows(12), "filler")], "t")
+    distil_savings = DatasetReport._savings(rep.scores)
+    baseline_savings = DatasetReport._savings(rep.baseline)
+    assert baseline_savings >= distil_savings - 0.05
+
+
+def test_baseline_has_no_recovery_path() -> None:
+    """Truncation is lossy by construction: nothing may be scored as recoverable."""
+    from distil.retention import score_dataset
+
+    rep = score_dataset([_Case(_rows(12), "filler")], "t")
+    assert all(not s.answer_recoverable for s in rep.baseline)
+    assert all(s.support_recoverable == 0 for s in rep.baseline)
+
+
+def test_support_recall_reported_when_gold_sentences_survive() -> None:
+    from distil.retention import format_dataset_report, score_dataset
+
+    gold = "It was directed by Tim Burton."
+    case = _Case([("d", f"Ed Wood is a film. {gold}")], "Tim Burton", support=[gold])
+    rep = score_dataset([case], "t", shape="prose")
+    assert rep.scores[0].support_total == 1
+    assert rep.scores[0].support_retained == 1
+    assert rep._support_recall(rep.scores, with_recovery=False) == (1.0, 1)
+    assert "support recall" in format_dataset_report(rep)
+
+
+def test_support_behind_a_handle_is_recoverable_not_lost() -> None:
+    """Gold sentences digested into the restore table count as recoverable — the
+    distinction a lossy compressor cannot make."""
+    from distil.retention import score_dataset
+
+    gold = "The director was Tim Burton."
+    case = _Case([("d", gold * 40)], "Tim Burton", support=[gold])
+    rep = score_dataset([case], "t")
+    score = rep.scores[0]
+    assert score.support_total == 1
+    assert score.support_retained == 0  # digested out of the visible text
+    assert score.support_recoverable == 1  # but proven present in the restore bytes
+    assert rep._support_recall(rep.scores, with_recovery=False) == (0.0, 1)
+    assert rep._support_recall(rep.scores, with_recovery=True) == (1.0, 1)
+
+
+def test_exclusions_appear_in_the_rendered_report() -> None:
+    from distil.retention import format_dataset_report, score_dataset
+
+    rep = score_dataset(
+        [_Case(_rows(3), "", answerable=False), _Case(_rows(3), "yes")], "t", shape="prose"
+    )
+    rendered = format_dataset_report(rep)
+    assert "marked unanswerable" in rendered
+    assert "not a span in the passage" in rendered
+
+
+def test_low_visible_recall_is_called_out() -> None:
+    """100% recall with everything behind a handle is lossless but costs round trips,
+    and the report must say so rather than only showing the reassuring number."""
+    from distil.retention import format_dataset_report, score_dataset
+
+    rep = score_dataset([_Case([("d", "The director was Tim Burton. " * 40)], "Tim Burton")], "t")
+    visible, graded = rep._answer_recall(rep.scores, with_recovery=False)
+    true, _ = rep._answer_recall(rep.scores, with_recovery=True)
+    assert graded == 1 and visible == 0.0 and true == 1.0
+    assert "NOTE: only 0.0% of answers are visible" in format_dataset_report(rep)
+
+
+def test_bad_shape_rejected() -> None:
+    from distil.retention import score_dataset
+
+    with pytest.raises(ValueError, match="shape must be"):
+        score_dataset([_Case(_rows(2), "x")], "t", shape="yaml")
+
+
+def test_dataset_report_serializes_both_arms() -> None:
+    from distil.retention import score_dataset
+
+    payload = score_dataset([_Case(_rows(12), "filler")], "hotpotqa").to_dict()
+    assert payload["dataset"] == "hotpotqa" and payload["shape"] == "json"
+    assert payload["compression_engaged"] is True
+    assert set(payload["distil"]) == set(payload["baseline"]) - {"label"}
+
+
+def test_corpus_is_lossless_and_gains_from_reversibility() -> None:
+    """The real corpus on the real pipeline: Tier-1/0 are lossless by construction,
+    so nothing may be lost — and some facts must land behind a handle, otherwise the
+    recoverable path is untested by this suite."""
+    report = run()
+    overall = report.overall()
+    assert overall.total > 0
+    assert overall.lost == 0
+    assert overall.recall == 1.0
+    assert overall.recoverable > 0, "no digested facts — the recoverable path is unexercised"
+    assert overall.visible_recall < 1.0
+
+    rendered = format_report(report)
+    assert "reversibility is worth" in rendered
+    assert "by block savings:" in rendered
+
+    payload = report.to_dict()
+    assert payload["overall"] == overall.to_dict()
+    assert set(payload["by_dimension"]) == {"numerics", "artifacts", "errors"}
+    assert any(b["total"] for b in payload["by_savings_bucket"].values())

--- a/tests/test_retention_cli.py
+++ b/tests/test_retention_cli.py
@@ -1,0 +1,181 @@
+"""`distil retention` CLI surface — exit codes are the contract.
+
+These are the paths a CI job depends on, so what matters is that a bad outcome exits
+non-zero and a good one exits zero. No network: the dataset loader is stubbed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from distil import datasets as ds
+from distil.cli import main
+
+
+class _Case:
+    def __init__(self, docs: list[tuple[str, str]], answer: str, support: list[str]) -> None:
+        self.id = "c1"
+        self.question = "q?"
+        self.docs = docs
+        self.answer = answer
+        self.support = support
+        self.answerable = True
+        self.dataset = "stub"
+
+
+def _compressible(answer: str = "Tim Burton") -> list[_Case]:
+    docs = [
+        (f"d{i}", f"Paragraph {i} about films and directors. id={i} path=/srv/x{i}.txt")
+        for i in range(12)
+    ]
+    docs.append(("gold", f"The director was {answer}."))
+    return [_Case(docs, answer, [f"The director was {answer}."])]
+
+
+def test_corpus_mode_passes(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["retention"]) == 0
+    assert "fact-level retention" in capsys.readouterr().out
+
+
+def test_corpus_gate_passes_at_zero_lost(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["retention", "--max-lost", "0"]) == 0
+
+
+def test_corpus_gate_fails_when_budget_is_impossible(capsys: pytest.CaptureFixture[str]) -> None:
+    """A negative budget can never be met — proves the gate can actually fail."""
+    assert main(["retention", "--max-lost", "-1"]) == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_corpus_json_is_machine_readable(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["retention", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["overall"]["lost"] == 0
+    assert set(payload["by_dimension"]) == {"numerics", "artifacts", "errors"}
+
+
+def test_dataset_list(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["retention", "--dataset", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "hotpotqa" in out and "squad" in out
+
+
+def test_dataset_mode_scores_and_passes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(ds, "load", lambda name, n, offline=False: _compressible())
+    assert main(["retention", "--dataset", "hotpotqa", "-n", "1", "--min-recall", "0.9"]) == 0
+    assert "public benchmark" in capsys.readouterr().out
+
+
+def test_dataset_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(ds, "load", lambda name, n, offline=False: _compressible())
+    assert main(["retention", "--dataset", "hotpotqa", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dataset"] == "hotpotqa"
+    assert "baseline" in payload and "distil" in payload
+
+
+def test_fetch_failure_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The failure that must never be silent: a gate that measured nothing."""
+
+    def boom(name: str, n: Any, offline: bool = False) -> Any:
+        raise ds.DatasetUnavailable("datasets-server unreachable after 3 attempts")
+
+    monkeypatch.setattr(ds, "load", boom)
+    assert main(["retention", "--dataset", "hotpotqa", "--min-recall", "0.99"]) == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_min_recall_rejects_unengaged_compression(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Short prose does not compress; a recall gate must NOT pass on an identity
+    transform, because 100% there is arithmetic rather than evidence."""
+    monkeypatch.setattr(
+        ds, "load", lambda name, n, offline=False: [_Case([("d", "Tiny.")], "Tiny", [])]
+    )
+    code = main(["retention", "--dataset", "squad", "--shape", "prose", "--min-recall", "0.99"])
+    assert code == 1
+    assert "compression did not engage" in capsys.readouterr().out
+
+
+def test_min_recall_fails_on_a_real_regression(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Force genuine loss by making the answer absent from the compressed text AND
+    from any restore entry: the gate must fail rather than round up."""
+    import distil.retention as r
+
+    monkeypatch.setattr(ds, "load", lambda name, n, offline=False: _compressible())
+
+    def lost_report(cases: Any, dataset: str = "", *, shape: str = "json") -> r.DatasetReport:
+        # Engaged compression (savings well above the floor) that lost the answer with
+        # no recovery path — the one outcome the gate exists to catch.
+        rep = r.DatasetReport(dataset=dataset, shape=shape)
+        rep.scores.append(
+            r.CaseScore(case_id="c1", savings=0.4, answer_retained=False, answer_recoverable=False)
+        )
+        rep.baseline.append(
+            r.CaseScore(case_id="c1", savings=0.4, answer_retained=False, answer_recoverable=False)
+        )
+        return rep
+
+    monkeypatch.setattr(r, "score_dataset", lost_report)
+    code = main(["retention", "--dataset", "hotpotqa", "--min-recall", "0.99"])
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "answer recall 0.0% < --min-recall" in out
+
+
+def test_live_mode_reads_the_meter(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    assert main(["retention", "--live"]) == 0
+    assert "no live retention samples yet" in capsys.readouterr().out
+
+    from distil.retention import LiveMeter
+
+    original = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t",
+                    "content": "latency_ms=42 path=/var/log/app/a.log",
+                }
+            ],
+        }
+    ]
+    LiveMeter(1.0).observe(original, original, None)
+    assert main(["retention", "--live"]) == 0
+    assert "live fact retention" in capsys.readouterr().out
+
+
+def test_worker_config_carries_retention_rate() -> None:
+    """wrap's default path runs the proxy in a hot-swap WORKER, so a flag that is not
+    in WorkerConfig silently never takes effect there."""
+    from distil.hotswap import WorkerConfig
+
+    cfg = WorkerConfig(upstream="http://x", retention_rate=0.25)
+    assert json.loads(cfg.to_env())["retention_rate"] == 0.25
+
+
+def test_worker_config_tolerates_unknown_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mid-upgrade, a newer supervisor can spawn an older worker. An unrecognised
+    config key must not kill the session."""
+    from distil.hotswap import WorkerConfig
+
+    monkeypatch.setenv(
+        "DISTIL_WORKER_CONFIG",
+        json.dumps({"upstream": "http://x", "retention_rate": 0.5, "from_the_future": True}),
+    )
+    cfg = WorkerConfig.from_env()
+    assert cfg.upstream == "http://x" and cfg.retention_rate == 0.5

--- a/tests/test_retention_live.py
+++ b/tests/test_retention_live.py
@@ -175,6 +175,56 @@ def test_anthropic_text_block_content_is_read() -> None:
     assert dims["numerics"].total > 0 and dims["artifacts"].total > 0
 
 
+def test_no_disk_read_for_handles_outside_the_store() -> None:
+    """Audit finding: expand() falls back to a synchronous disk read for unknown
+    handles, and this runs in the request path. Tool output that merely CONTAINS
+    'handle=deadbeef' would have turned one sampled request into file reads."""
+    reads: list[str] = []
+
+    class _Tracking:
+        handles = frozenset({"aaaaaaaa"})
+
+        def expand(self, handle: str) -> str:
+            reads.append(handle)
+            return "recovered bytes"
+
+    original = [_tool_result("latency_ms=42 path=/var/log/app/a.log")]
+    # A stub naming a handle the store does not hold — must never be consulted.
+    compressed = [_tool_result("<< +9 lines, handle=deadbeef >>")]
+    measure_live(original, compressed, _Tracking())
+    assert reads == []  # no lookup at all, so no disk fallback can fire
+
+    # A handle the store DOES hold is still consulted.
+    compressed_known = [_tool_result("<< +9 lines, handle=aaaaaaaa >>")]
+    measure_live(original, compressed_known, _Tracking())
+    assert reads == ["aaaaaaaa"]
+
+
+def test_store_without_a_handles_property_is_tolerated() -> None:
+    class _Bare:
+        def expand(self, handle: str) -> str:
+            raise AssertionError("must not be called without a handles set")
+
+    original = [_tool_result("latency_ms=42 path=/var/log/app/a.log")]
+    compressed = [_tool_result("<< +9 lines, handle=deadbeef >>")]
+    dims = measure_live(original, compressed, _Bare())
+    assert sum(t.lost for t in dims.values()) > 0
+
+
+def test_short_values_are_not_credited_by_a_loose_substring() -> None:
+    """Audit finding: a bare substring test inflated recoverable recall — "12" matches
+    inside "file-12.csv"."""
+    from distil.retention import _in_recovery
+
+    haystack = "see /srv/data/file-12.csv and hash a12b3c4d5e6f7 plus port=8012"
+    assert _in_recovery("12", haystack) is False
+    assert _in_recovery("5", haystack) is False
+    assert _in_recovery("12", "the count was 12 items") is True
+    assert _in_recovery("file-12.csv", haystack) is True
+    assert _in_recovery("", haystack) is False
+    assert _in_recovery("x", "") is False
+
+
 def test_unknown_handle_in_text_is_skipped() -> None:
     """A marker naming a handle the store cannot expand must not raise or credit."""
 

--- a/tests/test_retention_live.py
+++ b/tests/test_retention_live.py
@@ -1,0 +1,266 @@
+"""Live retention meter — content-free, sampled, fail-open.
+
+The meter runs in the request path and is the one part of the retention work that
+touches real user content, so these tests are about the guarantees rather than the
+arithmetic: a unique marker planted in tool output must NEVER reach disk, an
+exception must never propagate, and sampling must actually gate the work.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from distil.adapters.anthropic import compress_messages
+from distil.retention import LiveMeter, format_live, load_live, measure_live
+
+MARKER = "Zq9LiveMarker"
+
+
+def _tool_result(text: str) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "t1", "content": text}],
+    }
+
+
+def _big_log() -> str:
+    """A realistic log: mostly benign lines, a couple of errors.
+
+    Deliberately not all-errors — distil's keep policy pins error lines verbatim, so a
+    log of nothing but errors is never digested and would test nothing.
+    """
+    lines = [
+        f"2026-07-29 10:00:{i % 60:02d} INFO worker-{i} latency_ms={i * 7} "
+        f"path=/var/log/app/{MARKER}-{i}.log id={i} ok"
+        for i in range(300)
+    ]
+    lines.insert(150, f"2026-07-29 10:02:00 ERROR connection refused to db-primary {MARKER}")
+    return "\n".join(lines)
+
+
+def test_measures_real_compression_path() -> None:
+    """Drive the actual adapter, not a stub: facts must be accounted for."""
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    dims = measure_live(original, compressed, store)
+    total = sum(t.total for t in dims.values())
+    accounted = sum(t.retained + t.recoverable + t.lost for t in dims.values())
+    assert total > 0
+    assert accounted == total
+
+
+def _older_turns() -> list[dict[str, Any]]:
+    """The recency rule keeps the last RECENCY_KEEP_TURNS tool results verbatim, so a
+    log only gets digested once newer turns exist. That is the shape to test against."""
+    return [_tool_result(_big_log())] + [
+        _tool_result(f"later tool result {i} latency_ms={i}") for i in range(4)
+    ]
+
+
+def test_digested_facts_are_recoverable_via_the_store() -> None:
+    """Facts behind a handle must resolve through the live RestoreStore."""
+    original = _older_turns()
+    compressed, store = compress_messages(original)
+    dims = measure_live(original, compressed, store)
+    assert sum(t.recoverable for t in dims.values()) > 0
+    # Without the store, those same facts have no proven recovery path.
+    blind = measure_live(original, compressed, None)
+    assert sum(t.recoverable for t in blind.values()) == 0
+    assert sum(t.lost for t in blind.values()) > sum(t.lost for t in dims.values())
+
+
+def test_no_content_reaches_disk(tmp_path: Path) -> None:
+    """The load-bearing privacy invariant: counts only, never text."""
+    path = tmp_path / "retention.jsonl"
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    LiveMeter(1.0, path=path).observe(original, compressed, store)
+
+    raw = path.read_text(encoding="utf-8")
+    assert MARKER not in raw
+    assert "ERROR" not in raw and "/var/log" not in raw and "latency_ms" not in raw
+    record = json.loads(raw.strip().splitlines()[0])
+    assert set(record) == {"ts", "dims"}
+    for triple in record["dims"].values():
+        assert len(triple) == 3
+        assert all(isinstance(v, int) for v in triple)
+
+
+def test_rate_zero_is_fully_disabled(tmp_path: Path) -> None:
+    path = tmp_path / "retention.jsonl"
+    meter = LiveMeter(0.0, path=path)
+    assert not meter.enabled and not meter.should_sample()
+    meter.observe([_tool_result(_big_log())], [], None)
+    assert not path.exists()
+
+
+def test_sampling_gates_writes(tmp_path: Path) -> None:
+    path = tmp_path / "retention.jsonl"
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    meter = LiveMeter(0.5, rng=random.Random(1234), path=path)
+    for _ in range(40):
+        meter.observe(original, compressed, store)
+    written = len(path.read_text(encoding="utf-8").strip().splitlines())
+    assert 5 < written < 35  # sampled, not all-or-nothing
+
+
+def test_never_raises_on_hostile_input(tmp_path: Path) -> None:
+    """Fail-open: the meter must not be able to cost a user their request."""
+    meter = LiveMeter(1.0, path=tmp_path / "r.jsonl")
+    for junk in (None, [None], [{"role": "tool"}], [{"content": {"a": {"b": 1}}}], "nonsense"):
+        meter.observe(junk, junk, None)  # must not raise
+
+
+def test_broken_store_is_survived(tmp_path: Path) -> None:
+    class _Exploding:
+        def expand(self, handle: str) -> str:
+            raise RuntimeError("store is gone")
+
+    original = _older_turns()  # so digest handles actually exist to be expanded
+    compressed, _ = compress_messages(original)
+    dims = measure_live(original, compressed, _Exploding())
+    assert sum(t.total for t in dims.values()) > 0  # scored anyway
+    assert sum(t.recoverable for t in dims.values()) == 0  # unprovable => not credited
+
+
+def test_unwritable_path_does_not_raise(tmp_path: Path) -> None:
+    blocked = tmp_path / "afile"
+    blocked.write_text("not a directory", encoding="utf-8")
+    meter = LiveMeter(1.0, path=blocked / "nested" / "retention.jsonl")
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    meter.observe(original, compressed, store)  # swallowed
+
+
+def test_scan_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single enormous tool result must not be scanned without limit."""
+    import distil.retention as r
+
+    monkeypatch.setattr(r, "_LIVE_MAX_CHARS", 500)
+    huge = [_tool_result("path=/a/b/c.log latency_ms=5 " * 20000)]
+    compressed, store = compress_messages(huge)
+    dims = measure_live(huge, compressed, store)
+    # Bounded input => bounded target count, not a target per repetition.
+    assert sum(t.total for t in dims.values()) < 50
+
+
+def test_openai_tool_role_is_read() -> None:
+    original = [{"role": "tool", "content": f"latency_ms=42 path=/var/log/{MARKER}.log"}]
+    dims = measure_live(original, original, None)
+    assert dims["numerics"].total > 0
+    assert dims["artifacts"].total > 0
+
+
+def test_anthropic_text_block_content_is_read() -> None:
+    """tool_result content arrives as a list of {"type":"text"} blocks, not a bare str."""
+    original = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": "latency_ms=99 path=/srv/app/x.log"}],
+                }
+            ],
+        }
+    ]
+    dims = measure_live(original, original, None)
+    assert dims["numerics"].total > 0 and dims["artifacts"].total > 0
+
+
+def test_unknown_handle_in_text_is_skipped() -> None:
+    """A marker naming a handle the store cannot expand must not raise or credit."""
+
+    class _Empty:
+        def expand(self, handle: str) -> str | None:
+            return None
+
+    original = [_tool_result("latency_ms=42 path=/var/log/app/x.log")]
+    compressed = [_tool_result("<< +9 lines, handle=deadbeef >>")]
+    dims = measure_live(original, compressed, _Empty())
+    assert sum(t.recoverable for t in dims.values()) == 0
+    assert sum(t.lost for t in dims.values()) > 0
+
+
+def test_empty_traffic_scores_nothing() -> None:
+    dims = measure_live([{"role": "user", "content": "just a question"}], [], None)
+    assert all(t.total == 0 for t in dims.values())
+
+
+def test_aggregation_and_render(tmp_path: Path) -> None:
+    path = tmp_path / "retention.jsonl"
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    meter = LiveMeter(1.0, path=path)
+    meter.observe(original, compressed, store)
+    meter.observe(original, compressed, store)
+
+    dims, requests = load_live(path)
+    assert requests == 2
+    combined = sum(t.total for t in dims.values())
+    assert combined > 0
+    rendered = format_live(dims, requests)
+    assert "2 sampled requests" in rendered
+    assert "recall" in rendered
+
+
+def test_malformed_rows_are_skipped(tmp_path: Path) -> None:
+    path = tmp_path / "retention.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "not json",
+                "",  # blank line mid-file (a flush boundary) must be skipped
+                json.dumps({"no_dims": 1}),
+                json.dumps({"ts": 1, "dims": {"numerics": [3, 2, 1]}}),
+                json.dumps({"ts": 2, "dims": {"numerics": "bad"}}),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    dims, requests = load_live(path)
+    assert requests == 2  # the two well-formed rows
+    assert dims["numerics"].total == 3
+
+
+def test_missing_file_reads_empty(tmp_path: Path) -> None:
+    dims, requests = load_live(tmp_path / "absent.jsonl")
+    assert requests == 0 and all(t.total == 0 for t in dims.values())
+    assert "no live retention samples yet" in format_live(dims, requests)
+
+
+def test_cli_wires_the_flags_through() -> None:
+    """The call sites use getattr defaults so programmatic Namespaces keep working —
+    which would also hide a broken flag. Pin the real argparse path instead."""
+    from distil.cli import build_parser
+
+    parser = build_parser()
+    assert parser.parse_args(["wrap", "claude"]).retention == 0.05  # on by default: free
+    assert parser.parse_args(["wrap", "--retention", "0", "claude"]).retention == 0.0
+    assert parser.parse_args(["proxy"]).retention == 0.0  # explicit opt-in for a raw proxy
+    assert parser.parse_args(["proxy", "--retention", "0.1"]).retention == 0.1
+    assert parser.parse_args(["retention", "--live"]).live is True
+    assert parser.parse_args(["retention", "--dataset", "hotpotqa", "-n", "5"]).n == 5
+
+
+def test_proxy_accepts_retention_rate() -> None:
+    """build_handler must take the kwarg the CLI passes it."""
+    from distil.proxy import build_handler
+
+    assert build_handler(upstream="http://127.0.0.1:1", retention_rate=0.5) is not None
+
+
+def test_home_default_is_respected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    original = [_tool_result(_big_log())]
+    compressed, store = compress_messages(original)
+    LiveMeter(1.0).observe(original, compressed, store)
+    assert (tmp_path / "retention.jsonl").exists()


### PR DESCRIPTION
Every quality gate distil ships is graded on **our** corpus against **our** oracle, and all of them answer a *block-level* question. Neither habit answers the one users actually ask: **is the number I needed still there?**

This adds a recall metric, grades it against ground truth a stranger already trusts, measures it on real traffic without ever writing content to disk — and closes the capability gap the harness immediately found.

## Fact-level recall — `distil retention`

`fidelity.verify_reversible` measured *block*-level byte reconstruction, which is true by construction for Tier-0/1 and therefore always 100%. A metric that cannot fail is not a gate.

Every fact (keyed numerics, paths/URLs/hashes/UUIDs, error lines) now lands in `retained` / `recoverable` / `lost`. Recoverability is **verified, not inferred**: the handle must appear in *that block's own* compressed text **and** the fact must appear in *that handle's* restore bytes — so the percentages are absolute rather than merely comparative.

```
  dimension    recall   visible   lost   facts
  numerics     100.0%     86.6%      0     456
  artifacts    100.0%     96.4%      0      28
  errors       100.0%    100.0%      0      19
  ALL          100.0%     87.7%      0     503
```

Being reversible rather than lossy is worth **12.3% recall** — the moat as a measurement instead of an argument. Now a per-commit CI gate (`--max-lost 0`): zero cost, no API key, no network.

## External validity — `distil retention --dataset`

HotpotQA (`supporting_facts` gold sentences amid 8 distractor paragraphs) and SQuAD v2 (answer spans), loaded through the HuggingFace **datasets-server REST API** as plain JSON — not the `datasets` package — so `dependencies = []` still holds. Rows cache under `$DISTIL_HOME` so a published number reproduces offline.

A recall number alone proves nothing (an identity transform scores 100%), so each run also scores a truncation baseline **tuned to reproduce distil's own token savings on that same case**, printing both figures so the match is auditable:

| HotpotQA, n=100 | savings | answer recall | gold-sentence recall |
|---|---|---|---|
| **distil** (reversible) | 14.3% | **100.0%** | **100.0%** |
| truncation @ matched savings | 14.1% | 91.6% | 82.7% |

Runs **nightly**, not per-commit: a required check gated on a third-party host would make main's health hostage to their uptime. It exits non-zero on a fetch failure, an upstream schema change, and on compression that did not engage — silence is never success.

## A live meter, with no plaintext recorder

Recording real sessions to score them offline would put prompts and tool output on disk and break the content-free posture the census, ledger, and shadow ledger all maintain. **So this does not do that.** The meter scores **in-process** and persists **counts only** — three integers per dimension, with deliberately no field that could carry content:

```json
{"ts": 1785383519.9, "dims": {"numerics": [306, 10, 296], "artifacts": [300, 3, 297], "errors": [1, 1, 0]}}
```

A test plants a unique marker in tool output and asserts it never reaches disk; an end-to-end proxy run confirms it. Sampled (`--retention RATE`), bounded (64 KiB/request), fail-open. Defaults to `0.05` under `wrap` and `0` under a bare `proxy` — unlike `--shadow` it costs **no extra tokens**, because there is no second upstream call.

## The gap it found: HTML was compressing 0.0%

Not a regression — a missing capability, and structural rather than a missing heuristic. Minified markup arrives as one enormous line, so Tier-1's line-folding had nothing to fold and `_MIN_LINES` fell straight through to Tier-0. Any agent with a fetch or browser tool was paying full price for `<script>`, `<style>`, nav and footer.

`distil/compress/htmlx.py` extracts content with stdlib `html.parser` and keeps the exact original behind an expand handle. Measured on **real** pages, not fixtures:

| page | before | after | saved | facts lost |
|---|---|---|---|---|
| Wikipedia article | 281,093 tok | 14,260 tok | **94.9%** | **0** |
| Python docs page | 27,136 tok | 3,751 tok | **86.2%** | **0** |

Deliberately **recall-biased**: `<header>` is kept (it usually wraps the `<h1>`), `img` alt text is kept, `div`/`section` are never dropped. Reversibility is what licenses the aggressiveness — a lossy extractor's mistake is permanent, this one costs one `distil_expand`. Skipped under `--verbatim` (nothing to recover with) and on the recency-exempt latest tool result.

## Three defects caught while building this

Each had been reporting numbers **in distil's favour**:

- **HotpotQA's yes/no answers are never spans.** Grading them reported the dataset's answer *format* as 10% compression loss. Answers are now graded only when present in the **uncompressed** context.
- **SQuAD v2's unanswerable questions (55% of the split) scored as retained** — a free win on a majority of cases. Excluded and counted separately.
- **`--min-recall` now fails below 1% savings.** Recall from a near-identity transform is arithmetic, not evidence. This is not hypothetical: distil correctly declines to compress short prose, so `--shape prose` yields 0% savings and a vacuous 100%.

Also fixes a real bug this surfaced: `WorkerConfig` carried no `retention_rate`, so `wrap`'s hot-swap worker — **the default path** — would have run without the meter, and adding the kwarg without the dataclass field crashed worker spawn. `from_env` now ignores unknown keys so a newer supervisor can spawn an older worker mid-upgrade.

## Two judgment calls worth reviewing

- **Recall is the headline, not F1.** The loss is asymmetric: a dropped fact is a wrong answer, retained-but-unneeded content is merely fewer tokens saved (which the savings number already reports). Token-level precision against gold is really an article-extraction metric. Reasoning in ADR 0005 — happy to add F1 if you disagree.
- **HTML `href`s are dropped.** Most probe-able HTML artifacts are link URLs; keeping them guts savings on link-dense pages and they stay recoverable. So true recall is 100% while artifact *visible* recall is 4.8% on Wikipedia — an agent wanting a link pays one expand. Documented with the number attached rather than hidden, and now tunable on real expand-signal evidence.

## Verification

- `make lint` clean (ruff 0.15.10), `mypy` 1.17.1 clean on all four touched modules
- `make gate` **PASS** — `bench` + `verify` + new `retention` step
- `distil validate` **60/60** adversarial checks
- **2149 tests pass**, coverage **95.33%** (up from 94.98%); **100%** on `retention.py`, `datasets.py`, `htmlx.py`
- Packaging smoke confirms all three new modules ship in the wheel; both workflow YAMLs parse
- Live meter verified end-to-end through a real proxy (status 200, leak check clean)

Docs: [ADR 0005](docs/adr/0005-external-validity-and-fact-level-recall.md), `docs/EVALUATION.md` §5, README, CHANGELOG.
