### PR TITLE
release(1.40.0): what recall cannot see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.40.0] — what recall cannot see
+
+Four state probes, both priced surfaces, and every result as a reproducible record.
+
+`distil retention` answers "is the fact still there". `distil fidelity` answers the
+questions that survive a yes:
+
+- **artifact state** — is the file's final STATE right, or only its name present?
+  `stale` (present, wrong) is reported apart from `lost` (absent), because a
+  compressor that drops a whole file history is safer than one that preserves half
+  of it: the first leaves a gap the agent can see, the second leaves a false belief
+  it acts on.
+- **overclaim** — did the value keep its uncertainty? `"approximately 4200 ms"` →
+  `"4200 ms"` is a distortion every recall metric scores perfect. Reversing a bound
+  (`at least 3` → `at most 3`) is reported separately as `inverted`.
+- **continuation** — does the agent still know what is left to do?
+- **propagation** — does a loss at turn *k* show up as a changed decision at *k+n*?
+
+Both halves of the bill are graded: what the model READS, and what its own past
+answers cost when they re-enter as history.
+
+`--json` now emits an **eval record** rather than bare metrics — schema version,
+dataset fingerprint, subject identity, grader provenance, and gates carrying
+threshold, observation and outcome. A number nobody can reproduce or compare is a
+number nobody should act on. The schema ships at `schemas/eval-record.schema.json`
+and is validated against real output.
+
+**Measured on the shipped reversible tier:** artifact state 100% (7/7), hedge
+fidelity 94.7% (162/171) with 9 genuine overclaims, pending-work recall 100%,
+output surface 6 blocks digested with 4 facts removed and 0 silent failures. CI
+gates at `--max-silent 15` — the *measured* band, not zero, because gating at zero
+would assert a property the compressor does not have.
+
+The rule these probes enforce is that **no gate may pass without evidence**, and
+the cross-audit found it broken in six places — each one green, each one measuring
+nothing: an empty gate list, a fresh shadow ledger, an unscored output surface, a
+propagation profile with no events, a threshold accepted without running, and a
+probe with a zero denominator. All six now fail rather than certify. Three sweeps
+close the classes underneath: every alternative of every alternation must fire, no
+gate may certify an evidence-free input, and every `distil …` command printed in
+the docs must actually parse.
+
+Also in this release: the SDLC auto-fix loop closes end-to-end (#74–#80). A
+`GITHUB_TOKEN` push raises no workflow events, which had silently broken three
+chains.
+
+Upgrading is safe and additive — no behaviour of the compressor, proxy or CLI
+changes. `distil fidelity` is new; every existing command keeps its output shape.
+
 ## [1.39.1] — the release path, hardened and then actually run
 
 **The installed package is unchanged.** Every commit since 1.39.0 touches

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.39.1
-date-released: 2026-07-31
+version: 1.40.0
+date-released: 2026-08-05
 keywords:
   - llm
   - context-compression

--- a/docs/RUNNING-EVALS.md
+++ b/docs/RUNNING-EVALS.md
@@ -120,7 +120,7 @@ five things you need to reproduce or compare them.
 {
   "schema": "distil.eval/1",          // so a consumer knows when the shape changed
   "run":     { "at": "...", "duration_ms": 218,
-               "env": { "distil": "1.39.1", "python": "3.9.25", "platform": "darwin-arm64" } },
+               "env": { "distil": "1.40.0", "python": "3.9.25", "platform": "darwin-arm64" } },
   "subject": { "compressor": "Tier1Reversible", "module": "distil.compress.tier1" },
   "dataset": { "name": "corpus", "trajectories": 9,
                "domains": [...],

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.39.1"
+version = "1.40.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.39.1",
+  "version": "1.40.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.39.1",
+      "version": "1.40.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.39.1"
+version = "1.40.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts the eval suite from #81. Additive: no compressor, proxy or CLI behaviour changes.

Version bumped in all seven places `tests/test_packaging_smoke.py` checks — pyproject.toml, CITATION.cff (version + date-released), server.json (×2), packaging/npm/package.json, plugins/distil/.claude-plugin/plugin.json — plus the sample record in docs/RUNNING-EVALS.md.

Homebrew formula is pinned in a follow-up once the tarball exists, as with 1.39.1.

Known non-blocking items from the #81 cross-audit are tracked for the follow-up PR: offline `extract_ops` argument suppression (Medium), `--max-silent` diagnostic completeness (Low), a stale `subject` in a doc sample, and an `at_risk_facts == 0` reporting nuance.