### PR TITLE
release(1.41.1): the diagrams, and the one nobody could turn off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.41.1] — the diagrams, and the one nobody could turn off
+
+Documentation and accessibility only. No compressor, proxy or CLI behaviour changes.
+
+**Six diagrams were stills.** Each now carries the motion its own argument needs
+rather than a uniform fade: `ast-delta`'s three "same AST → unchanged" verdicts land
+one at a time, because the claim is cumulative — a reader has to watch reformatting
+fail to count, three times, before "1 / 3 defs" means anything. `io` sends a packet
+down each leg, because the point is that *both* directions are billed and a reader who
+only sees the outbound arrow half-remembers that. `vision`'s duplicate tiles dim as
+they are elided, so it reads as "these two, and only these two". `observability`
+reveals its four scopes left to right, because the claim is that each is *wider* than
+the last. `install` is a menu rather than an argument, so its cards simply deal in.
+`banner` is deliberately restrained — it is the README hero, and the only thing that
+moves is the mark's three bars, which already encode compression by narrowing.
+
+`logo`, `logo-lockup` and `og` stay static. A favicon that moves is a bug, and every
+social platform renders an OpenGraph card as a still — animating it risks the frame a
+scraper happens to capture being a half-drawn one.
+
+**`hero-terminal.svg` had twelve animations and no `prefers-reduced-motion` guard.**
+It had been on the landing page since the redesign, through an entire accessibility
+series, because nothing checked. It is also the awkward case: it plays once and
+freezes rather than looping, so the usual `animate { display: none }` would have left
+it permanently blank — every group starts at opacity 0, the typed lines are revealed
+by zero-width clip rects, and the result box is drawn by a dash offset. The guard
+asserts the end state of each. A hero that renders as an empty terminal for anyone
+with reduced motion enabled is worse than one that animates.
+
+**Four diagrams had no accessible name at all** — `cache-aware`, `cross-sdk`,
+`domains`, `head-to-head`. `<img alt>` names them on a page, but an SVG is also a
+document people open directly (GitHub renders `docs/assets/*.svg` as a page) and there
+`alt` does not exist. Titles and descriptions now travel with the files.
+
+**`tests/test_svg_assets.py`** makes all of it permanent: well-formed XML, a
+reduced-motion guard on anything that moves, `keyTimes` that start at 0 and end at 1
+and are non-decreasing, `values`/`keyTimes` counts that agree, and an accessible name.
+Both failure modes were verified to fail the test rather than assumed to. Static and
+unnamed assets are allowlisted with their reason, so the next one has to be argued for.
+
 ## [1.41.0] — what the cache bought, and what a name is worth
 
 Three things of the same shape: a claim distil could make but not show, and a number

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.41.0
+version: 1.41.1
 date-released: 2026-08-05
 keywords:
   - llm

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.41.0"
+version = "1.41.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.41.0",
+  "version": "1.41.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.41.0"
+version = "1.41.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Ships #91. Documentation and accessibility only — no compressor, proxy or CLI behaviour changes.

## Why this is worth a release

Two things the SVG audit found that nothing was checking:

**`hero-terminal.svg` had twelve animations and no `prefers-reduced-motion` guard** — on the landing page since the redesign, straight through an entire accessibility series. It's also the awkward case: it plays once and freezes rather than looping, so the usual `animate { display: none }` would have left it permanently blank. The guard asserts each element's end state instead.

**Four diagrams had no accessible name at all.** `<img alt>` names them on a page, but GitHub renders `docs/assets/*.svg` as a page of its own, and there `alt` doesn't exist.

Plus six diagrams animated, each with the motion its own argument needs — detailed in [CHANGELOG.md](CHANGELOG.md).

`tests/test_svg_assets.py` makes it permanent, and I verified it catches both a stripped guard and a truncated `keyTimes` list rather than assuming it would.

## Version bump

All six locations, `tests/test_packaging_smoke.py` green:

- `pyproject.toml` · `CITATION.cff` · `server.json` (×2) · `packaging/npm/package.json` · `plugins/distil/.claude-plugin/plugin.json`

Coverage **95.08%**, **2880 passed**, ruff clean, `distil --version` → `1.41.1`.