### PR TITLE
fix(pricing): price claude-opus-5, which was silently reporting $0 saved

### DIFF
--- a/distil/pricing.py
+++ b/distil/pricing.py
@@ -43,6 +43,7 @@ class Pricing:
 # Public list prices (USD / Mtok), current Claude model IDs. VERIFY before billing use.
 CATALOG: dict[str, Pricing] = {
     "claude-fable-5": Pricing("claude-fable-5", 10.0, 50.0),
+    "claude-opus-5": Pricing("claude-opus-5", 5.0, 25.0),
     "claude-opus-4-8": Pricing("claude-opus-4-8", 5.0, 25.0),
     "claude-opus-4-7": Pricing("claude-opus-4-7", 5.0, 25.0),
     "claude-opus-4-6": Pricing("claude-opus-4-6", 5.0, 25.0),

--- a/tests/test_pricing_opus5.py
+++ b/tests/test_pricing_opus5.py
@@ -1,0 +1,28 @@
+"""claude-opus-5 must price. It shipped unpriced, so `distil doctor` reported
+"ledger contains unpriced models: claude-opus-5" and every run on the model
+showed $0 saved — silently under-reporting the headline number on live traffic.
+"""
+
+from __future__ import annotations
+
+from distil.pricing import CATALOG, resolve
+
+
+def test_opus_5_is_priced() -> None:
+    p = CATALOG["claude-opus-5"]
+    assert (p.input_per_mtok, p.output_per_mtok) == (5.0, 25.0)
+
+
+def test_opus_5_resolves_in_the_id_shapes_real_traffic_uses() -> None:
+    for wire_id in (
+        "claude-opus-5",
+        "anthropic.claude-opus-5",  # Bedrock prefix
+        "claude-opus-5@20260101",  # Vertex version separator
+        "claude-opus-5-20260101",  # dated snapshot → longest-prefix match
+    ):
+        assert resolve(wire_id) is not None, wire_id
+        assert resolve(wire_id).name == "claude-opus-5", wire_id
+
+    # The guard that must not regress: an unknown upstream is never billed at
+    # Claude rates just because the catalog got a new entry.
+    assert resolve("gemini-3-pro") is None


### PR DESCRIPTION
`distil doctor` has been reporting `ledger contains unpriced models: claude-opus-5` — the catalog knew `claude-fable-5` and the Opus 4.x line but not the model actually serving this machine's traffic. Savings on it resolved to no price and rendered as **$0**, so the headline number under-reported real work without ever failing.

**$5.00 / $25.00 per MTok**, matching the Opus tier.

**Not added:** `claude-mythos-5` — same $10/$50 as fable, but Project Glasswing only, so it would be a guess at a model nobody here can call.

## The test

Pins the id shapes real traffic actually carries — bare, Bedrock's `anthropic.` prefix, Vertex's `@` separator, dated snapshot — plus the guard that matters more than any of them: an unknown upstream still resolves to `None`, so a new catalog entry never starts billing a Gemini or OpenAI model at Claude rates.

## Verification

- `2897 passed, 3 skipped` (full suite)
- `uvx ruff@0.15.10 check distil tests` + `format --check .` clean
- On the local machine, `distil doctor` now reports `✓ pricing: all recorded models priced (10 in catalog)` — the warning is gone