### PR TITLE
fix(sdlc): let a red CI actually reach the fixer

### DIFF
--- a/.github/workflows/sdlc-ci-fix.yml
+++ b/.github/workflows/sdlc-ci-fix.yml
@@ -44,6 +44,22 @@ jobs:
       SHA: ${{ github.event.check_suite.head_sha }}
       SUITE_ID: ${{ github.event.check_suite.id }}
     steps:
+      # The label this job applies is the ONLY thing that starts sdlc-fix.yml, and
+      # GitHub raises no workflow events for actions taken with GITHUB_TOKEN. Applying
+      # `agent:needs-fix` with the default token therefore labels the PR and wakes
+      # nothing — the CI→fix chain looks wired and is inert. Mint the App token so the
+      # label comes from a real bot identity. (Job-level `env` cannot see `steps.*`,
+      # so the token is applied per-step below rather than to GH_TOKEN up top.)
+      - name: Mint GitHub App token
+        id: apptoken
+        if: ${{ vars.SDLC_APP_ID != '' }}
+        # A missing/invalid key must not fail the job — fall through to
+        # SDLC_BOT_TOKEN / github.token and say so at the end.
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SDLC_APP_ID }}
+          private-key: ${{ secrets.SDLC_APP_PRIVATE_KEY }}
       - name: Resolve failing run
         id: run
         run: |
@@ -99,6 +115,10 @@ jobs:
           RUN_ID: ${{ steps.run.outputs.run_id }}
           RUN_URL: ${{ steps.run.outputs.run_url }}
           RUN_NAME: ${{ steps.run.outputs.run_name }}
+          # Step-level override of the job's GH_TOKEN: the label applied below must come
+          # from a bot identity or sdlc-fix.yml never fires.
+          GH_TOKEN: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
+          HAS_BOT_CRED: ${{ (steps.apptoken.outputs.token != '' || secrets.SDLC_BOT_TOKEN != '') && 'true' || 'false' }}
         run: |
           set -uo pipefail
           labels="$(gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null || true)"
@@ -122,14 +142,33 @@ jobs:
             gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -c 4000 || echo "(logs not available yet — see the run link)"
             printf '\n```\n\n'
             # shellcheck disable=SC2016  # literal markdown backticks, not expansion
-            printf '%s\n' '_compass ci-fix: handing this to the auto-fix loop (`agent:needs-fix`). Disable with repo variable `SDLC_CI_FIX=off`._'
+            if [ "$HAS_BOT_CRED" = "true" ]; then
+              printf '%s\n' '_compass ci-fix: handing this to the auto-fix loop (`agent:needs-fix`). Disable with repo variable `SDLC_CI_FIX=off`._'
+            else
+              printf '%s\n' '_compass ci-fix: labelled `agent:needs-fix`, but **no auto-fix will start** — no' \
+                            'bot credential was available, so the label was applied with `GITHUB_TOKEN` and' \
+                            'GitHub raises no workflow events for it. Fix this by hand, or configure' \
+                            '`SDLC_APP_ID` + `SDLC_APP_PRIVATE_KEY` (or `SDLC_BOT_TOKEN`)._'
+            fi
           } > "$body"
           gh pr comment "$PR" --body-file "$body"
           gh label create "agent:needs-fix" --color d93f0b --force >/dev/null 2>&1 || true
           # Remove + re-add so a fresh `labeled` event fires even if a stale label lingered.
           gh pr edit "$PR" --remove-label "agent:needs-fix" >/dev/null 2>&1 || true
           gh pr edit "$PR" --add-label "agent:needs-fix"
-          echo "PR #$PR labeled agent:needs-fix — sdlc-fix.yml takes it from here."
+          if [ "$HAS_BOT_CRED" = "true" ]; then
+            echo "PR #$PR labeled agent:needs-fix — sdlc-fix.yml takes it from here."
+          else
+            # Do not repeat the mistake this repo keeps finding: a green job asserting a
+            # handoff that cannot happen. Warn instead of claiming.
+            echo "::warning::PR #$PR was labeled agent:needs-fix, but NOTHING will pick it up."
+            echo "::warning::No bot credential was available, so the label was applied with"
+            echo "::warning::GITHUB_TOKEN — GitHub raises no workflow events for that token, so"
+            echo "::warning::sdlc-fix.yml will not fire. Either no credential is configured"
+            echo "::warning::(SDLC_APP_ID + SDLC_APP_PRIVATE_KEY, or SDLC_BOT_TOKEN), or the App"
+            echo "::warning::token step failed to mint one — it runs under continue-on-error, so"
+            echo "::warning::check its log before assuming the secrets are missing."
+          fi
 
   # ---------------------------------------------------------------------------
   # Default-branch path — rerun once (flakes are free), then a bounded CI medic


### PR DESCRIPTION
## The bug

`sdlc-ci-fix` applies `agent:needs-fix`. That label is the **only** trigger for `sdlc-fix.yml`. It was applying it with `github.token` — and GitHub raises no workflow events for that token, so the label landed and woke nothing.

The CI→fix half of the loop has been inert since installation. Not "occasionally flaky" — structurally incapable of firing.

This is the **third** instance of the same shape here:

| Chain | Symptom |
|---|---|
| classifier → design-review | 26 `domain:ui` labels in `lantern`, **0** runs |
| fixer → reviewer | fixed in #76 (push with `GITHUB_TOKEN` re-ran nothing) |
| **CI → fixer** | this PR |

Each looked wired, applied its label, reported success, and moved nothing.

## The fix

Mint the App token and label with it. Job-level `env` cannot reference `steps.*`, so the override goes on the labelling step rather than the job's `GH_TOKEN` — the same shape `sdlc-review.yml` already uses.

## Also: stop claiming a handoff that cannot happen

With no bot credential the job printed `sdlc-fix.yml takes it from here` and commented the same on the PR. Both false. Now the log warns and the PR comment says plainly that no auto-fix will start, and why — naming the *mint-failure* case as well as the missing-secret one, since the mint runs under `continue-on-error`.

## Verification

- YAML parse asserting the mint step exists (`if: vars.SDLC_APP_ID != ''`, `continue-on-error: true`) and that `GH_TOKEN` / `HAS_BOT_CRED` are overridden at step level
- `shellcheck -S warning` clean on the changed step
- Both message branches tested: the handoff is claimed **only** when a bot credential exists, and the failure branch names both possible causes

## Context

The reviewer→fixer chain was proven live earlier today (PR #78, closed): two full cycles, the second with `SDLC_TRIGGER_BOTS` deleted so the App authorised itself via its own minted identity. This PR brings the CI trigger up to the same standard.
