### PR TITLE
release(1.41.0): what the cache bought, and what a name is worth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,93 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.41.0] — what the cache bought, and what a name is worth
+
+Three things of the same shape: a claim distil could make but not show, and a number
+that was true for the wrong reason.
+
+### `distil cache` — the observability half of cache alignment
+
+distil already *prevented* prefix drift by construction. `strategies.distil` compresses
+the volatile tail and leaves every stable block byte-identical, so compression cannot be
+the cause of a cache miss. What was missing was any way to **show** it — and any way to
+name the case distil cannot fix: a caller whose own system prompt carries a timestamp.
+
+The report deliberately mixes two kinds of number. Cache reads and writes come from the
+provider's own `usage` — ground truth about money. Prefix drift is distil's diagnosis of
+why, from a content-free hash of the stable blocks it sent. It never prints one without
+the other, because a diagnosis with no measurement behind it is a guess.
+
+```
+requests        3
+cache reads     31,614 tokens  (billed at a discount)
+cache writes    15,819 tokens  (billed at a surcharge)
+hit ratio       66.6% of cacheable tokens were reads
+prefix drift    1 of 2 turns changed the stable prefix (50%)
+```
+
+Verified live on both the streaming and non-streaming paths: the prefix held across a
+turn append, then a session id prepended to the system prompt forced a re-create. The
+turn the hash flagged is the turn the provider re-billed — derived independently,
+agreeing. Only `system`, `tools` and `tool_choice` are hashed: a conversation growing is
+not drift, and a warning that fires on every healthy turn is one people switch off.
+
+The proxy now records `usage_cache_read` and `usage_cache_create` separately. Summed,
+they cannot tell a working cache from a thrashing one — a write is a surcharge, a read a
+discount, and a prefix that drifts every turn writes forever and never reads.
+
+With no proxied requests, `distil cache` exits non-zero rather than printing a
+reassuring zero. A cache report over no data reads as a clean bill of health for a
+session nobody measured.
+
+New: [docs/CACHE.md](docs/CACHE.md), including the one cache feature deliberately **not**
+shipped — a response cache — and the three reasons why.
+
+### BFCL was being scored as prose
+
+Its golds are bare code names; the generic matcher anchors on non-word boundaries. On
+the n=25 sample that credited **11 of 85 golds by accident** — `'a'` matching inside
+`"tool-schemas"`.
+
+Names are now matched as **identifiers**: a quoted JSON token, tolerating one level of
+escaping. The escaping is the part that makes it work — a tool schema is JSON nested
+inside a JSON payload, so its quotes arrive as `\"base\"`. An earlier attempt requiring
+a bare `"base"` read **2.9%** on a payload where every name was plainly present; that
+number measured the matcher, not the compressor. This removes the "upper bound" caveat
+that shipped with 1.40.0.
+
+Support recall is now **100.0%** — and the report says what that means. **Visible recall
+is 0%**: the schema sits behind a restore handle, one `distil_expand` away. At matched
+savings (89.3% vs 90.1%) truncation keeps **0 of 70** names; distil keeps all 70, none of
+them on screen. The table prints `visible → true support: bfcl 0%→100%` rather than the
+flattering figure alone, because a reader who assumes the model can *see* a schema it
+must first expand has been misled by numbers that are each individually correct.
+
+Fifteen golds BFCL genuinely names `a`, `b`, `c` are excluded **and counted**. A
+one-letter token occurs in almost any English text, so it can be neither credited nor
+failed honestly — the same treatment as an abstractive answer. A recall computed against
+a quietly reduced denominator is an inflated result.
+
+### `make gate` was weaker than CI
+
+CI ran `distil validate`; the Makefile did not. A local green gate promised a push it
+could not deliver — the one thing that target exists to prevent. Added, along with a test
+that compares the two by invoked subcommand and fails naming the missing one.
+
+### Also
+
+- Three tests fetched BFCL **live** to assert on `--min-recall` gate logic. Seven CI
+  runners hitting the same endpoint produced an HTTP 429, and the assertion degraded into
+  comparing its expected string against a rate-limit message. A red gate meaning "a third
+  party throttled us" trains people to re-run until green. They run offline now.
+- `eval-stack.svg` still said five gates and omitted `distil suite`. Rebuilt animated,
+  six gates lighting in run order.
+- `phantom-file.svg` and `cache-delta.svg` animated — the deletion is struck through and
+  dimmed, and the two re-read bars race at true relative scale. Both resolve to their end
+  state under `prefers-reduced-motion`.
+- `cli.html` never got a `suite` section from 1.40.0. Added, with `cache`.
+- `evals.html` was marking Corpus as the active nav page.
+
 ## [1.40.1] — the numbers, corrected
 
 Bug fixes and honest reporting. No compressor, proxy or CLI behaviour changes; the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.40.1
+version: 1.41.0
 date-released: 2026-08-05
 keywords:
   - llm

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.40.1",
+  "version": "1.41.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.40.1",
+  "version": "1.41.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.40.1"
+version = "1.41.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.40.1",
+  "version": "1.41.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.40.1",
+      "version": "1.41.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.40.1"
+version = "1.41.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Ships #88.

## Highlights

**`distil cache`** — distil already *prevented* prefix drift by construction; now it can show it, and name the case it cannot fix. Reads and writes come from the provider's own `usage` (ground truth about money); prefix drift is our diagnosis, from a content-free hash. It never prints one without the other. Verified live on streaming and non-streaming: the turn our hash flagged is the turn the provider re-billed 15,819 tokens.

**BFCL is no longer scored as prose** — 11 of 85 golds were being credited by accident. Matching names as quoted JSON tokens (tolerating the schema-in-payload escaping) takes support recall to 100.0% and removes the "upper bound" caveat 1.40.0 shipped with. The report now states that this is **true** recall and visible is **0%**, because a reader who assumes the model can see a schema it must first expand has been misled by correct numbers.

**`make gate` now runs everything CI runs.** It was missing `distil validate`, so a local green gate promised a push it could not deliver.

Full detail in [CHANGELOG.md](CHANGELOG.md).

## Version bump

All six locations, with `tests/test_packaging_smoke.py` green — the gate that exists because "four files" was once wrong and let 1.35.0 fail its own packaging check:

- `pyproject.toml`
- `CITATION.cff`
- `server.json` (×2)
- `packaging/npm/package.json`
- `plugins/distil/.claude-plugin/plugin.json`

## Gates

| gate | result |
|---|---|
| `distil bench` | PASS |
| `distil verify` | PASS |
| `distil validate` | PASS — 60/60 |
| `distil retention --max-lost 0` | PASS — 0 lost |
| `distil fidelity --max-silent 15` | PASS — 9 silent |
| `distil suite --tier 1` | PASS — 3 rich rows at 100% |

Coverage **95.08%**, **2784 passed**, ruff clean, `distil --version` → `1.41.0`.