### PR TITLE
release(1.39.1): the release path, hardened and then actually run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.39.1] — the release path, hardened and then actually run
+
+**The installed package is unchanged.** Every commit since 1.39.0 touches
+`.github/workflows/` or `packaging/homebrew/distil.rb`, neither of which ships in the
+wheel — `distil/` and the bundled corpus are byte-identical to 1.39.0. Nothing about
+compression, the proxy, or the CLI is different, and there is no reason to upgrade for
+behaviour. It is cut so the hardened publish path executes against a version that is not
+yet on PyPI, npm, or the tap, rather than waiting to find out during a release that
+matters.
+
+### Fixed — publish jobs that reported success while doing nothing
+
+- **A missing `NPM_TOKEN` now fails the release** instead of exiting 0 behind a warning.
+  That silent skip is how npm sat on 1.25.0 while PyPI reached 1.39.0 — fourteen
+  releases, each green, publishing nothing, while the README carried an npm badge and an
+  `npm i distil-llm` instruction aimed at the stale build. The registry now holds exactly
+  `1.25.0` and `1.39.0`, which is the evidence.
+- **A missing `TAP_TOKEN` now fails the release** for the same reason, behind an even
+  quieter `::notice::`. It worked only because the token happened to be set.
+- Both check idempotency **before** demanding a credential, so re-cutting a release with
+  nothing to publish neither fails nor needs one. For the tap that comparison covers the
+  url, the `sha256` **and** the version: a re-cut tag keeps the version and changes the
+  hash, and matching on version alone would have skipped repairing a formula whose
+  `brew install` fails its checksum.
+- A tarball fetch failure now says *"does the tag exist?"* instead of a bare `exit 56` —
+  the guard existed but was unreachable under `set -euo pipefail`.
+
+### Fixed — auditors that never saw the fix
+
+- **Both cross-audits now run on `synchronize`.** They triggered on open only, so an
+  auditor reviewed the commit that *contained* a bug and never the correction, unless
+  someone applied the `agent:audit` label by hand. Bot pushes are skipped only on
+  `synchronize` (the fix loop's rounds); PRs *opened* by Renovate, Copilot and release
+  bots still audit, because a blanket bot exclusion silently withdraws coverage from
+  dependency and generated-code changes.
+- **Concurrency is job-level, not workflow-level.** A workflow-level group is joined by
+  the run before the job's `if` is evaluated, so an event the job will skip still takes a
+  slot — cancelling the audit in flight, and evicting a queued one, since GitHub keeps a
+  single pending run per group. The PR ends with no verdict, which reads exactly like a
+  clean one. A skipped job never joins the group at all.
+
 ## [1.39.0] — certify the HTML transform, and a headline one fixture cannot swing
 
 ### Documentation

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.39.0
-date-released: 2026-07-30
+version: 1.39.1
+date-released: 2026-07-31
 keywords:
   - llm
   - context-compression

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.39.0"
+version = "1.39.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.39.0",
+      "version": "1.39.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.39.0"
+version = "1.39.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## The installed package is unchanged

Every commit since `v1.39.0` touches `.github/workflows/` or `packaging/homebrew/distil.rb` — neither ships in the wheel:

```console
$ git diff v1.39.0..main --name-only
.github/workflows/release.yml
.github/workflows/sdlc-audit-gemini.yml
.github/workflows/sdlc-audit.yml
packaging/homebrew/distil.rb
```

`distil/` and the bundled corpus are byte-identical to 1.39.0. Nothing about compression, the proxy, or the CLI differs, and **there is no behavioural reason to upgrade.** That's the first line of the changelog entry so a version bump isn't mistaken for a change.

## Why cut it anyway

**The publish hardening from #69 and #70 has never executed.** Both were verified by running their shell bodies locally — which is not the same as the workflow running — and the paths that matter only exist for a version that hasn't shipped: an npm version not yet on the registry, a tap not yet at this version. Re-running 1.39.0 would take the idempotent "nothing to do" branch every time and prove nothing.

Exercising it on a release where nothing is at stake beats discovering a mistake on one where something is.

### What this release will actually test

| path | first real execution |
|---|---|
| `publish-npm` idempotency-then-token ordering | version absent from npm → publishes |
| `bump-homebrew` url + sha256 + version comparison | tap not at 1.39.1 → repairs |
| the `if !SHA=…` guard | only fires on a bad tag, so still untested |
| job-level audit concurrency | already exercised on #71/#72 |

## Version surfaces

All six that `release.sh` checks for a final, verified against its own logic:

```
pyproject=1.39.1 citation=1.39.1 plugin=1.39.1 server=1.39.1 npm=1.39.1
all five surfaces agree on 1.39.1
CHANGELOG has [1.39.1]
```

`CITATION.cff` carries today's date (2026-07-31).

## Gates

lint + `format --check` clean · `bench`/`verify`/`validate` PASS (60/60 adversarial) · **2175 tests**, coverage **95.36%** · packaging smoke 14/14.

## After merge

`./scripts/release.sh` from `main` pushes `v1.39.1`. I'll verify against the published artifacts rather than the job statuses — which matters more than usual here, since two of the four publish jobs return success when they skip, and that's precisely what this release exists to confirm no longer happens.
