### PR TITLE
fix(sdlc): stop claiming the reviewer will re-run when it cannot

### DIFF
--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -174,18 +174,24 @@ jobs:
               # green job asserting something false, which is the failure this repo
               # keeps finding.
               echo "::warning::Fix pushed to $HEAD_REF, but NOTHING will re-validate it."
-              echo "::warning::Pushes made with GITHUB_TOKEN do not trigger workflow runs,"
-              echo "::warning::so no reviewer, audit or gate will see this commit and the"
-              echo "::warning::auto-fix loop stops here. Configure SDLC_APP_ID +"
-              echo "::warning::SDLC_APP_PRIVATE_KEY (preferred) or the SDLC_BOT_TOKEN secret."
+              echo "::warning::No usable bot credential was available, so the push fell back"
+              echo "::warning::to GITHUB_TOKEN — and GitHub raises no workflow events for"
+              echo "::warning::those, so no reviewer, audit or gate sees this commit."
+              echo "::warning::Either no credential is configured (SDLC_APP_ID +"
+              echo "::warning::SDLC_APP_PRIVATE_KEY, or SDLC_BOT_TOKEN), or the App token"
+              echo "::warning::step failed to mint one — it runs under continue-on-error, so"
+              echo "::warning::check its log before assuming the secrets are missing."
               # shellcheck disable=SC2016  # the backticks below are markdown code
               # spans in a PR comment, not shell expansions.
               gh pr comment "$PR" --body "$(printf '%s\n' \
                 '⚠️ **Auto-fix pushed, but nothing re-ran.**' '' \
                 "A fix was committed to \`$HEAD_REF\`, and then no checks re-ran against it." \
-                'GitHub raises no workflow events for pushes authenticated with `GITHUB_TOKEN`,' \
-                'and neither `SDLC_APP_ID` nor `SDLC_BOT_TOKEN` is configured — so the reviewer,' \
-                'the cross-audits and the gate matrix have **not** seen this commit.' '' \
+                'No usable bot credential was available, so the push fell back to' \
+                '`GITHUB_TOKEN` — and GitHub raises no workflow events for those, so the' \
+                'reviewer, the cross-audits and the gate matrix have **not** seen it.' '' \
+                'Either no credential is configured (`SDLC_APP_ID` + `SDLC_APP_PRIVATE_KEY`,' \
+                'or `SDLC_BOT_TOKEN`), **or** the App-token step failed to mint one — it runs' \
+                'under `continue-on-error`, so check its log before assuming a missing secret.' '' \
                 'It is unvalidated, `agent:needs-fix` is still on this PR, and the loop cannot' \
                 'continue on its own. Re-run the checks by hand, or configure a bot credential' \
                 'so the loop closes itself.')" >/dev/null 2>&1 || true

--- a/.github/workflows/sdlc-fix.yml
+++ b/.github/workflows/sdlc-fix.yml
@@ -149,6 +149,9 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}   # untrusted branch name → via env
           BOT_TOKEN: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
+          # Whether BOT_TOKEN is a real bot credential or the GITHUB_TOKEN fallback.
+          # It decides whether this loop can close at all — see the push step.
+          HAS_BOT_CRED: ${{ (steps.apptoken.outputs.token != '' || secrets.SDLC_BOT_TOKEN != '') && 'true' || 'false' }}
         run: |
           set -euo pipefail
           git config user.name  "compass-agent"
@@ -160,14 +163,44 @@ jobs:
           git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
           if [ -n "$(git log --oneline "origin/$HEAD_REF..HEAD" 2>/dev/null)" ]; then
             git push origin "HEAD:$HEAD_REF"
-            echo "Pushed fix to $HEAD_REF — Reviewer will re-run."
+            if [ "$HAS_BOT_CRED" = "true" ]; then
+              echo "Pushed fix to $HEAD_REF — Reviewer will re-run."
+            else
+              # GitHub does not raise workflow events for pushes authenticated with
+              # GITHUB_TOKEN — a deliberate recursion guard. So with no App and no PAT
+              # this push re-runs NOTHING: not the reviewer, not the audits, not the
+              # gate matrix. The fix lands unvalidated, agent:needs-fix stays put, and
+              # the loop stops here. Saying "Reviewer will re-run" in that state was a
+              # green job asserting something false, which is the failure this repo
+              # keeps finding.
+              echo "::warning::Fix pushed to $HEAD_REF, but NOTHING will re-validate it."
+              echo "::warning::Pushes made with GITHUB_TOKEN do not trigger workflow runs,"
+              echo "::warning::so no reviewer, audit or gate will see this commit and the"
+              echo "::warning::auto-fix loop stops here. Configure SDLC_APP_ID +"
+              echo "::warning::SDLC_APP_PRIVATE_KEY (preferred) or the SDLC_BOT_TOKEN secret."
+              # shellcheck disable=SC2016  # the backticks below are markdown code
+              # spans in a PR comment, not shell expansions.
+              gh pr comment "$PR" --body "$(printf '%s\n' \
+                '⚠️ **Auto-fix pushed, but nothing re-ran.**' '' \
+                "A fix was committed to \`$HEAD_REF\`, and then no checks re-ran against it." \
+                'GitHub raises no workflow events for pushes authenticated with `GITHUB_TOKEN`,' \
+                'and neither `SDLC_APP_ID` nor `SDLC_BOT_TOKEN` is configured — so the reviewer,' \
+                'the cross-audits and the gate matrix have **not** seen this commit.' '' \
+                'It is unvalidated, `agent:needs-fix` is still on this PR, and the loop cannot' \
+                'continue on its own. Re-run the checks by hand, or configure a bot credential' \
+                'so the loop closes itself.')" >/dev/null 2>&1 || true
+            fi
           else
             echo "Builder produced no commit to push."
           fi
       - name: Clear in-progress flag
         if: ${{ always() && steps.cap.outputs.proceed == 'true' }}
         run: |
-          # The push above re-runs the Reviewer, which re-adds agent:needs-fix (a fresh
-          # `labeled` event) if issues remain, or swaps in agent:reviewed-clean. We only
-          # drop the in-progress marker here — never agent:needs-fix (avoids a label race).
+          # With a bot credential the push above re-runs the Reviewer, which re-adds
+          # agent:needs-fix (a fresh `labeled` event) if issues remain, or swaps in
+          # agent:reviewed-clean. We only drop the in-progress marker here — never
+          # agent:needs-fix (avoids a label race).
+          #
+          # On the GITHUB_TOKEN fallback nothing re-runs, so agent:needs-fix simply
+          # stays and the loop halts; the push step warns and comments about that.
           gh pr edit "$PR" --remove-label "sdlc:fixing" >/dev/null 2>&1 || true


### PR DESCRIPTION
## I can't make the loop close — but I can stop it lying about being closed

**The credential is the fix, and only you can add it.** What I can fix is that the loop currently *asserts* something false.

## The finding

`sdlc-fix` pushes with `BOT_TOKEN`, which falls through to `github.token`:

```yaml
BOT_TOKEN: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
```

And that fallback is what's live — confirmed against the repo config:

```console
$ gh api repos/dshakes/distil/actions/variables --jq '.variables[].name'
PUBLISH_TO_PYPI                        # no SDLC_APP_ID

$ gh api repos/dshakes/distil/actions/secrets --jq '.secrets[].name'
ANTHROPIC_API_KEY  CLAUDE_CODE_OAUTH_TOKEN  GEMINI_API_KEY
NPM_TOKEN  OPENAI_API_KEY  TAP_TOKEN  TRAFFIC_TOKEN     # no SDLC_BOT_TOKEN
```

**GitHub raises no workflow events for pushes authenticated with `GITHUB_TOKEN`** — a deliberate recursion guard. So an auto-fix push re-runs *nothing*: not the reviewer, not the cross-audits, not the gate matrix. The fix lands unvalidated, `agent:needs-fix` stays, the loop halts.

Meanwhile the job printed:

```
Pushed fix to $HEAD_REF — Reviewer will re-run.
```

…and a comment two steps below asserted the same. A green job stating something false is precisely what #69, #70 and #75 removed from the publish jobs — here it's in the loop that's meant to *fix* things.

## The change

Truthful in both states. With a bot credential: the existing message. Without one: a warning **and a PR comment** saying the fix is unvalidated, nothing re-ran, the label is still set, and what to configure.

The comment matters more than the annotation — nobody reads the log of a job that passed, but the PR is where the human already is.

## Deliberately does *not* fail the job

`sdlc-ci-fix` triggers on `check_suite: completed`. A new failure here would feed the CI medic, which relabels `agent:needs-fix` and re-triggers this very workflow. **Turning a silent stall into a loop would be a worse bug than the one being fixed** — so this warns loudly instead, which is the opposite of the call made on the publish jobs and for a specific reason.

## To actually close the loop

| option | effect |
|---|---|
| `SDLC_APP_ID` + `SDLC_APP_PRIVATE_KEY` | documented path; App pushes trigger workflows |
| `SDLC_BOT_TOKEN` (PAT) | fallback; also triggers |

Either makes `HAS_BOT_CRED` true and the old message accurate again — no further code change needed.

## Verified

Both branches exercised, shell parses, `actionlint` clean.

Two self-inflicted problems caught on the way: my first version broke the YAML (a multi-line `--body` escaped the block scalar), and my `actionlint exit=$?` was reading `head`'s status through a pipe — the same trap that produced a wrong readout twice earlier today. Both fixed; the SC2016 suppression carries its reason, since the backticks are markdown code spans rather than shell.
