### PR TITLE
release(1.40.1): the numbers, corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.40.1] — the numbers, corrected
+
+Bug fixes and honest reporting. No compressor, proxy or CLI behaviour changes; the
+1.40.0 eval suite is unchanged.
+
+**`distil stats` crashed on a legacy Windows console.** The savings line contains
+`→`, and Python's default `errors="strict"` turns that into a `UnicodeEncodeError`
+mid-render on a cp1252 terminal: exit 1, a traceback, output truncated. It only fired
+once a ledger had baseline tokens, so it had been invisible since the line was
+written. Streams now degrade with `errors="replace"` instead of failing — a
+reporting tool must never fail on the report.
+
+**A lifetime figure was being read as the current rate.** Validating the published
+adoption numbers against this repo's own ledger found both correct and both
+misleading the same way: `−20.4%` lifetime against `−0.4%` over the last 7 days, two
+orders of magnitude apart, with only the lifetime number shown. `distil stats` now
+prints the recent window whenever it disagrees, names the cause, and names the
+remedy. A window that comes out LARGER than baseline reads `+10.0% LARGER` rather
+than the previous `−-10.0%`, and gets advice for overhead rather than for
+lossless-only.
+
+**The subscription default never said what it costs.** A subscription session runs
+lossless-only so no digest is left unrecoverable — correct, and Tier-0 only, which
+measures ~0-2% against the 30-60% the recoverable digest reaches. The notice now
+leads with that cost and offers the persistent opt-in (`distil default --mode
+expand`) rather than only the per-run flag. **The default itself is unchanged.**
+
+**Offline artifact parsing.** A tool call's own ARGUMENTS no longer condemn it — a
+successful `Write(file_path="a.py", content="No such file or directory")` was
+recording nothing. The call boundary is parsed (paren depth, quote-aware) rather
+than guessed from a `->` delimiter, and only a closed set of recognised invocation
+heads gets that immunity, so an exception repr or a result wrapper is still read as
+evidence. Ops inside one call share its outcome, so a failed
+`Bash(command="rm a.py && touch b.py")` records neither. The live path was never
+affected: it knows the real call/result boundary.
+
+Also: `--max-silent` diagnostics name every component of their own total, the eval
+record's `subject` in the docs matches what the CLI emits, and an output surface
+that changed blocks but endangered no facts says so.
+
 ## [1.40.0] — what recall cannot see
 
 Four state probes, both priced surfaces, and every result as a reproducible record.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.40.0
+version: 1.40.1
 date-released: 2026-08-05
 keywords:
   - llm

--- a/docs/RUNNING-EVALS.md
+++ b/docs/RUNNING-EVALS.md
@@ -120,7 +120,7 @@ five things you need to reproduce or compare them.
 {
   "schema": "distil.eval/1",          // so a consumer knows when the shape changed
   "run":     { "at": "...", "duration_ms": 218,
-               "env": { "distil": "1.40.0", "python": "3.9.25", "platform": "darwin-arm64" } },
+               "env": { "distil": "1.40.1", "python": "3.9.25", "platform": "darwin-arm64" } },
   "subject": { "compressor": "_ServingSurface", "module": "distil.compress.strategies" },
   "dataset": { "name": "corpus", "trajectories": 9,
                "domains": [...],

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.40.0"
+version = "1.40.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.40.0",
+  "version": "1.40.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.40.0"
+version = "1.40.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts the fixes from #83. **No compressor, proxy or CLI behaviour changes** — the 1.40.0 eval suite is unchanged, and the subscription safety default is unchanged.

- `distil stats` crashed with `UnicodeEncodeError` on a legacy Windows console once a ledger had baseline tokens (broken since that line was written; no test had ever exercised it).
- A lifetime savings figure read as the current rate: −20.4% lifetime vs −0.4% over 7 days on this repo's own ledger, with only the first shown. Negative windows rendered `−-10.0%`.
- The subscription default never stated its cost or the persistent opt-in.
- Offline artifact parsing: a call's own arguments no longer condemn it, behind a closed allowlist so result wrappers and exception reprs are still evidence.

Version bumped in the seven locations `tests/test_packaging_smoke.py` checks. Homebrew pin follows once the tag exists.