### PR TITLE
release(1.41.2rc1): the escape hatch that wasn't, and a price nobody was charged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.41.2] — the escape hatch that wasn't, and a price nobody was charged
+
+**`distil default --always-on` took `launchctl load` returning 0 as proof the proxy
+worked.** It means *the job was accepted*, nothing more. On one real machine the proxy
+bound its port and 404'd every request — a `--upstream` pointed at a server that does
+not serve `/v1/messages` — and because Claude Code skips model-name validation whenever
+`ANTHROPIC_BASE_URL` is set, every session on that machine failed as "there's an issue
+with the selected model". The message sends you hunting the model. The fault was the
+base URL, and distil had written it.
+
+`probe_routing` now POSTs `/v1/messages` and demands anything but a 404 — a 401 is
+*proof*, because it means the request reached a real messages handler. `--always-on`
+starts the service, proves the route, and only then writes the base URL; a failed
+preflight wires nothing and exits 1. `doctor` probes the same way: "the port is
+listening" was the old bar, and it was already true the entire time everything was
+broken.
+
+**The second defect was worse, because it was the way out.** Both removal paths —
+`default --undo` and `offboard`, the command someone runs when they have had enough —
+looked only in `~/.claude/settings.json` and matched the entry against a port: `--undo`
+against the current `--port`, `offboard` against a hardcoded `:8788`. Claude Code also
+merges *project* settings, and those take **precedence** over the home file. `offboard`
+carried a third defect of its own: it prompted only if the home file existed, so on a
+machine without one it asked nothing and cleaned nothing, in any file — then reported
+success and printed the uninstall command.
+
+All of it was true of the same machine at once. A dead `127.0.0.1:8788` in a repo's
+`.claude/settings.local.json` survived uninstalling distil **entirely**, and went on
+killing every session started in that directory.
+
+`claude_settings_files()` enumerates every file Claude Code merges, in precedence
+order. `unwire_base_url()` cleans by shape — any loopback URL is ours — while leaving a
+real remote gateway (LiteLLM, Bedrock, a corporate egress) untouched even under
+`--yes`. `loopback_base_url()` is the read-only probe the prompt was missing, so
+`offboard` asks only where something is really there and names the value it found.
+`doctor` diagnoses the winning entry and reports the ones it shadows as shadowed,
+because fixing a loser changes nothing and sends you in circles.
+
+**`claude-opus-5` was not in the pricing catalog.** The catalog knew `claude-fable-5`
+and the Opus 4.x line but not the model actually serving traffic, so savings on it
+resolved to no price and rendered as $0 — under-reporting real work without ever
+failing. Now $5.00 / $25.00 per MTok. `claude-mythos-5` is deliberately absent: same
+$10/$50 as fable, but Project Glasswing only, so it would be a guess at a model most
+callers cannot reach.
+
+**`tests/conftest.py` sandboxes the new reach.** `--undo` and `offboard` can now
+rewrite Claude Code settings machine-wide, which is precisely why no test may keep it:
+a suite run from this repo would otherwise rewrite the developer's own `~/.claude` —
+the accident that started all of this.
+
 ## [1.41.1] — the diagrams, and the one nobody could turn off
 
 Documentation and accessibility only. No compressor, proxy or CLI behaviour changes.

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.41.1",
+  "version": "1.41.2-rc.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.41.1",
+  "version": "1.41.2rc1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.41.1"
+version = "1.41.2rc1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.41.1",
+  "version": "1.41.2rc1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.41.1",
+      "version": "1.41.2rc1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Soak candidate for **1.41.2**. Per `RELEASING.md`, any release that changes runtime behavior soaks as an rc first — this touches `cli.py`, `setup.py`, `doctor.py`, and `pricing.py`, so it is not soak-exempt.

Ships the two merged fixes:

- **#93** — `default --always-on` proves the proxy actually serves `/v1/messages` before writing `ANTHROPIC_BASE_URL`; `doctor` probes routing rather than trusting a bound port; `--undo` sweeps every settings file Claude Code merges and cleans by shape rather than by port.
- **#94** — `claude-opus-5` priced at $5/$25 per MTok; it was resolving to no price and rendering as $0.

Plus `offboard`, fixed in #93's second commit: it had the same two defects as `--undo` plus a third of its own — it prompted only if `~/.claude/settings.json` existed, so a machine without one was asked nothing and cleaned nothing, in any file, and then reported success.

## Version surfaces

`pyproject.toml` → `1.41.2rc1`; `plugins/distil/.claude-plugin/plugin.json` and `server.json` → `1.41.2rc1`; `packaging/npm/package.json` → `1.41.2-rc.1` (semver spelling). `CITATION.cff` stays at `1.41.1` — the last citable final, per the rc rule in `RELEASING.md`. The CHANGELOG entry is written under the final `[1.41.2]` this rc soaks for.

> Worth a follow-up: `scripts/release.sh` skips the plugin/server/npm version-agreement check on the rc path, so it passed preflight while `tests/test_packaging_smoke.py` failed on all three. The test caught it; the driver should too.

## Verification

- `2897 passed, 3 skipped` (full suite, via the release driver's own gate)
- `uvx ruff@0.15.10 check distil tests` + `format --check .` clean
- Clean-wheel install smoke test passed: `distil 1.41.2rc1`, bench gate runs