### PR TITLE
fix(release): a missing tap token must fail the release, not pass it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,14 +284,33 @@ jobs:
           # url/sha to "v" and break `brew install` for everyone.
           [ -n "$VER" ] || { echo "::error::RELEASE_VERSION is empty — refusing to touch the tap"; exit 1; }
 
-          # Idempotency first, and deliberately BEFORE the token gate: a re-cut whose
-          # tap already names this version has nothing to push, so it must neither
-          # fail nor require a credential. A brew tap is necessarily public, so this
-          # reads anonymously. Same ordering as publish-npm's `npm view` pre-check,
-          # which an audit on #69 showed has to come first.
+          # Hash the tarball before anything else: it is a public download needing no
+          # credential, and the idempotency check below has to compare against it.
+          # Assign inside `if` so errexit does not kill the step before the message:
+          # under `set -euo pipefail` a 404 from curl aborted the script outright, which
+          # made the guard below unreachable and reported a bare `exit 56`.
+          if ! SHA="$(curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"; then
+            echo "::error::could not fetch the v${VER} source tarball — does the tag exist?"
+            exit 1
+          fi
+          [ -n "$SHA" ] || { echo "::error::could not hash the v${VER} tarball"; exit 1; }
+
+          # Idempotency, deliberately BEFORE the token gate: a re-cut whose tap is
+          # already in the exact state this job would write has nothing to push, so it
+          # must neither fail nor require a credential. A brew tap is necessarily
+          # public, so this reads anonymously. Ordering follows the audit on #69.
+          #
+          # All THREE fields must match, not just the version. A tag re-cut changes the
+          # tarball hash for the same version number, so a formula naming v$VER with a
+          # stale sha256 is broken — `brew install` fails its checksum — and is exactly
+          # the case that needs the repair below. Matching on version alone would skip
+          # it and call that success. (Audit finding on #70.)
           TAP_FORMULA="https://raw.githubusercontent.com/dshakes/homebrew-tap/main/Formula/distil.rb"
-          if curl -fsSL "$TAP_FORMULA" 2>/dev/null | grep -q "version \"${VER}\""; then
-            echo "tap already at ${VER} — nothing to do"
+          CURRENT="$(curl -fsSL "$TAP_FORMULA" 2>/dev/null || true)"
+          if printf '%s' "$CURRENT" | grep -q "archive/refs/tags/v${VER}\.tar\.gz" \
+             && printf '%s' "$CURRENT" | grep -q "sha256 \"${SHA}\"" \
+             && printf '%s' "$CURRENT" | grep -q "version \"${VER}\""; then
+            echo "tap already at ${VER} with a matching url and sha256 — nothing to do"
             exit 0
           fi
 
@@ -307,8 +326,6 @@ jobs:
             echo "::error::Add a repo secret TAP_TOKEN with push access to dshakes/homebrew-tap."
             exit 1
           fi
-          SHA="$(curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
-          [ -n "$SHA" ] || { echo "::error::could not hash the v${VER} tarball"; exit 1; }
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/dshakes/homebrew-tap" tap
           cd tap
           python3 - "$VER" "$SHA" <<'PY'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,10 @@ jobs:
     # resolved version, not the ref: the tag-only guard skipped this job on
     # every workflow_dispatch release, which RELEASING.md documents as supported,
     # so brew silently stayed on the previous version.
-    if: ${{ !contains(needs.build.outputs.version, 'rc') }}
+    #
+    # Forks are excluded here rather than inside the step, so a fork that tags a
+    # release never runs a job it has no credential for and cannot fix.
+    if: ${{ !contains(needs.build.outputs.version, 'rc') && github.repository == 'dshakes/distil' }}
     steps:
       - name: Update tap formula
         env:
@@ -275,15 +278,35 @@ jobs:
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
           set -euo pipefail
-          if [ -z "${TAP_TOKEN:-}" ]; then
-            echo "::notice::TAP_TOKEN not set — skipping Homebrew tap bump."
-            exit 0
-          fi
           # see publish-pypi: GITHUB_REF_NAME is the branch on workflow_dispatch
           VER="${RELEASE_VERSION:-}"
           # Never write a formula from an empty version: it would rewrite the tap's
           # url/sha to "v" and break `brew install` for everyone.
           [ -n "$VER" ] || { echo "::error::RELEASE_VERSION is empty — refusing to touch the tap"; exit 1; }
+
+          # Idempotency first, and deliberately BEFORE the token gate: a re-cut whose
+          # tap already names this version has nothing to push, so it must neither
+          # fail nor require a credential. A brew tap is necessarily public, so this
+          # reads anonymously. Same ordering as publish-npm's `npm view` pre-check,
+          # which an audit on #69 showed has to come first.
+          TAP_FORMULA="https://raw.githubusercontent.com/dshakes/homebrew-tap/main/Formula/distil.rb"
+          if curl -fsSL "$TAP_FORMULA" 2>/dev/null | grep -q "version \"${VER}\""; then
+            echo "tap already at ${VER} — nothing to do"
+            exit 0
+          fi
+
+          # Past here the tap genuinely needs updating, so a missing token is fatal.
+          # It used to `exit 0` behind a ::notice::, the quietest annotation GitHub
+          # has — a green job that published nothing, which is exactly how npm sat
+          # fourteen releases behind before #69. `brew install dshakes/tap/distil`
+          # would go on serving the previous version with nothing to show for it.
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "::error::TAP_TOKEN is not set, so the Homebrew tap cannot be moved to ${VER}."
+            echo "::error::Failing rather than skipping: brew users would keep getting the"
+            echo "::error::previous release while this job reported success."
+            echo "::error::Add a repo secret TAP_TOKEN with push access to dshakes/homebrew-tap."
+            exit 1
+          fi
           SHA="$(curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/v${VER}.tar.gz" | shasum -a 256 | cut -d' ' -f1)"
           [ -n "$SHA" ] || { echo "::error::could not hash the v${VER} tarball"; exit 1; }
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/dshakes/homebrew-tap" tap


### PR DESCRIPTION
The same trap #69 removed from `publish-npm`, still live one job below it.

`bump-homebrew` exits 0 when `TAP_TOKEN` is absent, behind a `::notice::` — the *quietest* annotation GitHub has, on a green job. npm proved where that ends: fourteen releases of silent skips while every run reported success. `brew install dshakes/tap/distil` would go the same way, serving the previous release with nothing to show for it.

It works today only because `TAP_TOKEN` happens to be set. That's one expiry away from being the npm story again — and not trusting a green tick that never checked anything is rather the point of this project.

## Ordering follows #69's audit finding rather than repeating the mistake

Idempotency comes **first**. A brew tap is necessarily public, so the check reads the formula anonymously:

```bash
TAP_FORMULA="https://raw.githubusercontent.com/dshakes/homebrew-tap/main/Formula/distil.rb"
if curl -fsSL "$TAP_FORMULA" | grep -q "version \"${VER}\""; then
  echo "tap already at ${VER} — nothing to do"; exit 0
fi
```

A re-cut whose tap already names this version has nothing to push, so it must neither fail nor require a credential. Only past that point — where the tap genuinely needs moving — is a missing token fatal. That's exactly the correction Codex made to my first pass at the npm job; applying it up front here rather than shipping the same bug twice.

**Forks** are excluded at the `if:` (`github.repository == 'dshakes/distil'`), so a fork tagging a release never runs a job it has no credential for and can't fix.

The existing `RELEASE_VERSION` empty-guard is preserved and still runs before anything touches the tap — writing `v` into the url/sha would break `brew install` for everyone.

## Verified against the live tap, by running it

| case | expected | actual |
|---|---|---|
| no token, tap already at 1.39.0 | exit 0 | `exit=0` — `tap already at 1.39.0 — nothing to do` |
| no token, tap not at 9.9.9 | exit 1 | `exit=1` — `::error::Add a repo secret TAP_TOKEN…` |
| token set, empty version | exit 1 | `exit=1` — `::error::RELEASE_VERSION is empty — refusing to touch the tap` |

The first row confirms the load-bearing assumption: the tap really is anonymously readable, so moving the check earlier doesn't just relocate the failure.

YAML parses; packaging smoke 14/14; lint clean.

## After this

Both remaining publish jobs now fail loudly instead of skipping quietly. `publish-pypi` was already correct (dormant behind an opt-in, then failing for real) and `publish-image` needs no secret, so this closes the set.
