### PR TITLE
chore(homebrew): pin the formula sha256 to the v1.39.1 tarball

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.39.0 source tarball. To recompute for a new version:
+# sha256 is for the v1.39.1 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.39.0.tar.gz"
-  sha256 "4b71ffb751a7e23750056c7d2df60828b1207db900b300ae7e7ab168dae4f268"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.39.1.tar.gz"
+  sha256 "a3b51fd6f08f7837ea8cc255a5f2045823d03eb0bee537e2ff84809bde13c615"
   license "Apache-2.0"
-  version "1.39.0"
+  version "1.39.1"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
Post-release follow-up for `v1.39.1` (#73).

`scripts/release.sh` patches `packaging/homebrew/distil.rb` after the tag exists — it needs the tarball to hash — then offers to push straight to `main`. Declined; `main` is PR-only.

| field | value |
|---|---|
| `url` | `…/archive/refs/tags/v1.39.1.tar.gz` |
| `sha256` | `a3b51fd6f08f7837ea8cc255a5f2045823d03eb0bee537e2ff84809bde13c615` |
| sha comment | names `v1.39.1` |

Codex flagged on #73 that this file still said `1.39.0` and correctly declined to block on it, since the hash cannot exist before the tag does. This is that lag closing.

**In-repo source copy only** — the tap itself is updated by `release.yml`'s `bump-homebrew`, which is one of the two paths 1.39.1 exists to exercise. `tests/test_packaging_smoke.py` checks the url tag, version field and sha comment all name the same tag: 14/14.
