### PR TITLE
chore(homebrew): pin the formula sha256 to the v1.39.0 tarball

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.38.0 source tarball. To recompute for a new version:
+# sha256 is for the v1.39.0 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.38.0.tar.gz"
-  sha256 "d75e279367aed1894a092258e9290ade40ffbf9d701217ff02d237489be46c00"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.39.0.tar.gz"
+  sha256 "4b71ffb751a7e23750056c7d2df60828b1207db900b300ae7e7ab168dae4f268"
   license "Apache-2.0"
-  version "1.38.0"
+  version "1.39.0"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
Post-release follow-up for `v1.39.0` (#67).

`scripts/release.sh` patches `packaging/homebrew/distil.rb` after the tag exists — it needs the tarball to hash — then offers to push straight to `main`. Declined, since `main` is PR-only.

| field | value |
|---|---|
| `url` | `…/archive/refs/tags/v1.39.0.tar.gz` |
| `sha256` | `4b71ffb751a7e23750056c7d2df60828b1207db900b300ae7e7ab168dae4f268` |
| sha comment | names `v1.39.0` |

**Scope is the in-repo source copy only.** The tap itself needs no manual step — `release.yml`'s `bump-homebrew` job clones `dshakes/homebrew-tap` and pushes the formula there. Without this PR the repo copy would say v1.38.0 while the tap serves 1.39.0, and `tests/test_packaging_smoke.py` checks that the url tag, version field and sha comment all name the same tag (14/14 green).

Worth repeating from the 1.38.0 round: `bump-homebrew` exits 0 when it *skips* on a missing `TAP_TOKEN`, so its green tick alone never proves the tap moved. I'll confirm from the job log rather than the status.