### PR TITLE
release(1.38.0rc1): soak the recall harness and the HTML transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
-## [Unreleased] — recall, and a number a stranger can check
+## [1.38.0] — recall, and a number a stranger can check
 
 Every quality gate distil shipped until now was graded on **our** corpus against
 **our** oracle. The statistics were rigorous; the external validity was zero — a

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.37.0",
+  "version": "1.38.0rc1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.38.0rc1",
+  "version": "1.38.0-rc.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.37.0",
+  "version": "1.38.0rc1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.37.0"
+version = "1.38.0rc1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.37.0",
+  "version": "1.38.0rc1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.37.0",
+      "version": "1.38.0rc1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -209,17 +209,42 @@ def test_manifests_agree_on_version_and_name() -> None:
     assert spec["name"] in marker, f"server.json name {spec['name']!r} not in README marker"
 
 
+def _npm_version(pep440: str) -> str:
+    """The npm-semver spelling of a PEP 440 version.
+
+    Finals are identical in both schemes, so this is the identity for them. A
+    prerelease is not: PEP 440 writes ``1.38.0rc1`` and npm requires a hyphenated
+    prerelease, ``1.38.0-rc.1``. Demanding byte-equality with pyproject therefore
+    forced package.json to hold a string npm considers invalid — harmless only
+    because release.yml skips `publish-npm` for rc tags, which is a trap waiting for
+    whoever changes that. Translating keeps the anti-drift guarantee (the version is
+    still pinned to pyproject) while leaving the manifest valid at every point.
+    """
+    match = re.fullmatch(r"(\d+\.\d+\.\d+)(?:(a|b|rc)(\d+))?", pep440)
+    if match is None or match.group(2) is None:
+        return pep440
+    return f"{match.group(1)}-{match.group(2)}.{match.group(3)}"
+
+
+def test_npm_version_translation() -> None:
+    assert _npm_version("1.38.0") == "1.38.0"
+    assert _npm_version("1.38.0rc1") == "1.38.0-rc.1"
+    assert _npm_version("2.0.0b3") == "2.0.0-b.3"
+
+
 def test_npm_package_version_matches() -> None:
     """The npm wrapper is a published surface with a version badge in the README,
     and nothing was checking it. It drifted to 1.27.0 in-repo while the registry
     still served 1.25.0 and PyPI was on 1.33.1 — a badge advertising a build nine
     releases old. Same failure class as server.json: a manifest promises a version
     and nothing verifies the promise.
+
+    Pinned to pyproject's version in npm's own spelling — see `_npm_version`.
     """
     pkg = json.loads((ROOT / "packaging" / "npm" / "package.json").read_text())
-    version = _pyproject()["project"]["version"]
-    assert pkg["version"] == version, (
-        f"packaging/npm/package.json is {pkg['version']}, package is {version} — "
+    expected = _npm_version(_pyproject()["project"]["version"])
+    assert pkg["version"] == expected, (
+        f"packaging/npm/package.json is {pkg['version']}, expected {expected} — "
         "bump it with the other manifests at release time"
     )
     assert pkg["name"] == _pyproject()["project"]["name"]

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.37.0"
+version = "1.38.0rc1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Version bump for the work merged in #61. **This is an rc, not the final** — see below.

## Why rc and not 1.38.0

`RELEASING.md` is explicit: *"Any release that changes runtime behavior soaks as an rc first"*, exempting only docs, tests, CI, and packaging metadata — "nothing a running proxy/wrap/gateway executes."

#61 changes what a running proxy executes:

- a new HTML transform in the live compression path (`compress/htmlx.py`, reached from `adapters/anthropic.py`)
- an adapter change *ahead of* the `_MIN_LINES` gate
- a retention meter sampling real requests in the request path
- `WorkerConfig` gaining a field the hot-swap worker reads

That policy exists because of the 1.10.0→1.11.3 day: six releases, each fixing the previous, where the fixes were correct in review and wrong under real use. So this soaks.

**Soak plan** per RELEASING.md: ≥3 days of real work under `distil wrap`, via
`pipx upgrade --pip-args=--pre distil-llm`. Any P0/P1 → fix, cut rc2, restart the clock. Clean → bump to `1.38.0` on the same tree; that final is byte-identical code plus the version bump.

## Version surfaces

All five manifests that must agree are bumped — `pyproject.toml`, `server.json` (**twice**: spec and package), `packaging/npm/package.json`, `plugins/distil/.claude-plugin/plugin.json`:

| surface | 1.38.0rc1 |
|---|---|
| `pyproject.toml` | ✅ |
| `server.json` (spec + package) | ✅ ✅ |
| `packaging/npm/package.json` | ✅ |
| `plugins/distil/.claude-plugin/plugin.json` | ✅ |
| `CITATION.cff` | intentionally **not** bumped — rc rule: stays at the last citable final (1.37.0) |

`CHANGELOG.md`'s `[Unreleased]` became `[1.38.0]` — written once, under the final this rc soaks for, which is what `release.sh` checks for an rc.

`tests/test_packaging_smoke.py` is the check that enforces manifest agreement, and it is green. Worth stating because 1.35.0 shipped a mismatch on the belief that the bump was four files.

## One thing to weigh before promoting to final

The HTML transform is **default-on in the serving path, but the certification corpus contains no HTML trajectory** — so `distil bench` does not certify it. Its evidence today is unit tests, real-page measurements (Wikipedia 94.9% / Python docs 86.9%, 0 facts lost), the `retention` gate on non-HTML content, and whatever the soak turns up.

ADR 0003/0004 set the precedent that a new content type gets certified before going default-on (that is what the vision work did). Two options, your call:

1. **Soak as-is** and promote if clean — the transform is reversible, so a bad extraction costs one `distil_expand` rather than the content.
2. **Add an HTML trajectory to the corpus first**, so `bench`/`certify` actually cover it, then promote. Closes the gap properly; I can do this before the final.

I'd lean 2 before the final, given it ships on by default.

## Gates

lint + `format --check` clean (ruff 0.15.10) · `bench`/`verify`/`validate`/`retention` PASS · **2157 tests**, coverage **95.35%** · packaging smoke 13/13 · `release.sh --dry-run` rehearsed.

After merge, `./scripts/release.sh` from `main` pushes the `v1.38.0rc1` tag; CI marks it prerelease, skips Homebrew and Docker, and publishes the rc to PyPI (pip ignores prereleases unless asked).
