### PR TITLE
chore(homebrew): pin the formula sha256 to the v1.40.1 tarball

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.40.0 source tarball. To recompute for a new version:
+# sha256 is for the v1.40.1 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.40.0.tar.gz"
-  sha256 "3d7d4b20a53ca0bd965a730848c728133d822f5cbb6cf220abca8935efa68149"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.40.1.tar.gz"
+  sha256 "986ab2110c66e6a0bb5f8e20547a148275d375567c524d84ff3a951e67b35957"
   license "Apache-2.0"
-  version "1.40.0"
+  version "1.40.1"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
Post-release step, as with every prior version — the tag exists, so the tarball hash is knowable.

Verified twice: the digest is stable across two independent fetches, and the pinned value matches what GitHub serves for `v1.40.1`.