### PR TITLE
fix(sdlc): read CI logs with github.token, not the App

### DIFF
--- a/.github/workflows/sdlc-ci-fix.yml
+++ b/.github/workflows/sdlc-ci-fix.yml
@@ -119,6 +119,11 @@ jobs:
           # from a bot identity or sdlc-fix.yml never fires.
           GH_TOKEN: ${{ steps.apptoken.outputs.token || secrets.SDLC_BOT_TOKEN || github.token }}
           HAS_BOT_CRED: ${{ (steps.apptoken.outputs.token != '' || secrets.SDLC_BOT_TOKEN != '') && 'true' || 'false' }}
+          # The step's GH_TOKEN is a bot identity so the LABEL raises an event. The log
+          # fetch below must NOT use it: an App without Actions:read would fail the read,
+          # hit the `|| echo "(logs not available)"` fallback, and hand the Builder an
+          # empty failure report — silently, which is the worst version of this bug.
+          LOG_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           labels="$(gh pr view "$PR" --json labels --jq '.labels[].name' 2>/dev/null || true)"
@@ -139,7 +144,7 @@ jobs:
             printf '🔴 **CI failed** on this PR — workflow **%s** ([run](%s)). Failing-step log excerpt:\n\n' "$RUN_NAME" "$RUN_URL"
             printf '```\n'
             # Log text is untrusted CI output: fenced verbatim as data for the Builder.
-            gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -c 4000 || echo "(logs not available yet — see the run link)"
+            GH_TOKEN="$LOG_TOKEN" gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -c 4000 || echo "(logs not available yet — see the run link)"
             printf '\n```\n\n'
             # shellcheck disable=SC2016  # literal markdown backticks, not expansion
             if [ "$HAS_BOT_CRED" = "true" ]; then


### PR DESCRIPTION
## The regression

#79 added a step-level `GH_TOKEN` override so the **label** is applied by a bot identity — that is the only thing that raises the workflow event and wakes `sdlc-fix.yml`.

But the override captured the whole step, including the `gh run view --log-failed` that gathers the failure report handed to the Builder.

An App without `Actions: read` would then fail that read, fall through the existing guard:

```
gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -c 4000 \
  || echo "(logs not available yet — see the run link)"
```

…and hand the Builder an **empty failure report**. Silently. The agent would be asked to fix a CI failure it was never shown — worse than the job erroring outright, because it looks like it worked.

## The fix

The log fetch runs under `github.token`, which always has Actions read for its own repo. Only the comment and the label keep the bot identity, which is all they ever needed.

## Scope

This account's App does hold `actions: write`, so the bug would not have bitten here. It is fixed anyway because:

- the same change went into `compass`'s `sdlc/workflows/` **template**, which installs into every repo — where the App may hold a narrower permission set
- "works because of a permission nobody wrote down" is not a property worth depending on

Companion PRs: dshakes/compass#107 and dshakes/lantern#215 carry the identical fix.

## Verification

- `LOG_TOKEN` resolves to `github.token`
- the log fetch is pinned to it; the label is **not** (asserted separately, since pinning the label would silently re-break the whole chain)
- `shellcheck -S warning` clean
- both ci-fix message branches still pass — the handoff is claimed only when a credential exists

## Credit

Found by the Codex cross-audit on dshakes/compass#107, one commit after I introduced it.
