### PR TITLE
release(1.38.0): recall, external validity, and the HTML blind spot

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.37.0
-date-released: 2026-07-26
+version: 1.38.0
+date-released: 2026-07-30
 keywords:
   - llm
   - context-compression

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.38.0-rc.1",
+  "version": "1.38.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.38.0rc1",
+  "version": "1.38.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.38.0rc1"
+version = "1.38.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.38.0rc1",
+  "version": "1.38.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.38.0rc1",
+      "version": "1.38.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.38.0rc1"
+version = "1.38.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Promotes `1.38.0rc1` (#62) to the final.

## Soak skipped — maintainer decision

`RELEASING.md` asks a runtime-behaviour change to soak as an rc for ≥3 days, and this one qualifies: a new HTML transform in the live compression path, a sampled retention meter in the request path, an adapter change ahead of the `_MIN_LINES` gate, and a `WorkerConfig` field the hot-swap worker reads.

I raised that and the maintainer chose to ship the final now. It's recorded in the commit message as well as here, so anyone reading `git log` after an incident can see the gate was skipped deliberately rather than missed.

## Version surfaces — all six that `release.sh` checks for a final

Unlike the rc path, the non-rc branch of `release.sh` asserts every surface, so all six move:

| surface | 1.38.0 |
|---|---|
| `pyproject.toml` | ✅ |
| `CITATION.cff` (`version` + `date-released`) | ✅ — now bumped; the rc rule that pinned it to 1.37.0 no longer applies |
| `server.json` (spec + package) | ✅ ✅ |
| `packaging/npm/package.json` | ✅ plain `1.38.0` |
| `plugins/distil/.claude-plugin/plugin.json` | ✅ |

The npm wrapper returns to an unhyphenated `1.38.0`: the PEP 440 / npm spelling divergence fixed in #62 only bites on prereleases, and finals are identical in both schemes — so the translation added there is the identity here, and `release.sh`'s literal `NPM_V = VERSION` check passes.

I also simulated `release.sh`'s non-rc cross-surface check directly against the tree: `pyproject=1.38.0 citation=1.38.0 plugin=1.38.0 server=1.38.0 npm=1.38.0` — all five agree.

## Known gap carried into the final

**The HTML transform is default-on in the serving path, but the certification corpus contains no HTML trajectory — so `distil bench` does not cover that content type.** Its evidence is unit tests and real-page measurement (Wikipedia 94.9%, 0 facts lost), not the gate. ADR 0003/0004 set the precedent that a new content type is certified before going default-on, which is what the vision work did; that work is still owed and is noted in the commit.

The mitigating property is that the transform is reversible — a bad extraction costs one `distil_expand` rather than the content.

## Gates

lint + `format --check` clean (ruff 0.15.10) · `bench`/`verify`/`validate`/`retention` PASS · **2158 tests**, coverage **95.35%** · packaging smoke 14/14 · manifest agreement verified against `release.sh`'s own logic.

After merge: `./scripts/release.sh` from `main` pushes `v1.38.0`, and CI publishes to PyPI via Trusted Publishing, builds the Docker image, and refreshes the Homebrew sha256 — all of which the rc path skipped.
