### PR TITLE
ci(audit): audit the fix in Gemini too, with its own concurrency group

### DIFF
--- a/.github/workflows/sdlc-audit-gemini.yml
+++ b/.github/workflows/sdlc-audit-gemini.yml
@@ -21,7 +21,19 @@ on:
 # and silently reduce three opinions to whichever finished first.
 concurrency:
   group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Cancel ONLY when this run will actually audit. Workflow-level concurrency is
+  # evaluated BEFORE the job-level `if`, so a run whose job will be skipped — a bot
+  # `synchronize`, an unrelated label — still joins the group. With a bare
+  # `cancel-in-progress: true` it would kill a valid audit already in flight and then
+  # skip, leaving the PR with no verdict at all: the precise opposite of the coverage
+  # this trigger exists to add. (Audit finding on #72; #71 shipped with it.)
+  #
+  # The predicate is the job's `if`, deliberately duplicated rather than referenced —
+  # workflow-level concurrency cannot see job outputs. Keep the two in step.
+  cancel-in-progress: >-
+    ${{ github.actor != 'dependabot[bot]'
+    && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+    && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit') }}
 
 permissions:
   contents: read

--- a/.github/workflows/sdlc-audit-gemini.yml
+++ b/.github/workflows/sdlc-audit-gemini.yml
@@ -1,13 +1,27 @@
-# Auditor (Gemini) — third cross-model audit. Runs automatically when a PR opens (an
-# independent third opinion alongside the Claude reviewer and Codex auditor) and on
-# demand via the `agent:audit` label. Read-only; posts Gemini's verdict as a PR comment.
-# Needs secret GEMINI_API_KEY — skips cleanly (no failure) when it is absent.
-# Not on `synchronize`, so the fix loop's pushes don't re-spend Gemini credits each round.
+# Auditor (Gemini) — third cross-model audit. Runs when a PR opens, when a human pushes
+# to it, and on demand via the `agent:audit` label. An independent third opinion
+# alongside the Claude reviewer and the Codex auditor. Read-only; posts Gemini's verdict
+# as a PR comment. Needs secret GEMINI_API_KEY — skips cleanly (no failure) when absent.
+#
+# `synchronize` is in the list for the reason given in sdlc-audit.yml (#71): without it
+# the auditor only ever saw the commit that CONTAINED a bug, and the fix shipped
+# unreviewed unless someone remembered the label. The cost that originally justified
+# leaving it out is filtered in the job condition instead — see there.
 name: "sdlc · audit (Gemini)"
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
+
+# One Gemini audit per PR, so a rapid push cannot leave an older run to finish last and
+# post a verdict against a superseded commit.
+#
+# The group name is deliberately NOT the one sdlc-audit.yml uses: concurrency groups are
+# shared across workflows, so a common name would make the two auditors cancel each other
+# and silently reduce three opinions to whichever finished first.
+concurrency:
+  group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -15,9 +29,17 @@ permissions:
 
 jobs:
   audit-gemini:
-    # Auto on open/reopen, or on the agent:audit label. (label.name is null on open events.)
-    # dependabot-actor runs get Dependabot's (empty) secret store — agent can't auth, so skip
-    if: github.actor != 'dependabot[bot]' && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
+    # Same three guards as sdlc-audit.yml, for the same reasons:
+    #  1. dependabot never audits — empty secret store, the agent cannot auth at all.
+    #  2. bot pushes are skipped ONLY on `synchronize` (the SDLC fix loop's per-round
+    #     commits). Scoped deliberately: a blanket bot exclusion would also stop auditing
+    #     PRs *opened* by Renovate, Copilot and release bots, which are exactly the
+    #     dependency and generated-code changes a third opinion is worth having on.
+    #  3. a label triggers only when it is `agent:audit` (label.name is null on opens).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+      && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this

--- a/.github/workflows/sdlc-audit-gemini.yml
+++ b/.github/workflows/sdlc-audit-gemini.yml
@@ -13,27 +13,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
-# One Gemini audit per PR, so a rapid push cannot leave an older run to finish last and
-# post a verdict against a superseded commit.
-#
-# The group name is deliberately NOT the one sdlc-audit.yml uses: concurrency groups are
-# shared across workflows, so a common name would make the two auditors cancel each other
-# and silently reduce three opinions to whichever finished first.
-concurrency:
-  group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
-  # Cancel ONLY when this run will actually audit. Workflow-level concurrency is
-  # evaluated BEFORE the job-level `if`, so a run whose job will be skipped — a bot
-  # `synchronize`, an unrelated label — still joins the group. With a bare
-  # `cancel-in-progress: true` it would kill a valid audit already in flight and then
-  # skip, leaving the PR with no verdict at all: the precise opposite of the coverage
-  # this trigger exists to add. (Audit finding on #72; #71 shipped with it.)
-  #
-  # The predicate is the job's `if`, deliberately duplicated rather than referenced —
-  # workflow-level concurrency cannot see job outputs. Keep the two in step.
-  cancel-in-progress: >-
-    ${{ github.actor != 'dependabot[bot]'
-    && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
-    && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit') }}
 
 permissions:
   contents: read
@@ -53,6 +32,22 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    # Job level, NOT workflow level. A workflow-level group is joined by the RUN, before
+    # the `if` above is evaluated, so an event this job will skip — a bot `synchronize`,
+    # an unrelated label — still takes a slot: it can cancel the audit in flight, and
+    # because GitHub keeps only one PENDING run per group it can also evict a queued one.
+    # Either way the PR ends up with no verdict, which is worse than the gap `synchronize`
+    # was added to close, because a missing audit is indistinguishable from a clean one.
+    #
+    # A skipped job never joins the group at all, so the whole class is gone by
+    # construction rather than by an expression that has to enumerate the skip cases.
+    # (Audit findings on #72, twice — the first attempt guarded `cancel-in-progress`
+    # with the job's own predicate, which still left the pending-slot eviction open.)
+    #
+    # The group name is per-workflow so the two auditors never cancel each other.
+    concurrency:
+      group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       # Secrets aren't readable in a job-level `if`, so gate every later step on this
       # first step's output — absent key means the job completes green as a no-op.

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -24,7 +24,19 @@ on:
 # spending Codex credits on commits nobody will merge. (Audit finding on #71.)
 concurrency:
   group: sdlc-audit-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Cancel ONLY when this run will actually audit. Workflow-level concurrency is
+  # evaluated BEFORE the job-level `if`, so a run whose job will be skipped — a bot
+  # `synchronize`, an unrelated label — still joins the group. With a bare
+  # `cancel-in-progress: true` it would kill a valid audit already in flight and then
+  # skip, leaving the PR with no verdict at all: the precise opposite of the coverage
+  # this trigger exists to add. (Audit finding on #72; #71 shipped with it.)
+  #
+  # The predicate is the job's `if`, deliberately duplicated rather than referenced —
+  # workflow-level concurrency cannot see job outputs. Keep the two in step.
+  cancel-in-progress: >-
+    ${{ github.actor != 'dependabot[bot]'
+    && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
+    && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit') }}
 
 permissions:
   contents: read

--- a/.github/workflows/sdlc-audit.yml
+++ b/.github/workflows/sdlc-audit.yml
@@ -18,25 +18,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
-# One audit per PR. `synchronize` makes rapid pushes possible, and without this an
-# older run can finish LAST and post a verdict — clean or blocking — against a commit
-# that has already been superseded. Cancelling in flight also stops a push storm from
-# spending Codex credits on commits nobody will merge. (Audit finding on #71.)
-concurrency:
-  group: sdlc-audit-${{ github.event.pull_request.number }}
-  # Cancel ONLY when this run will actually audit. Workflow-level concurrency is
-  # evaluated BEFORE the job-level `if`, so a run whose job will be skipped — a bot
-  # `synchronize`, an unrelated label — still joins the group. With a bare
-  # `cancel-in-progress: true` it would kill a valid audit already in flight and then
-  # skip, leaving the PR with no verdict at all: the precise opposite of the coverage
-  # this trigger exists to add. (Audit finding on #72; #71 shipped with it.)
-  #
-  # The predicate is the job's `if`, deliberately duplicated rather than referenced —
-  # workflow-level concurrency cannot see job outputs. Keep the two in step.
-  cancel-in-progress: >-
-    ${{ github.actor != 'dependabot[bot]'
-    && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
-    && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit') }}
 
 permissions:
   contents: read
@@ -67,6 +48,22 @@ jobs:
       && (github.event.action != 'synchronize' || !endsWith(github.actor, '[bot]'))
       && (github.event.action != 'labeled' || github.event.label.name == 'agent:audit')
     runs-on: ubuntu-latest
+    # Job level, NOT workflow level. A workflow-level group is joined by the RUN, before
+    # the `if` above is evaluated, so an event this job will skip — a bot `synchronize`,
+    # an unrelated label — still takes a slot: it can cancel the audit in flight, and
+    # because GitHub keeps only one PENDING run per group it can also evict a queued one.
+    # Either way the PR ends up with no verdict, which is worse than the gap `synchronize`
+    # was added to close, because a missing audit is indistinguishable from a clean one.
+    #
+    # A skipped job never joins the group at all, so the whole class is gone by
+    # construction rather than by an expression that has to enumerate the skip cases.
+    # (Audit findings on #72, twice — the first attempt guarded `cancel-in-progress`
+    # with the job's own predicate, which still left the pending-slot eviction open.)
+    #
+    # The group name is per-workflow so the two auditors never cancel each other.
+    concurrency:
+      group: sdlc-audit-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
#71 fixed this for the Codex auditor. Gemini carried the identical gap: it triggered on `opened, reopened, labeled` but not `synchronize`, so it reviewed the commit that *contained* a bug and never the fix, unless someone applied `agent:audit` by hand.

Two auditors sharing one blind spot isn't two opinions on the fix.

## Same shape as #71, including the mistake it already paid for

Bot pushes are skipped **only on `synchronize`** — the sole event the SDLC fix loop produces — so its per-round commits don't re-spend Gemini credits. Bot-*opened* PRs (Renovate, Copilot, release bots) keep auditing.

That distinction isn't incidental: a blanket `!endsWith(actor,'[bot]')` was filed **Blocking** on #71 precisely because it withdraws coverage from dependency and generated-code changes. Applying the corrected form here rather than rediscovering it.

`dependabot` keeps its unconditional skip, which is about *capability* not cost — those runs get an empty secret store and can't authenticate.

## The detail worth the most care: the concurrency group

```yaml
concurrency:
  group: sdlc-audit-gemini-${{ github.event.pull_request.number }}   # NOT sdlc-audit-…
  cancel-in-progress: true
```

**Concurrency groups are shared across workflows.** Reusing `sdlc-audit-${{ … }}` would make the two auditors cancel each other, quietly reducing three opinions to whichever started last — exactly the failure this project keeps finding: a green run that did less than it appears to have.

Asserted distinct in the same commit:

```
gemini group: sdlc-audit-gemini-${{ github.event.pull_request.number }}
codex  group: sdlc-audit-${{ github.event.pull_request.number }}
groups are distinct: auditors cannot cancel each other
```

## The injection defence is untouched

This file's security property is that it checks out the **base** commit and never places the PR tree on disk, so nothing the Gemini CLI auto-loads from a workspace — `GEMINI.md` as agent context, `.env`, `.gemini/settings.json` whose `mcpServers` it spawns as processes — can come from a contributor. The PR enters as data only.

Verified by diffing specifically for `ref:`/`checkout`/`base`/`GEMINI.md`/`mcpServers`/`.env` lines rather than reading past them: **no change to any of them.** Only the trigger, the concurrency block, and the job condition moved.

## Verified

- 9 event/actor combinations evaluated against the condition (human push runs, `compass-agent[bot]` push skips, `renovate[bot]`/`copilot[bot]` opens still run, dependabot never)
- `actionlint` clean
- Concurrency groups asserted distinct

## Note, not addressed here

Gemini "skips cleanly (no failure) when `GEMINI_API_KEY` is absent" — the same green-job-that-did-nothing shape #69 and #70 removed from the publish jobs. The consequence differs (a lost internal signal, not a user-facing artefact that silently never shipped), so I've left it rather than widen this PR. Worth deciding on separately.
