### PR TITLE
chore(homebrew): pin the formula sha256 to the v1.40.0 tarball

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.39.1 source tarball. To recompute for a new version:
+# sha256 is for the v1.40.0 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.39.1.tar.gz"
-  sha256 "a3b51fd6f08f7837ea8cc255a5f2045823d03eb0bee537e2ff84809bde13c615"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.40.0.tar.gz"
+  sha256 "3d7d4b20a53ca0bd965a730848c728133d822f5cbb6cf220abca8935efa68149"
   license "Apache-2.0"
-  version "1.39.1"
+  version "1.40.0"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
Post-release step, same as every prior version. The v1.40.0 tag exists so the tarball hash is knowable.

Verified by re-downloading the published tarball and comparing digests — the pinned `sha256` matches what GitHub serves.