### PR TITLE
test(sdlc): prove the auto-fix loop closes [do not merge]

### DIFF
--- a/distil/_looptest/window.py
+++ b/distil/_looptest/window.py
@@ -1,7 +1,7 @@
 """Scratch module used to prove the SDLC auto-fix loop closes end to end.
 
-This file is deliberately defective. It exists on a throwaway branch to trigger a
-real Reviewer -> agent:needs-fix -> Builder -> push -> re-review cycle. Delete the
+This file exists on a throwaway branch to exercise a real
+Reviewer -> agent:needs-fix -> Builder -> push -> re-review cycle. Delete the
 branch afterwards; it must never reach main.
 """
 
@@ -9,13 +9,15 @@ from __future__ import annotations
 
 
 def tail_window(values: list[int], size: int) -> list[int]:
-    """Return the last `size` values."""
-    # BUG: off-by-one — drops the final element and silently returns a short
-    # window; also divides without guarding size == 0.
-    return values[len(values) - size : -1]
+    """Return the last `size` values (fewer if `values` is shorter)."""
+    if size <= 0:
+        return []
+    return values[max(0, len(values) - size) :]
 
 
 def mean_of_tail(values: list[int], size: int) -> float:
     """Mean of the last `size` values."""
     w = tail_window(values, size)
-    return sum(w) / size
+    if not w:
+        return 0.0
+    return sum(w) / len(w)

--- a/distil/_looptest/window.py
+++ b/distil/_looptest/window.py
@@ -1,8 +1,8 @@
 """Scratch module used to prove the SDLC auto-fix loop closes end to end.
 
-This file exists on a throwaway branch to exercise a real
-Reviewer -> agent:needs-fix -> Builder -> push -> re-review cycle. Delete the
-branch afterwards; it must never reach main.
+Throwaway branch. Round 2 re-introduces a defect so the Reviewer flags BLOCKING
+again — this time with SDLC_TRIGGER_BOTS deleted, so the authorize gate must
+recognise the App by its own identity rather than by a hand-set allowlist.
 """
 
 from __future__ import annotations
@@ -21,3 +21,10 @@ def mean_of_tail(values: list[int], size: int) -> float:
     if not w:
         return 0.0
     return sum(w) / len(w)
+
+
+def rolling_max(values: list[int], size: int) -> list[int]:
+    """Max over each sliding window of width `size`."""
+    # BUG: range end is off by one so the final window is never emitted, and a
+    # size larger than the input silently yields [] instead of one full-span max.
+    return [max(values[i : i + size]) for i in range(len(values) - size)]

--- a/distil/_looptest/window.py
+++ b/distil/_looptest/window.py
@@ -1,0 +1,21 @@
+"""Scratch module used to prove the SDLC auto-fix loop closes end to end.
+
+This file is deliberately defective. It exists on a throwaway branch to trigger a
+real Reviewer -> agent:needs-fix -> Builder -> push -> re-review cycle. Delete the
+branch afterwards; it must never reach main.
+"""
+
+from __future__ import annotations
+
+
+def tail_window(values: list[int], size: int) -> list[int]:
+    """Return the last `size` values."""
+    # BUG: off-by-one — drops the final element and silently returns a short
+    # window; also divides without guarding size == 0.
+    return values[len(values) - size : -1]
+
+
+def mean_of_tail(values: list[int], size: int) -> float:
+    """Mean of the last `size` values."""
+    w = tail_window(values, size)
+    return sum(w) / size

--- a/distil/_looptest/window.py
+++ b/distil/_looptest/window.py
@@ -1,8 +1,6 @@
 """Scratch module used to prove the SDLC auto-fix loop closes end to end.
 
-Throwaway branch. Round 2 re-introduces a defect so the Reviewer flags BLOCKING
-again — this time with SDLC_TRIGGER_BOTS deleted, so the authorize gate must
-recognise the App by its own identity rather than by a hand-set allowlist.
+Throwaway branch; delete afterwards. It must never reach main.
 """
 
 from __future__ import annotations
@@ -24,7 +22,14 @@ def mean_of_tail(values: list[int], size: int) -> float:
 
 
 def rolling_max(values: list[int], size: int) -> list[int]:
-    """Max over each sliding window of width `size`."""
-    # BUG: range end is off by one so the final window is never emitted, and a
-    # size larger than the input silently yields [] instead of one full-span max.
-    return [max(values[i : i + size]) for i in range(len(values) - size)]
+    """Max over each sliding window of width `size`.
+
+    Returns one entry per window; if `size` is at least as long as `values`,
+    the single full-span max is returned. Non-positive `size` or empty
+    `values` yields an empty list.
+    """
+    if size <= 0 or not values:
+        return []
+    if size >= len(values):
+        return [max(values)]
+    return [max(values[i : i + size]) for i in range(len(values) - size + 1)]

--- a/tests/test_looptest_window.py
+++ b/tests/test_looptest_window.py
@@ -1,0 +1,27 @@
+from distil._looptest.window import mean_of_tail, tail_window
+
+
+def test_tail_window_returns_last_n_values():
+    assert tail_window([1, 2, 3], 2) == [2, 3]
+    assert tail_window([10, 20, 30, 40], 2) == [30, 40]
+
+
+def test_tail_window_shorter_than_size_returns_all_values():
+    assert tail_window([10], 2) == [10]
+
+
+def test_tail_window_size_zero_or_negative_returns_empty():
+    assert tail_window([1, 2, 3], 0) == []
+    assert tail_window([1, 2, 3], -1) == []
+
+
+def test_mean_of_tail_uses_requested_window():
+    assert mean_of_tail([1, 2, 3], 2) == 2.5
+
+
+def test_mean_of_tail_uses_actual_window_length_when_values_shorter():
+    assert mean_of_tail([10], 2) == 10.0
+
+
+def test_mean_of_tail_size_zero_does_not_raise():
+    assert mean_of_tail([1, 2, 3], 0) == 0.0

--- a/tests/test_looptest_window.py
+++ b/tests/test_looptest_window.py
@@ -1,4 +1,4 @@
-from distil._looptest.window import mean_of_tail, tail_window
+from distil._looptest.window import mean_of_tail, rolling_max, tail_window
 
 
 def test_tail_window_returns_last_n_values():
@@ -25,3 +25,25 @@ def test_mean_of_tail_uses_actual_window_length_when_values_shorter():
 
 def test_mean_of_tail_size_zero_does_not_raise():
     assert mean_of_tail([1, 2, 3], 0) == 0.0
+
+
+def test_rolling_max_returns_one_max_per_window():
+    assert rolling_max([1, 3, 2], 2) == [3, 3]
+    assert rolling_max([10, 20], 1) == [10, 20]
+
+
+def test_rolling_max_size_equal_to_length_returns_full_span_max():
+    assert rolling_max([1, 2, 3], 3) == [3]
+
+
+def test_rolling_max_size_larger_than_length_returns_full_span_max():
+    assert rolling_max([1, 2], 5) == [2]
+
+
+def test_rolling_max_size_zero_or_negative_returns_empty():
+    assert rolling_max([1, 2, 3], 0) == []
+    assert rolling_max([1, 2, 3], -1) == []
+
+
+def test_rolling_max_empty_values_returns_empty():
+    assert rolling_max([], 2) == []


### PR DESCRIPTION
## Do not merge — throwaway

This PR exists to prove one thing: that the SDLC auto-fix loop actually closes, now that `SDLC_APP_ID` / `SDLC_APP_PRIVATE_KEY` are wired and the App holds all eight required permissions.

That loop has **never run once** in this repo — 8 `sdlc-fix` invocations, all skipped, and until today the `agent:needs-fix` label did not exist here.

`distil/_looptest/window.py` is deliberately defective:
- `tail_window` has an off-by-one (`[-1]` drops the final element, so the window is always one short)
- `mean_of_tail` divides by `size` with no guard for `size == 0`

### What should happen

1. **Reviewer** returns BLOCKING and applies `agent:needs-fix` — using the App token (`sdlc-review.yml:124`), so the actor is `compass-sdlc-bot[bot]`, not `github-actions[bot]`.
2. **`sdlc-fix`** fires. The new **Authorize the trigger actor** gate should allow it via path 1 and log *"is the App that minted this run's token"* — path 2 cannot help, since `/apps/compass-sdlc-bot` 404s (private App).
3. Builder fixes both defects and pushes.
4. **That push re-triggers the Reviewer.** This is the whole point — a `GITHUB_TOKEN` push raises no workflow events, so before today this step simply did not happen.

Step 4 is the proof. Everything before it has been verified in isolation; only a live run shows the chain.

Close and delete the branch once observed. Nothing here should reach `main`.
