### PR TITLE
fix(setup,doctor): prove the route before wiring, and reach every file on undo

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1963,13 +1963,15 @@ def cmd_default(args: argparse.Namespace) -> int:
     from . import onboard
     from .setup import (
         alias_body,
+        claude_settings_files,
         default_settings_path,
         detect_shell,
         env_body,
+        probe_routing,
         remove_managed,
         service_spec,
         service_unload_cmd,
-        unwire_settings_env,
+        unwire_base_url,
         wire_settings_env,
         write_managed,
     )
@@ -1998,11 +2000,21 @@ def cmd_default(args: argparse.Namespace) -> int:
                 print(f"✓ removed proxy service {path}")
             except OSError:
                 pass
-        if agent == "claude":  # inverse of the settings.json wiring below
-            st2, msg2 = unwire_settings_env(
-                default_settings_path(), "ANTHROPIC_BASE_URL", f"http://127.0.0.1:{args.port}"
-            )
-            print(("✓ " if st2 in ("ok", "absent", "foreign") else "✗ ") + msg2)
+        if agent == "claude":
+            # Sweep EVERY settings file Claude Code merges, not just ~/.claude/settings.json,
+            # and match on "loopback" rather than on this run's --port. The old undo did the
+            # opposite on both counts, so an entry written on another port, or written into a
+            # project's .claude/settings.local.json (which overrides the home file), survived
+            # the uninstall and kept killing sessions after distil was gone from the machine.
+            cleaned = 0
+            for sp in claude_settings_files():
+                st2, msg2 = unwire_base_url(sp)
+                if st2 == "absent":
+                    continue  # the common case for most of these paths; saying so is noise
+                print(("✓ " if st2 in ("ok", "foreign") else "✗ ") + msg2)
+                cleaned += st2 == "ok"
+            if not cleaned:
+                print("✓ no ANTHROPIC_BASE_URL left in any Claude Code settings file")
         print(f"  open a new terminal (or: source {rc}) to finish")
         return 0
 
@@ -2020,6 +2032,22 @@ def cmd_default(args: argparse.Namespace) -> int:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         print(f"✓ wrote proxy service → {path}")
+        # Start, PROVE it routes, and only then wire the base URL. The old order wired
+        # first and reported success from `launchctl load`'s exit code, which means "the
+        # job was accepted" — not "the proxy serves requests". A proxy that binds the port
+        # and 404s (wrong --upstream, stale build) then took down every Claude Code session
+        # on the machine, disguised as "there's an issue with the selected model".
+        if load and not args.no_start:
+            ok = subprocess.run(load, shell=True).returncode == 0
+            print("  ✓ proxy service started" if ok else f"  ⚠ start it manually: {load}")
+        routed, detail = probe_routing("127.0.0.1", args.port)
+        if not routed:
+            print(f"\n✗ preflight failed — {detail}")
+            print("  Nothing was wired. Your existing setup is untouched.")
+            print(f"  See the error yourself:  distil proxy --{mode} --port {args.port}")
+            print("  Then re-run this command.")
+            return 1
+        print(f"✓ preflight: {detail}")
         _st, msg = write_managed(rc, env_body(args.port, shell=shell))
         print(f"✓ {msg}  (ANTHROPIC_BASE_URL → http://127.0.0.1:{args.port})")
         if agent == "claude":
@@ -2036,9 +2064,6 @@ def cmd_default(args: argparse.Namespace) -> int:
             print(f"{glyph2} {msg2}")
             if st2 == "conflict":
                 print(f"  re-run with: distil default --always-on --force  (backs up {sp} first)")
-        if load and not args.no_start:
-            ok = subprocess.run(load, shell=True).returncode == 0
-            print("  ✓ proxy service running" if ok else f"  ⚠ start it manually: {load}")
         print(
             f"\nEvery base-URL-honoring tool now routes through distil. Reload your shell (source {rc})."
         )

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2104,12 +2104,14 @@ def cmd_offboard(args: argparse.Namespace) -> int:
 
     from . import onboard
     from .setup import (
+        claude_settings_files,
         default_settings_path,
         detect_shell,
+        loopback_base_url,
         remove_managed,
         service_spec,
         service_unload_cmd,
-        unwire_settings_env,
+        unwire_base_url,
         unwire_statusline,
     )
 
@@ -2154,12 +2156,28 @@ def cmd_offboard(args: argparse.Namespace) -> int:
         st, msg = unwire_statusline(sp)
         print(("✓ " if st in ("ok", "absent", "foreign") else "✗ ") + msg)
 
-    # 3b · the settings.json ANTHROPIC_BASE_URL that --always-on wires for IDE-
-    # launched Claude Code (VSCode, Cursor's Claude Code extension, ...), which
-    # never goes through a shell rc file and so isn't touched by step 1.
-    if sp.exists() and ask(f"Unwire distil's ANTHROPIC_BASE_URL from {sp}?"):
-        st, msg = unwire_settings_env(sp, "ANTHROPIC_BASE_URL", "http://127.0.0.1:8788")
-        print(("✓ " if st in ("ok", "absent", "foreign") else "✗ ") + msg)
+    # 3b · the ANTHROPIC_BASE_URL that --always-on wires for IDE-launched Claude Code
+    # (VSCode, Cursor's Claude Code extension, ...), which never goes through a shell rc
+    # file and so isn't touched by step 1.
+    #
+    # This step had three bugs and each one alone was enough to leave the machine broken
+    # after a "successful" offboard: it read only ~/.claude/settings.json when Claude Code
+    # also merges project settings that OVERRIDE it; it matched the value against a
+    # hardcoded :8788, so any other port was judged foreign and kept; and it was gated on
+    # that one file existing, so a machine without it was asked nothing and cleaned
+    # nothing — anywhere. Sweep every file, match by shape, prompt only where there is
+    # something real to remove, and name the value so the answer is an informed one.
+    found_any = False
+    for bp in claude_settings_files():
+        val = loopback_base_url(bp)
+        if not val:
+            continue
+        found_any = True
+        if ask(f"Unwire ANTHROPIC_BASE_URL ({val}) from {bp}?"):
+            st, msg = unwire_base_url(bp)
+            print(("✓ " if st in ("ok", "absent", "foreign") else "✗ ") + msg)
+    if not found_any:
+        print("  · no ANTHROPIC_BASE_URL wired in any Claude Code settings file")
 
     # 4 · local data (opt-in; it's the user's measured savings history)
     home = Path(os.environ.get("DISTIL_HOME", str(Path.home() / ".distil")))

--- a/distil/doctor.py
+++ b/distil/doctor.py
@@ -349,6 +349,52 @@ def _port_listening(host: str, port: int, timeout: float = 0.35) -> bool:
         return False
 
 
+def _base_url_checks() -> list[Check]:
+    """Run the base-URL guard over every settings file Claude Code merges.
+
+    Reading only ``~/.claude/settings.json`` let a dead base URL in a project's
+    ``.claude/settings.local.json`` — which takes *precedence* over the home file —
+    sit invisible to doctor while it broke every session started in that directory.
+    Only the winning entry is probed; the ones it shadows are reported as shadowed,
+    because fixing a loser changes nothing and sends the user in circles.
+    """
+    from .setup import claude_settings_files
+
+    out: list[Check] = []
+    winner: Path | None = None
+    for path in claude_settings_files():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+        except (OSError, json.JSONDecodeError):
+            continue
+        env = data.get("env") if isinstance(data, dict) else None
+        if not (isinstance(env, dict) and env.get("ANTHROPIC_BASE_URL")):
+            continue
+        where = _short_path(path)
+        if winner is not None:
+            out.append(
+                Check(
+                    f"base URL ({where})",
+                    INFO,
+                    f"ANTHROPIC_BASE_URL → {env['ANTHROPIC_BASE_URL']} "
+                    f"(shadowed by {_short_path(winner)}, which wins)",
+                )
+            )
+            continue
+        winner = path
+        chk = _check_base_url(data)
+        if chk is not None:
+            out.append(Check(f"{chk.name} ({where})", chk.status, chk.detail, chk.hint))
+    return out
+
+
+def _short_path(path: Path) -> str:
+    try:
+        return "~/" + str(path.relative_to(Path.home()))
+    except ValueError:
+        return str(path)
+
+
 def _check_base_url(data: object) -> Check | None:
     """Guard against a dead ANTHROPIC_BASE_URL in settings.json.
 
@@ -368,7 +414,23 @@ def _check_base_url(data: object) -> Check | None:
         # distil only ever writes a loopback proxy; never probe foreign hosts.
         return Check("base URL", INFO, f"ANTHROPIC_BASE_URL → {base} (not a local distil proxy)")
     if _port_listening(host, port):
-        return Check("base URL", OK, f"ANTHROPIC_BASE_URL → {host}:{port} (listening)")
+        # "Listening" was the old bar, and it is too low: a proxy aimed at a wrong
+        # upstream binds the port and 404s every request. Claude Code skips model-name
+        # validation whenever ANTHROPIC_BASE_URL is set, so that surfaces as "there's an
+        # issue with the selected model" — a message that sends the user hunting the
+        # model. Probe the route, so doctor names the real fault.
+        from .setup import probe_routing
+
+        routed, detail = probe_routing(host, port, deadline=4.0)
+        if routed:
+            return Check("base URL", OK, f"ANTHROPIC_BASE_URL → {detail}")
+        return Check(
+            "base URL",
+            FAIL,
+            f"ANTHROPIC_BASE_URL → {detail}",
+            "every Claude Code session fails while this stands (often reported as "
+            "'an issue with the selected model'). Undo: distil default --always-on --undo",
+        )
     return Check(
         "base URL",
         FAIL,
@@ -386,9 +448,7 @@ def _check_claude_code() -> list[Check]:
         data = json.loads(settings.read_text(encoding="utf-8")) if settings.exists() else {}
     except (OSError, json.JSONDecodeError):
         data = {}
-    base_url = _check_base_url(data)
-    if base_url is not None:
-        out.append(base_url)
+    out.extend(_base_url_checks())
     sl = (data.get("statusLine") or {}).get("command", "") if isinstance(data, dict) else ""
     if "distil" in sl or "statusline.sh" in sl:
         out.append(Check("status line", OK, "wired into ~/.claude/settings.json"))

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -31,6 +31,74 @@ def default_settings_path() -> Path:
     return Path.home() / ".claude" / "settings.json"
 
 
+def claude_settings_files(cwd: Path | None = None) -> list[Path]:
+    """Every settings file Claude Code merges, highest precedence first.
+
+    ``doctor`` and ``--undo`` used to read only ``~/.claude/settings.json``. Claude
+    Code also reads *project*-scoped settings, and those **override** the user's —
+    so a dead ``ANTHROPIC_BASE_URL`` in a repo's ``.claude/settings.local.json`` is
+    invisible to a check that reads the home file, and survives every uninstall.
+    That is exactly how one stale port outlived ``distil default --undo`` and went
+    on killing every session started in that directory after distil was gone.
+
+    Includes non-existent paths: callers test for presence, and an undo that only
+    visits files it already knows about is the bug this exists to close.
+    """
+    home = Path.home()
+    paths = [
+        Path("/etc/claude-code/managed-settings.json")
+        if _is_windows() or not Path("/Library/Application Support").is_dir()
+        else Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+    ]
+    start = (cwd or Path.cwd()).resolve()
+    for d in (start, *start.parents):
+        paths += [d / ".claude" / "settings.local.json", d / ".claude" / "settings.json"]
+        if d == home:
+            break
+    paths += [home / ".claude" / "settings.local.json", home / ".claude" / "settings.json"]
+    return list(dict.fromkeys(paths))  # dedupe, first (highest-precedence) wins
+
+
+def unwire_base_url(settings_path: Path) -> tuple[str, str]:
+    """Remove a **loopback** ``ANTHROPIC_BASE_URL`` from *settings_path*.
+
+    The port-exact :func:`unwire_settings_env` is not enough for undo: wire on one
+    port, undo without repeating ``--port``, and the entry is judged "foreign" and
+    left behind — an uninstall that reports success and leaves the machine broken.
+    Any ``127.0.0.1``/``localhost`` URL is distil's to clean up; a real remote host
+    is someone else's gateway and is left exactly as it is.
+
+    Returns ``(status, message)``: ``ok`` | ``absent`` | ``foreign`` | ``error``.
+    """
+    from urllib.parse import urlparse
+
+    if not settings_path.exists():
+        return ("absent", f"no settings file at {settings_path}")
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return ("error", f"{settings_path} is not valid JSON ({exc})")
+    if not isinstance(data, dict):
+        return ("error", f"{settings_path} is not a JSON object")
+
+    env = data.get("env")
+    existing = env.get("ANTHROPIC_BASE_URL") if isinstance(env, dict) else None
+    if not existing:
+        return ("absent", f"no ANTHROPIC_BASE_URL in {settings_path}")
+    if urlparse(str(existing)).hostname not in ("127.0.0.1", "localhost", "::1"):
+        return ("foreign", f"ANTHROPIC_BASE_URL is {existing!r} (not loopback) — left as-is")
+
+    settings_path.with_name(settings_path.name + ".bak").write_text(
+        settings_path.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    assert isinstance(env, dict)  # a truthy `existing` came out of that dict
+    del env["ANTHROPIC_BASE_URL"]
+    if not env:
+        del data["env"]
+    settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return ("ok", f"removed ANTHROPIC_BASE_URL ({existing}) from {settings_path}")
+
+
 def wire_statusline(
     settings_path: Path, *, command: str = DEFAULT_COMMAND, force: bool = False
 ) -> tuple[str, str]:
@@ -350,6 +418,66 @@ def service_spec(port: int, mode: str) -> tuple[Path | None, str | None, str | N
         )
         return path, content, load
     return (None, None, None)
+
+
+def probe_routing(host: str, port: int, *, deadline: float = 10.0) -> tuple[bool, str]:
+    """Does the proxy at *host:port* actually SERVE ``/v1/messages``, or merely listen?
+
+    A listening socket proves nothing. A proxy pointed at the wrong upstream accepts
+    the connection and hands back that upstream's 404 for every request — and because
+    Claude Code skips model-name validation whenever ``ANTHROPIC_BASE_URL`` is set
+    (behind a gateway the provider defines the model names), the user sees "there's an
+    issue with the selected model" in every session on the machine. The error names the
+    wrong thing, so the search starts in the wrong place.
+
+    Credentials are deliberately omitted: an HTTP 401 is *proof* the request reached a
+    real messages handler, which is the only thing under test. Anything but a 404 means
+    routing works. We retry on connection errors only — a 404 is a definitive answer,
+    not a race — so a service that needs a second to bind still passes.
+    """
+    import time
+    import urllib.error
+    import urllib.request
+
+    payload = json.dumps(
+        {
+            "model": "claude-sonnet-5",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "."}],
+        }
+    ).encode()
+    url = f"http://{host}:{port}/v1/messages"
+    last = "no response"
+    end = time.monotonic() + deadline
+    while True:
+        req = urllib.request.Request(  # noqa: S310 — loopback only, built from our own port
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json", "anthropic-version": "2023-06-01"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=4) as resp:  # noqa: S310
+                code, headers = resp.status, resp.headers
+            break
+        except urllib.error.HTTPError as exc:  # 401/400 are answers, and good ones
+            code, headers = exc.code, exc.headers
+            break
+        except OSError as exc:  # refused / unbound / timed out — may still be starting
+            last = str(exc)
+            if time.monotonic() >= end:
+                return False, f"no response from {host}:{port} — {last}"
+            time.sleep(0.4)
+    if code == 404:
+        return False, (
+            f"{host}:{port} is listening but answered 404 for /v1/messages — it is not "
+            "routing (a wrong --upstream does exactly this)"
+        )
+    # Not required to pass: the headers ride on the compression path, and a proxy can be
+    # correctly routing before it has anything to compress. Reported when present because
+    # it upgrades "something answers" to "distil answers".
+    stamped = any(str(k).lower().startswith("x-distil-") for k in (headers or {}))
+    who = "distil" if stamped else "a proxy"
+    return True, f"{who} on {host}:{port} routes /v1/messages (HTTP {code})"
 
 
 def service_unload_cmd() -> str | None:

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -59,6 +59,27 @@ def claude_settings_files(cwd: Path | None = None) -> list[Path]:
     return list(dict.fromkeys(paths))  # dedupe, first (highest-precedence) wins
 
 
+def loopback_base_url(settings_path: Path) -> str | None:
+    """The loopback ``ANTHROPIC_BASE_URL`` in *settings_path*, or None.
+
+    Read-only, so a caller can ask "is there anything here?" before prompting.
+    ``offboard`` used to prompt off ``settings_path.exists()`` alone, which asked
+    about files holding nothing and — worse — asked about nothing at all when the
+    home file was absent, skipping every other file in the process.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    env = data.get("env") if isinstance(data, dict) else None
+    val = env.get("ANTHROPIC_BASE_URL") if isinstance(env, dict) else None
+    if not val or urlparse(str(val)).hostname not in ("127.0.0.1", "localhost", "::1"):
+        return None
+    return str(val)
+
+
 def unwire_base_url(settings_path: Path) -> tuple[str, str]:
     """Remove a **loopback** ``ANTHROPIC_BASE_URL`` from *settings_path*.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,30 @@ from __future__ import annotations
 
 import pytest
 
+from distil import setup as _setup
+
+#: The unpatched enumerator, captured before the autouse sandbox below replaces it.
+#: Reach it through the ``real_claude_settings_files`` fixture to test enumeration
+#: itself; everything else must see the sandbox.
+_REAL_CLAUDE_SETTINGS_FILES = _setup.claude_settings_files
+
 
 @pytest.fixture(autouse=True)
 def _distil_home_sandbox(monkeypatch, tmp_path_factory):
     monkeypatch.setenv("DISTIL_HOME", str(tmp_path_factory.mktemp("distil-home")))
     monkeypatch.delenv("DISTIL_SESSION", raising=False)
+    # `distil default --undo` now sweeps EVERY settings file Claude Code merges and
+    # deletes any loopback ANTHROPIC_BASE_URL it finds. That reach is the whole point
+    # of the fix — and it is precisely why no test may keep it: a suite run from this
+    # repo would otherwise rewrite the developer's own ~/.claude settings, which is the
+    # accident that bricked Claude Code once already. Point it at an empty sandbox.
+    sandbox = tmp_path_factory.mktemp("claude-settings")
+    monkeypatch.setattr(
+        _setup, "claude_settings_files", lambda cwd=None: [sandbox / "settings.json"]
+    )
+
+
+@pytest.fixture
+def real_claude_settings_files():
+    """The genuine enumerator, for the tests that assert on precedence order."""
+    return _REAL_CLAUDE_SETTINGS_FILES

--- a/tests/test_cli_onboard.py
+++ b/tests/test_cli_onboard.py
@@ -1601,6 +1601,9 @@ def test_cmd_default_always_on_service_start(tmp_path, monkeypatch, capsys) -> N
     # agent=="claude" makes cmd_default wire settings.json — redirect it to tmp so the
     # suite never touches the real ~/.claude/settings.json (this write bricked Claude Code).
     monkeypatch.setattr(setup_mod, "default_settings_path", lambda: tmp_path / "settings.json")
+    # The service starts BEFORE the base URL is wired now, and wiring is gated on the
+    # proxy proving it serves /v1/messages. No real proxy here, so state the verdict.
+    monkeypatch.setattr(setup_mod, "probe_routing", lambda h, p, **k: (True, f"stub {h}:{p}"))
 
     class _OK:
         returncode = 0
@@ -1621,7 +1624,7 @@ def test_cmd_default_always_on_service_start(tmp_path, monkeypatch, capsys) -> N
     )
     assert rc == 0
     assert any("launchctl" in str(c) for c in calls)
-    assert "proxy service running" in capsys.readouterr().out
+    assert "proxy service started" in capsys.readouterr().out
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,6 +3,7 @@ self-test must round-trip a request through an in-process upstream."""
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 
@@ -37,16 +38,47 @@ def test_check_base_url_guard() -> None:
     foreign = doctor._check_base_url({"env": {"ANTHROPIC_BASE_URL": "http://example.com:443"}})
     assert foreign is not None and foreign.status == doctor.INFO
 
-    # A live loopback port → OK.
+    # A port that merely LISTENS is not OK. This is the whole lesson of the outage:
+    # the socket was bound the entire time, `doctor` said OK, and every Claude Code
+    # session on the machine still failed. Only serving /v1/messages counts.
     srv = socket.socket()
     srv.bind(("127.0.0.1", 0))
     srv.listen(1)
     try:
         port = srv.getsockname()[1]
-        live = doctor._check_base_url({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}"}})
-        assert live is not None and live.status == doctor.OK
+        bound = doctor._check_base_url({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}"}})
+        assert bound is not None and bound.status == doctor.FAIL
     finally:
         srv.close()
+
+    # A port that actually answers /v1/messages → OK.
+    with _messages_server() as port:
+        live = doctor._check_base_url({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}"}})
+        assert live is not None and live.status == doctor.OK
+
+
+@contextlib.contextmanager
+def _messages_server(status: int = 401):
+    """A loopback server that answers /v1/messages with *status* and 404s everything
+    else — the smallest thing that tells "routes" apart from "merely listening"."""
+    import http.server
+    import threading
+
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's spelling
+            self.send_response(status if self.path == "/v1/messages" else 404)
+            self.end_headers()
+
+        def log_message(self, *a: object) -> None:  # keep pytest output clean
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield srv.server_address[1]
+    finally:
+        srv.shutdown()
+        srv.server_close()
 
 
 def test_proxy_selftest_round_trips() -> None:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -315,3 +315,86 @@ def test_doctor_reports_a_shadowed_base_url_as_shadowed(tmp_path, monkeypatch) -
     assert len(checks) == 2
     assert checks[0].status == doctor.FAIL and "project.json" in checks[0].name
     assert checks[1].status == doctor.INFO and "shadowed" in checks[1].detail
+
+
+# ── `distil offboard`, the command a leaving user actually runs ────────────────
+#
+# `default --undo` was only half the escape hatch. `offboard` is the documented way
+# out, and it had the same two defects plus a third of its own: it prompted off
+# `~/.claude/settings.json` existing, so on a machine without that file it asked
+# nothing and cleaned nothing — in any file. It then reported success and printed the
+# uninstall command, which is how a base URL outlived distil itself.
+
+
+def _offboard_args(**over):
+    base = dict(yes=True, no_interactive=True, purge=False)
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_offboard_clears_a_project_scoped_base_url(tmp_path, monkeypatch, capsys) -> None:
+    """The user's actual machine: the dead entry lived in a repo's settings.local.json,
+    on a port offboard never matched, while ~/.claude/settings.json did not exist."""
+    from distil import setup
+
+    proj = tmp_path / "repo" / ".claude"
+    proj.mkdir(parents=True)
+    local = proj / "settings.local.json"
+    local.write_text('{"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8788"}}\n')
+    home_settings = tmp_path / "home" / ".claude" / "settings.json"  # deliberately absent
+
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [local, home_settings])
+    monkeypatch.setattr(setup, "default_settings_path", lambda: home_settings)
+    monkeypatch.setattr(setup, "detect_shell", lambda: ("zsh", tmp_path / ".zshrc"))
+    monkeypatch.setattr(setup, "service_spec", lambda *a, **k: (tmp_path / "absent.plist", "", ""))
+
+    assert cli.cmd_offboard(_offboard_args()) == 0
+    assert "ANTHROPIC_BASE_URL" not in local.read_text(), (
+        "offboard reported success and left the entry that was killing every session"
+    )
+
+
+def test_offboard_is_silent_when_there_is_nothing_to_unwire(tmp_path, monkeypatch, capsys) -> None:
+    """No base URL anywhere → say so once. The old code asked the user to confirm
+    removing something that was not there, then reported 'absent' after they said yes."""
+    from distil import setup
+
+    empty = tmp_path / "settings.json"
+    empty.write_text('{"permissions": {"allow": []}}\n')
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [empty])
+    monkeypatch.setattr(setup, "default_settings_path", lambda: empty)
+    monkeypatch.setattr(setup, "detect_shell", lambda: ("zsh", tmp_path / ".zshrc"))
+    monkeypatch.setattr(setup, "service_spec", lambda *a, **k: (tmp_path / "absent.plist", "", ""))
+
+    assert cli.cmd_offboard(_offboard_args()) == 0
+    out = capsys.readouterr().out
+    assert "no ANTHROPIC_BASE_URL wired" in out
+    assert "Unwire ANTHROPIC_BASE_URL" not in out, "never prompt about nothing"
+
+
+def test_offboard_spares_a_real_gateway(tmp_path, monkeypatch) -> None:
+    """--yes must not become a licence to delete somebody's actual gateway."""
+    from distil import setup
+
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"env": {"ANTHROPIC_BASE_URL": "https://gateway.corp.example"}}\n')
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [settings])
+    monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    monkeypatch.setattr(setup, "detect_shell", lambda: ("zsh", tmp_path / ".zshrc"))
+    monkeypatch.setattr(setup, "service_spec", lambda *a, **k: (tmp_path / "absent.plist", "", ""))
+
+    assert cli.cmd_offboard(_offboard_args()) == 0
+    assert "gateway.corp.example" in settings.read_text()
+
+
+def test_loopback_base_url_reads_without_writing(tmp_path) -> None:
+    from distil.setup import loopback_base_url
+
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"env": {"ANTHROPIC_BASE_URL": "http://localhost:9999"}}\n')
+    before = settings.read_text()
+    assert loopback_base_url(settings) == "http://localhost:9999"
+    assert settings.read_text() == before, "the probe that decides whether to prompt must not edit"
+    assert loopback_base_url(tmp_path / "nope.json") is None
+    settings.write_text("{ not json\n")
+    assert loopback_base_url(settings) is None

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,317 @@
+"""The preflight that stands between a broken proxy and a machine-wide outage.
+
+Written after `distil default --always-on` wired ANTHROPIC_BASE_URL into
+~/.claude/settings.json, reported success from `launchctl load`'s exit code, and left
+every Claude Code session on the machine failing. The proxy was up the whole time. It
+was pointed at an upstream that does not serve /v1/messages, so it answered 404 to
+everything — and because Claude Code skips model-name validation whenever a base URL is
+set, the failure surfaced as "there's an issue with the selected model".
+
+The load-bearing test is `test_listening_but_404_is_not_routing`: a socket you can
+connect to was the old bar, and it is exactly the signal that was already true while
+everything was broken.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from distil import cli
+from distil.setup import probe_routing
+
+
+def _serve(status: int, headers: dict[str, str] | None = None):
+    """A loopback server answering every POST with *status*. Returns (port, shutdown)."""
+
+    class H(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's contract
+            self.send_response(status)
+            for k, v in (headers or {}).items():
+                self.send_header(k, v)
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+        def log_message(self, *a: object) -> None:  # keep pytest output readable
+            return
+
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv.server_address[1], srv.shutdown
+
+
+def test_listening_but_404_is_not_routing() -> None:
+    """The exact production failure: the port answers, and answers 404 to everything."""
+    port, stop = _serve(404)
+    try:
+        ok, detail = probe_routing("127.0.0.1", port, deadline=2.0)
+    finally:
+        stop()
+    assert ok is False
+    assert "404" in detail and "not routing" in detail
+
+
+def test_401_proves_routing_without_credentials() -> None:
+    """We send no API key on purpose — a 401 means a real messages handler saw it."""
+    port, stop = _serve(401)
+    try:
+        ok, detail = probe_routing("127.0.0.1", port, deadline=2.0)
+    finally:
+        stop()
+    assert ok is True
+    assert "401" in detail
+
+
+def test_distil_header_upgrades_the_verdict() -> None:
+    """`a proxy` answers; `distil` answers *and* says so."""
+    port, stop = _serve(401, {"x-distil-mode": "digest"})
+    try:
+        _, with_hdr = probe_routing("127.0.0.1", port, deadline=2.0)
+    finally:
+        stop()
+    port2, stop2 = _serve(401)
+    try:
+        _, without = probe_routing("127.0.0.1", port2, deadline=2.0)
+    finally:
+        stop2()
+    assert with_hdr.startswith("distil on")
+    assert without.startswith("a proxy on")
+
+
+def test_nothing_listening_fails_within_the_deadline() -> None:
+    port, stop = _serve(401)
+    stop()  # free the port, then probe it — nothing is there
+    ok, detail = probe_routing("127.0.0.1", port, deadline=1.0)
+    assert ok is False
+    assert "no response" in detail
+
+
+def test_404_does_not_burn_the_deadline() -> None:
+    """A 404 is an answer, not a race — retrying it would stall setup for 10s."""
+    import time
+
+    port, stop = _serve(404)
+    try:
+        t0 = time.monotonic()
+        probe_routing("127.0.0.1", port, deadline=30.0)
+        assert time.monotonic() - t0 < 5.0
+    finally:
+        stop()
+
+
+# --------------------------------------------------------------------------- #
+# The wiring itself: a failed preflight must leave the machine untouched.
+# --------------------------------------------------------------------------- #
+
+
+def _always_on_ns(rc_file, port: int) -> argparse.Namespace:
+    return argparse.Namespace(
+        undo=False,
+        always_on=True,
+        rc=str(rc_file),
+        port=port,
+        agent="claude",
+        mode="expand",
+        no_start=True,
+        force=False,
+    )
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """cmd_default with every real side effect redirected into tmp_path."""
+    import distil.setup as setup_mod
+    from distil import onboard
+
+    monkeypatch.setattr(
+        onboard,
+        "detect",
+        lambda: onboard.Env(
+            os_name="Darwin",
+            agents=[("claude", "Claude Code")],
+            installed_version="1.0.0",
+            method="pipx",
+            managers=["pipx"],
+        ),
+    )
+    rc_file = tmp_path / ".zshrc"
+    rc_file.write_text("")
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(setup_mod, "detect_shell", lambda: ("zsh", rc_file))
+    monkeypatch.setattr(setup_mod, "default_settings_path", lambda: settings)
+    monkeypatch.setattr(
+        setup_mod, "service_spec", lambda *a, **k: (tmp_path / "svc.plist", "content", None)
+    )
+    return rc_file, settings
+
+
+def test_failed_preflight_writes_no_config(wired, capsys) -> None:
+    """The whole point: a proxy that does not route must not become the default."""
+    rc_file, settings = wired
+    port, stop = _serve(404)
+    try:
+        rc = cli.cmd_default(_always_on_ns(rc_file, port))
+    finally:
+        stop()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "preflight failed" in out
+    assert "Nothing was wired" in out
+    assert not settings.exists(), "settings.json was written despite a failed preflight"
+    assert "ANTHROPIC_BASE_URL" not in rc_file.read_text()
+
+
+def test_passing_preflight_writes_config(wired, capsys) -> None:
+    """And the happy path still wires — a gate that never opens is not a gate."""
+    rc_file, settings = wired
+    port, stop = _serve(401, {"x-distil-mode": "digest"})
+    try:
+        rc = cli.cmd_default(_always_on_ns(rc_file, port))
+    finally:
+        stop()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "preflight: distil on" in out
+    assert "ANTHROPIC_BASE_URL" in settings.read_text()
+
+
+# --------------------------------------------------------------------------- #
+# doctor: the same tightening, so it names the real fault instead of "listening"
+# --------------------------------------------------------------------------- #
+
+
+def test_doctor_fails_a_listening_but_unrouted_base_url() -> None:
+    from distil.doctor import FAIL, OK, _check_base_url
+
+    port, stop = _serve(404)
+    try:
+        chk = _check_base_url({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}"}})
+    finally:
+        stop()
+    assert chk is not None
+    assert chk.status == FAIL
+    assert chk.status != OK, "a listening socket used to be enough — it never was"
+    assert "selected model" in (chk.hint or ""), "the hint must name the misleading symptom"
+
+
+def test_doctor_passes_a_routing_base_url() -> None:
+    from distil.doctor import OK, _check_base_url
+
+    port, stop = _serve(401, {"x-distil-mode": "digest"})
+    try:
+        chk = _check_base_url({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{port}"}})
+    finally:
+        stop()
+    assert chk is not None
+    assert chk.status == OK
+    assert "routes /v1/messages" in chk.detail
+
+
+# ── The second failure: an uninstall that reported success and left the machine broken ──
+#
+# The preflight above stops distil writing a base URL that does not work. It does nothing
+# about one already written. `distil default --undo` was supposed to be that escape hatch
+# and could not reach the entry that mattered, for two independent reasons:
+#
+#   1. it looked only in ~/.claude/settings.json, and Claude Code also merges *project*
+#      settings — which take PRECEDENCE over the home file; and
+#   2. it matched the value against `--port` from the current invocation, so an entry
+#      wired on another port was classified "foreign" and deliberately left in place.
+#
+# Both were true at once for one real machine: `.claude/settings.local.json` in a repo
+# held 127.0.0.1:8788, nothing listened there, and every session started in that
+# directory died with ConnectionRefused — after distil had been uninstalled entirely.
+
+
+def test_undo_removes_a_base_url_wired_on_a_different_port(tmp_path, monkeypatch) -> None:
+    """The load-bearing one. Undo must clean up by *shape*, not by this run's --port."""
+    from distil import setup
+
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8788"}}\n')
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [settings])
+    monkeypatch.setattr(setup, "detect_shell", lambda: ("zsh", tmp_path / ".zshrc"))
+
+    # --port defaults to 8788 in real use; pass a DIFFERENT one, which is what happens
+    # whenever someone types plain `distil default --undo` after wiring a custom port.
+    rc = cli.cmd_default(
+        argparse.Namespace(
+            undo=True,
+            always_on=False,
+            rc=str(tmp_path / ".zshrc"),
+            port=9999,
+            agent="claude",
+            mode="lossless-only",
+            no_start=True,
+            force=False,
+        )
+    )
+    assert rc == 0
+    assert "ANTHROPIC_BASE_URL" not in settings.read_text(), (
+        "undo left the entry that was breaking every session — the exact uninstall bug"
+    )
+
+
+def test_unwire_base_url_spares_a_real_gateway(tmp_path) -> None:
+    """Cleaning by shape must not mean cleaning by force: a non-loopback base URL is
+    somebody's actual gateway (LiteLLM, Bedrock proxy, a corporate egress) and distil
+    never wrote it. Deleting it would trade our outage for theirs."""
+    from distil.setup import unwire_base_url
+
+    settings = tmp_path / "settings.json"
+    settings.write_text('{"env": {"ANTHROPIC_BASE_URL": "https://gateway.corp.example"}}\n')
+    status, msg = unwire_base_url(settings)
+    assert status == "foreign"
+    assert "gateway.corp.example" in settings.read_text()
+    assert "left as-is" in msg
+
+
+def test_unwire_base_url_preserves_neighbouring_settings(tmp_path) -> None:
+    from distil.setup import unwire_base_url
+
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        '{"permissions": {"allow": ["Bash(ls)"]}, '
+        '"env": {"ANTHROPIC_BASE_URL": "http://localhost:8788", "FOO": "bar"}}\n'
+    )
+    assert unwire_base_url(settings)[0] == "ok"
+    data = __import__("json").loads(settings.read_text())
+    assert data["env"] == {"FOO": "bar"}, "only distil's key comes out"
+    assert data["permissions"]["allow"] == ["Bash(ls)"]
+    assert (tmp_path / "settings.json.bak").exists(), "an undo that edits must be reversible"
+
+
+def test_project_settings_outrank_home_settings(tmp_path, real_claude_settings_files) -> None:
+    """Precedence is the reason the outage was invisible: doctor read the home file and
+    reported clean while a project file overrode it."""
+    home = tmp_path / "home"
+    proj = home / "work" / "repo"
+    proj.mkdir(parents=True)
+    (home / ".claude").mkdir()
+
+    order = real_claude_settings_files(cwd=proj)
+    idx = {p: i for i, p in enumerate(order)}
+    assert idx[proj / ".claude" / "settings.local.json"] < idx[proj / ".claude" / "settings.json"]
+    assert idx[proj / ".claude" / "settings.json"] < idx[home / ".claude" / "settings.json"]
+    assert order[0].name == "managed-settings.json", "managed policy outranks everything"
+
+
+def test_doctor_reports_a_shadowed_base_url_as_shadowed(tmp_path, monkeypatch) -> None:
+    """Two files, both set. Only the winner is diagnosed; naming the loser as a live
+    fault would send the user editing a file that changes nothing."""
+    from distil import doctor, setup
+
+    win = tmp_path / "project.json"
+    lose = tmp_path / "home.json"
+    win.write_text('{"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:1"}}\n')
+    lose.write_text('{"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:2"}}\n')
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [win, lose])
+
+    checks = doctor._base_url_checks()
+    assert len(checks) == 2
+    assert checks[0].status == doctor.FAIL and "project.json" in checks[0].name
+    assert checks[1].status == doctor.INFO and "shadowed" in checks[1].detail

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -277,6 +277,19 @@ def test_cmd_default_installs_alias_and_undoes(tmp_path, capsys) -> None:
     assert "# keep me" in rc.read_text()
 
 
+def _stub_preflight(monkeypatch, *, routed: bool = True) -> None:
+    """`distil default --always-on` refuses to wire anything until the proxy proves it
+    serves /v1/messages. No test starts a real one, so state the verdict explicitly —
+    a test that silently skipped the preflight would be asserting the old, broken order."""
+    from distil import setup
+
+    monkeypatch.setattr(
+        setup,
+        "probe_routing",
+        lambda host, port, **kw: (routed, f"stub: routed={routed} on {host}:{port}"),
+    )
+
+
 def test_cmd_default_always_on_writes_service_and_env(tmp_path, monkeypatch, capsys) -> None:
     from distil import cli, setup
 
@@ -286,6 +299,8 @@ def test_cmd_default_always_on_writes_service_and_env(tmp_path, monkeypatch, cap
     )
     settings = tmp_path / "settings.json"
     monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    monkeypatch.setattr(setup, "claude_settings_files", lambda cwd=None: [settings])
+    _stub_preflight(monkeypatch)
     # Record shell-outs so we can assert install is silent but undo stops the service.
     import subprocess
 
@@ -322,6 +337,7 @@ def test_cmd_default_always_on_non_claude_agent_skips_settings_json(tmp_path, mo
     )
     settings = tmp_path / "settings.json"
     monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    _stub_preflight(monkeypatch)
     assert (
         cli.cmd_default(_default_args(tmp_path, always_on=True, agent="codex", no_start=True)) == 0
     )
@@ -339,6 +355,7 @@ def test_cmd_default_always_on_settings_env_conflict_needs_force(
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://mine.example"}}))
     monkeypatch.setattr(setup, "default_settings_path", lambda: settings)
+    _stub_preflight(monkeypatch)
     assert cli.cmd_default(_default_args(tmp_path, always_on=True)) == 0
     assert "mine.example" in settings.read_text()  # left untouched without --force
     out = capsys.readouterr().out


### PR DESCRIPTION
## The outage

`distil default --always-on` took `launchctl load` returning 0 as proof the proxy worked. It means *the job was accepted*, nothing more. The proxy bound its port and 404'd every request (wrong `--upstream`), and because Claude Code skips model-name validation whenever `ANTHROPIC_BASE_URL` is set, every session on the machine failed as **"there's an issue with the selected model"** — a message that sends you hunting the model, not the base URL.

## Two defects

**1. Wire-before-verify.** `probe_routing()` now POSTs `/v1/messages` and demands anything but a 404 — a 401 is *proof*, because it means the request reached a real messages handler. `--always-on` starts the service, proves the route, and only then writes the base URL; a failed preflight wires nothing and exits 1. `doctor` probes the same way: "the port is listening" was the old bar, and it was already true the entire time everything was broken.

**2. Undo couldn't reach the damage** — worse, because it was the escape hatch. It looked only in `~/.claude/settings.json` and matched the value against the current `--port`. But Claude Code also merges *project* settings, which take **precedence** over the home file; and an entry wired on another port was classified `foreign` and left in place on purpose.

Both were true of one real machine at once: a repo's `.claude/settings.local.json` held a dead `127.0.0.1:8788` that survived uninstalling distil **entirely**, and went on killing every session started in that directory.

`claude_settings_files()` enumerates every file Claude Code merges, in precedence order. `unwire_base_url()` cleans by shape — any loopback URL is ours — while leaving a real remote gateway (LiteLLM, Bedrock, corporate egress) untouched. `doctor` diagnoses only the winning entry and names the shadowed ones as shadowed, so nobody edits a file that changes nothing.

## Test sandbox

`conftest` sandboxes the new reach. `--undo` can now rewrite Claude Code settings machine-wide, which is precisely why no test may keep it — a suite run from this repo would otherwise rewrite the developer's own `~/.claude`, the accident that started this.

## Verification

- `2891 passed, 3 skipped` (full suite)
- `uvx ruff@0.15.10 check distil tests` + `format --check .` clean
- Reproduced the original failure end-to-end (project-scoped file, wrong port) and confirmed `undo` clears it and `doctor` names it

The load-bearing tests are `test_listening_but_404_is_not_routing` and `test_undo_removes_a_base_url_wired_on_a_different_port`.