### PR TITLE
chore(homebrew): pin the formula sha256 to the v1.38.0 tarball

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.33.0 source tarball. To recompute for a new version:
+# sha256 is for the v1.38.0 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.33.0.tar.gz"
-  sha256 "b591d423308067b8738644331788ac6674360ded318bf2809add75a60c09bc60"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.38.0.tar.gz"
+  sha256 "d75e279367aed1894a092258e9290ade40ffbf9d701217ff02d237489be46c00"
   license "Apache-2.0"
-  version "1.33.0"
+  version "1.38.0"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
Post-release follow-up for `v1.38.0` (#63).

`scripts/release.sh` patches `packaging/homebrew/distil.rb` after the tag exists — it needs the tarball to compute the sha256 — and then offers to push the result **straight to `main`**. I declined that prompt, since `main` is PR-only, so the bump comes through here instead.

| field | value |
|---|---|
| `url` | `…/archive/refs/tags/v1.38.0.tar.gz` |
| `sha256` | `d75e279367aed1894a092258e9290ade40ffbf9d701217ff02d237489be46c00` |
| sha comment | names `v1.38.0` |

`tests/test_packaging_smoke.py` checks that the url tag, version field and sha comment all name the *same* tag — 14/14 green.

## Still outstanding after this merges

This repo's copy is the **source**, not what Homebrew serves. Per `RELEASING.md`, the formula has to be copied into the tap repo before `brew install dshakes/tap/distil` gets 1.38.0:

```
dshakes/homebrew-tap → Formula/distil.rb
```

I can't reach that repo from here, so it needs a hand — otherwise brew users stay on the previous release regardless of this merge.
