### PR TITLE
Adoption + enterprise: library API, outage guard, OIDC/RBAC, deploy layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
           node-version: "20"
       - name: census-worker validators (node:test)
         run: node --test packaging/census-worker/test/validate.test.mjs packaging/census-worker/test/beat.test.mjs
-      - name: npm bridge package (node:test)
-        run: node --test packaging/npm/test/runner.test.mjs
+      - name: npm package (node:test)
+        # Glob, not a hand-listed file: a new test file nobody remembers to add
+        # here is a test that silently never runs.
+        run: node --test packaging/npm/test/*.test.mjs
 
   coverage:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,56 @@ rewrite Claude Code settings machine-wide, which is precisely why no test may ke
 a suite run from this repo would otherwise rewrite the developer's own `~/.claude` —
 the accident that started all of this.
 
+---
+
+**rc2 — the same failure, one layer up.** rc1 fixed `--always-on` writing a base URL it
+had not proved. Three outages on one machine in a single day showed the other half: a
+base URL in `~/.claude/settings.json` **outranks** the environment `distil wrap` sets.
+So when the always-on service was not running, wrap dutifully started a proxy, exported
+its port, and Claude Code ignored it and dialled the dead one. Every session failed with
+`API Error: Unable to connect (ConnectionRefused)` — an error naming the *provider*.
+`distil wrap` now refuses to start into that configuration and names the fix, and the
+end-of-session warning no longer guesses "agent update?" when it can check.
+
+**Distil is embeddable.** `from distil import compress_messages, expand_handle`. The
+package previously exported only `__version__`, so nothing could depend on it without
+shelling out to the CLI. Not named `compress`/`expand`: `distil.compress` and
+`distil.expand` are modules, and Python binds a submodule onto its parent on import, so
+those names would resolve to the function or the module depending on unrelated import
+order. A test enumerates submodules and fails on any future collision.
+
+**`▼413 · 0% smaller` is gone.** A real token count beside a rounded zero reads as
+broken, and it is the likeliest first-run uninstall trigger for traffic that genuinely
+compresses to very little. Sub-1% now renders `<1% smaller` with the reason, across all
+four surfaces. `doctor` also stopped reporting a routing proxy as bypassed: it inferred
+traffic from the savings ledger, which skips zero-saving windows by design.
+
+**A real TypeScript library.** The npm package was a CLI bridge. `compress(messages)`
+now runs natively in Node and is **byte-identical** to the Python engine, enforced by a
+92-case conformance suite. The digest tier is deliberately not ported — it mints handles
+into a store shared with the proxy and MCP server, and it is the tier the certificate
+measures. Where JS cannot reproduce Python's bytes (integral floats, integer-like keys)
+the port declines rather than emitting uncertified output.
+
+**Enterprise surface.** OIDC + RBAC on the gateway (three ordered roles, stdlib-only
+JWS; RS256 refused rather than unverified when the extra is absent), a Helm chart with
+secure defaults asserted by test, Prometheus alert rules and a Grafana dashboard whose
+every expression is CI-checked against the metrics distil actually emits,
+`distil_requests_rejected_total` so quota enforcement is visible, `SECURITY.md`, and a
+security whitepaper that states the gaps — no SOC 2, no SLA, no SAML — rather than
+omitting them.
+
+**Reach and honesty.** `opencode` and `qwen` wrap presets; Agno and Strands
+integrations; `docs/IDE-AGENTS.md` documents the proxy route for Cursor/Cline/Continue
+and says plainly that Copilot is not redirectable. The README now leads with what distil
+does and moves the proof below the fold.
+
+**Fixed while getting here:** `npm test` ran `node --test test/`, which on Node 22
+resolves `test` as a module and dies — the package's tests were not running; CI
+hand-listed one npm test file so new ones never executed; and `cli.main()` left SIGPIPE
+at `SIG_DFL` process-wide, so any later broken pipe killed pytest with exit 141 and no
+failing test to point at.
+
 ## [1.41.1] — the diagrams, and the one nobody could turn off
 
 Documentation and accessibility only. No compressor, proxy or CLI behaviour changes.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ pipx install distil-llm && distil onboard    # detects your agent + billing, wir
 ```
 
 <p align="center">
+  <img src="docs/assets/integration-surface.svg" alt="Four ways to run distil — agent wrap, proxy/gateway, MCP server, and the in-process library. Wrap, proxy and MCP reach the reversible digest tier, covered by the decision-equivalence certificate; the in-process library is lossless-only and byte-identical to the Python engine, enforced by a conformance suite." width="100%"/>
+</p>
+
+<p align="center">
   <img src="docs/assets/hero-terminal.svg" alt="Animated distil proof session: distil bench prints GATE: PASS (every trajectory certified non-inferior); distil wrap -- claude routes with zero config; a live line shows 53% smaller, equivalence 100%; then the proof ledger closes with 1,284,551 → 601,204 tokens (53.2% smaller), cost $18.41 → $8.72 calibrated to billed usage, 0 shadow decision changes across 63 A/B samples, 100% recoverable restore" width="84%"/>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,28 @@
   <a href="https://dshakes.github.io/distil/adoption.html"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdshakes%2Fdistil%2Fmetrics%2Fdata%2Fbadges%2Fdownloads-real.json" alt="PyPI installs/month, bot-filtered"/></a>
 </p>
 
-<h2 align="center">Compress your agent's context.<br/>Prove its decisions don't change.</h2>
+<h2 align="center">Cut your agent's token bill.<br/>Prove its decisions don't change.</h2>
 
-<p align="center"><b>Every other compressor asks you to <i>trust</i> it won't break your agent. Distil is the only one that proves it won't.</b><br/>On <b>500 real coding tasks</b>, compressed context <b>matched full context within statistical noise</b>: <b>42.0% vs 39.2%</b>. <sub>(SWE-bench Verified)</sub></p>
+<p align="center"><b>Compress the tool output, logs, files, and history your agent re-sends every turn — reversibly, so nothing is ever actually gone.</b><br/>Then, unlike every other compressor, <b>prove it didn't break anything</b>.</p>
+
+## What it does
+
+- **Wrap your agent** — `distil wrap -- claude` · `codex` · `gemini` · `aider` · `opencode` · `qwen`. Zero config, no code change.
+- **Run a proxy** — point any `base_url` client at it. Python, TypeScript, any language, any framework.
+- **Call it as a library** — `from distil import compress_messages` in your own agent loop.
+- **Give your agent a recall tool** — MCP server: it compresses its own output and gets the exact bytes back on demand.
+- **Framework hooks** — LangChain · LangGraph · LiteLLM · Agno · Strands, in-process, no network hop.
+- **See what it did** — live status line, session dissect, per-request headers, OTel spans, Prometheus metrics.
+
+```bash
+pipx install distil-llm && distil onboard    # detects your agent + billing, wires everything
+```
 
 <p align="center">
   <img src="docs/assets/hero-terminal.svg" alt="Animated distil proof session: distil bench prints GATE: PASS (every trajectory certified non-inferior); distil wrap -- claude routes with zero config; a live line shows 53% smaller, equivalence 100%; then the proof ledger closes with 1,284,551 → 601,204 tokens (53.2% smaller), cost $18.41 → $8.72 calibrated to billed usage, 0 shadow decision changes across 63 A/B samples, 100% recoverable restore" width="84%"/>
 </p>
-<p align="center"><sub><code>uvx --from distil-llm distil bench</code> — runs the certificate gate in ~10s, no API key · <code>distil wrap -- claude</code> routes your agent, zero config.</sub></p>
+
+> **Will it save you money?** Honestly: **only on metered billing** (an API key). On a flat-rate Pro/Max subscription it trims context and latency, not the bill. And savings come from **large** tool output — a short session that never reads a big file will show close to 0%, which is the tool working correctly, not failing. [Why →](#-compression-modes--in-plain-english)
 
 <!-- ═══ LIVE community counter — fed by the opt-in census, re-polls every 5 min ═══ -->
 <p align="center"><sub>◉ &nbsp;<b>LIVE</b> · measured from the opt-in census on a <a href="https://github.com/dshakes/distil/tree/metrics">public git branch</a>, never estimated</sub></p>
@@ -37,19 +51,42 @@
 <td align="center"><b>🔬 See the proof</b><br/><sub>real harness</sub><br/><br/><a href="#-the-proof"><b>benchmark ↓</b></a> · <a href="docs/PAPER.md">paper</a><br/><a href="https://dshakes.github.io/distil/compare.html">vs the others</a></td>
 </tr></table>
 
-<p align="center"><sub>Honest scope: +2.8pp is a point estimate (CI −0.6..+6.2pp — <b>non-inferiority certified, superiority not yet</b>). <a href="#-the-proof">Details, incl. what doesn't transfer →</a></sub></p>
-
 <p align="center">
   <a href="#-use-it-now">Use it</a> ·
+  <a href="#-use-it-as-a-library">Library</a> ·
   <a href="#-works-with-every-sdk">Integrations</a> ·
   <a href="#-install-your-way">Install</a> ·
-  <a href="https://dshakes.github.io/distil/compare.html">vs the others</a> ·
+  <a href="#why-trust-it">Why trust it</a> ·
   <a href="https://dshakes.github.io/distil/getting-started.html"><b>Full Docs →</b></a>
 </p>
 
 ---
 
-<h3 align="center">Proof first — not a pitch 📊</h3>
+## 🧩 Use it as a library
+
+Building the agent yourself? Compress the message list where it lives — no proxy, no network hop:
+
+```python
+from distil import compress_messages, expand_handle
+
+result = compress_messages(messages)          # OpenAI/Anthropic-style dicts
+print(f"{result.saved_pct:.1f}% smaller")
+response = client.messages.create(model=..., messages=result.messages)
+
+original = expand_handle(result.handles[0])   # byte-exact, any time, any process
+```
+
+Tool results get the reversible digest; user and system text get lossless transforms only; **the model's own turns are never rewritten**. Handles resolve across processes and restarts, so a digest made by the proxy expands here and vice versa. `verbatim=True` disables digests entirely.
+
+<sub>Named `compress_messages`/`expand_handle` rather than `compress`/`expand` because `distil.compress` and `distil.expand` are modules — a top-level export sharing those names would resolve to the function or the module depending on unrelated import order.</sub>
+
+---
+
+<h3 align="center" id="why-trust-it">Why trust it 📊</h3>
+
+<p align="center"><b>Every other compressor asks you to <i>trust</i> it won't break your agent. Distil is the only one that proves it won't.</b><br/>On <b>500 real coding tasks</b>, compressed context <b>matched full context within statistical noise</b>: <b>42.0% vs 39.2%</b>. <sub>(SWE-bench Verified)</sub></p>
+
+<p align="center"><sub>Honest scope: +2.8pp is a point estimate (CI −0.6..+6.2pp — <b>non-inferiority certified, superiority not yet</b>). <a href="#-the-proof">Details, incl. what doesn't transfer →</a></sub></p>
 
 <p align="center"><img src="docs/assets/head-to-head.svg" alt="Distil vs LLMLingua-2 vs Headroom — token savings, decision-change rate, latency" width="100%"/></p>
 
@@ -94,7 +131,9 @@ distil wrap -- claude -p "summarise this diff"
 distil wrap -- python my_agent_sdk_script.py
 ```
 
-Each recognized agent (`claude` / `codex` / `gemini` / `aider`) auto-selects the right env var and upstream — no `--env-var` or `--upstream` flag needed. Prints `preset: <agent> detected → <VAR>` on start. Explicit flags always win.
+> **Using Cursor, Cline, Continue, or Windsurf?** They are IDE extensions — no argv to wrap and no documented env var, so `distil wrap` cannot reach them. Run a proxy and point the editor's base-URL setting at it: [docs/IDE-AGENTS.md](docs/IDE-AGENTS.md). (GitHub Copilot is not redirectable at all, and that page says so rather than wasting your afternoon.)
+
+Each recognized agent (`claude` / `codex` / `gemini` / `aider` / `opencode` / `qwen`) auto-selects the right env var and upstream — no `--env-var` or `--upstream` flag needed. Prints `preset: <agent> detected → <VAR>` on start. Explicit flags always win.
 
 <details>
 <summary><b>Make it the default</b> — never type <code>distil wrap</code> again</summary>
@@ -289,6 +328,8 @@ client = wrap(anthropic.Anthropic())   # compresses the request, keeps the cache
 | LiteLLM | `distil.integrations.litellm.compress(kwargs)` | [`examples/python_litellm.py`](examples/python_litellm.py) |
 | LangChain | `distil.integrations.langchain.compress_messages(msgs)` | — |
 | LangGraph | `pre_model_hook=pre_model_hook()` (compresses graph state before the model node) | [`examples/python_langgraph.py`](examples/python_langgraph.py) |
+| Agno | `distil.integrations.agno.compressed_model(model)` | — |
+| Strands | `distil.integrations.strands.compressing_hook()` | — |
 
 ### LangChain / LangGraph — `langchain-distil`
 
@@ -456,7 +497,7 @@ Basics are in [Use it now](#-use-it-now) and [Works with every SDK](#-works-with
 >
 > `▼` = tokens saved · `total` = lifetime · `de` = decision-equivalence (verdict once 50 A/B + 30 A/A shadow samples accrue). Sharing the line with git/cwd/model? `DISTIL_STATUSLINE=minimal` → `distil ▼7.8K · 27M total`. On a flat-rate **subscription**, dollars are notional and auto-hidden (`DISTIL_SUBSCRIPTION=0/1`).
 
-**Compression modes — in plain English**
+### 🎚 Compression modes — in plain English
 
 You usually don't need to pick. `distil onboard` detects your billing and sets the right mode for you — it writes it into your setup so every session just works. Pass a flag to override for a specific session.
 
@@ -551,7 +592,10 @@ Full module-by-module map: [Architecture](https://dshakes.github.io/distil/archi
 - **Vision — repeated screenshots stop costing full price** — a 1024×1024 image is ~1,400 input tokens, and an agent that screenshots a UI or polls a dashboard pays that on *every turn the block stays in context*. Distil elides only **byte-identical** repeats, replacing each with a recoverable reference: the first occurrence and every distinct image are untouched, nothing is re-encoded or downscaled, and `distil_expand` returns the original `source` byte-exact. URL sources are never treated as duplicates — two occurrences of one URL are not evidence of the same pixels. The prevailing alternative resizes, which is lossy by construction and unverifiable; this is **certified at 100% decision-equivalence against a live vision model** (A/A floor 100%, TOST *p*<0.0001), and the certificate ships in the package stating its own scope. Certify your own workload with `distil certify --strategy vision --runner anthropic` — your result outranks ours, **including a failure**. `DISTIL_VISION=0` disables it. Full reference: [Techniques § Vision](https://dshakes.github.io/distil/techniques.html#vision).
 - **Supply-chain hardening** — releases carry [PEP 740 Sigstore attestations](https://peps.python.org/pep-0740/) (via PyPI trusted publishing), a CycloneDX SBOM on every GitHub release, and [OpenSSF Scorecard](https://github.com/ossf/scorecard) weekly on `main`. The release job **fails** if PyPI does not report an attestation bundle for the version it just published, so this line cannot drift into being false. Verified for every release back to 1.19.0. Don't take our word for it: `curl -s https://pypi.org/integrity/distil-llm/<version>/<filename>/provenance` (note the *integrity* API — `/pypi/<pkg>/<ver>/json` does not carry an attestations field, and reading it there reports a false negative), or `uvx pypi-attestations verify pypi --repository https://github.com/dshakes/distil pypi:distil_llm-<version>-py3-none-any.whl`.
 
-See [Deploy & security](https://dshakes.github.io/distil/deploy-security.html) for topologies (local sidecar, container sidecar, shared gateway) and the threat model.
+- **Kubernetes** — a Helm chart for the multi-tenant gateway ships in [`packaging/helm/distil-gateway`](packaging/helm/distil-gateway): auth-required, non-root and read-only-rootfs by default, PDB, HPA, NetworkPolicy restricting egress to DNS + 443, plus a ServiceMonitor and alert rules. A [Grafana dashboard](packaging/grafana/distil-gateway-dashboard.json) comes with it, and CI cross-checks every panel and alert against the metrics distil actually emits.
+- **SSO / RBAC** — the gateway accepts OIDC bearer tokens alongside its own `dsk-` keys, with three ordered roles (`viewer` < `operator` < `admin`). JWS verification is stdlib-only; RS256 needs the `[oidc]` extra and an RS256 token is **refused** when it is absent rather than accepted unverified.
+
+See [Deploy & security](https://dshakes.github.io/distil/deploy-security.html) for topologies (local sidecar, container sidecar, shared gateway), the [security whitepaper](docs/SECURITY-WHITEPAPER.md) for a review-ready data-handling and compliance summary, and [`SECURITY.md`](SECURITY.md) to report a vulnerability.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a suspected vulnerability.**
+
+Report privately through GitHub's [private vulnerability
+reporting](https://github.com/dshakes/distil/security/advisories/new) on this
+repository. That channel is monitored and keeps the report non-public until a fix
+is available.
+
+Include what you need to make it actionable:
+
+- the version (`distil --version`) and how it was installed
+- what an attacker gains, and what access they need to start
+- a reproduction — ideally a failing command or a short script
+- whether you have published or plan to publish anything about it
+
+### What to expect
+
+This is an open-source project maintained without a commercial support
+organisation behind it, so the honest commitment is effort, not a contractual
+clock:
+
+| | |
+|---|---|
+| Acknowledgement | Best effort, typically within a few days |
+| Assessment and severity | After acknowledgement, shared with you |
+| Fix and release | Prioritised over feature work; release cadence is fast |
+| Credit | Offered in the advisory and CHANGELOG unless you decline |
+
+If you need a guaranteed response time, distil does not offer one today. See
+[`docs/SECURITY-WHITEPAPER.md`](docs/SECURITY-WHITEPAPER.md) § 11.
+
+## Supported versions
+
+Fixes land on the latest release. There is no long-term-support branch, and
+backports to older minors are not provided — upgrading is the supported path, and
+releases are frequent and small for exactly that reason.
+
+## Scope
+
+Distil runs entirely inside your own boundary: it operates no hosted service, and
+compression is local. Reports in scope include, for example:
+
+- content leaking out of the machine (telemetry, logs, the census payload)
+- the proxy or gateway being usable as an SSRF pivot beyond its single configured
+  upstream
+- authentication or tenant-isolation failures in the gateway
+- a digest that is not byte-reversible, or a handle resolving to another block's
+  content
+- secrets appearing in logs, metrics, receipts, or error output
+- supply-chain issues in the published artifacts
+
+### Explicitly out of scope
+
+These are documented design boundaries, not oversights — see
+[`THREAT_MODEL.md`](THREAT_MODEL.md):
+
+- **A same-UID local attacker.** Encryption at rest protects against backup/sync
+  leakage and cross-user reads on shared filesystems. Someone who can already read
+  both `${DISTIL_HOME}/restore/` and `restore.key` as your user is out of scope.
+- **Cross-tenant memory isolation within one gateway process.** Tenants share a
+  process by design; run one gateway per trust boundary where that matters. This
+  is stated in `distil gateway --help`.
+- **Compression quality.** A digest that loses information you wanted is a bug,
+  and an important one — but file it as a normal issue with a reproduction, not as
+  a vulnerability.
+
+## Hardening this project applies to itself
+
+- Zero runtime dependencies in the core — the attack surface is the Python
+  standard library plus this repository.
+- Releases carry [PEP 740](https://peps.python.org/pep-0740/) Sigstore
+  attestations via PyPI Trusted Publishing; the release job fails if PyPI does not
+  report an attestation bundle for the version it just published.
+- A CycloneDX SBOM is attached to every GitHub release.
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard) runs weekly on `main`.
+- CI runs an adversarial gate (`distil validate`) that drives the compressor
+  against hostile inputs — including secret-looking ones — and asserts
+  reversibility, fail-open behaviour, and content-free telemetry.
+
+Verify a published artifact yourself:
+
+```bash
+uvx pypi-attestations verify pypi \
+  --repository https://github.com/dshakes/distil \
+  pypi:distil_llm-<version>-py3-none-any.whl
+```

--- a/distil/__init__.py
+++ b/distil/__init__.py
@@ -43,3 +43,37 @@ except PackageNotFoundError:  # source checkout / zipapp without dist-info
             __version__ = _m.group(1) if _m else "0+source"
         except Exception:  # noqa: BLE001 — version must never break import
             __version__ = "0+source"
+
+
+# ---------------------------------------------------------------------------
+# Public library API
+# ---------------------------------------------------------------------------
+# Re-exported lazily via __getattr__ (PEP 562): `import distil` must stay cheap
+# because the CLI imports this package on every `--version`/completion call, and
+# the compression stack pulls in the whole adapter tree. Importing the name is
+# what pays for it:  `from distil import compress_messages`.
+#
+# NOT named `compress`: `distil.compress` is an existing SUBPACKAGE. Python binds
+# a submodule onto its parent package as soon as anything imports it, which would
+# silently shadow a same-named __getattr__ export — so `from distil import compress`
+# would hand back the module in any program that had touched the subpackage, and
+# the function otherwise. A name that resolves to two different objects depending
+# on unrelated import order is not an API. `compress_messages` also matches the
+# vocabulary already used in adapters/anthropic.py and integrations/langchain.py.
+
+__all__ = ["CompressionResult", "compress_messages", "expand_handle", "__version__"]
+
+_LAZY = {"compress_messages": "api", "expand_handle": "api", "CompressionResult": "api"}
+
+
+def __getattr__(name: str) -> object:  # pragma: no cover - trivial dispatch
+    mod = _LAZY.get(name)
+    if mod is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(f".{mod}", __name__), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - REPL/tab-completion affordance
+    return sorted(__all__)

--- a/distil/api.py
+++ b/distil/api.py
@@ -1,0 +1,173 @@
+"""Public library API — embed distil in your own agent.
+
+The proxy (``distil proxy`` / ``distil wrap``) stays the zero-config path: it needs
+no code change and sees the agent's *intent* alongside its output, which is what
+makes query-aware keeps possible. This module is for the other case — you are
+building the agent, you already hold the message list, and you want to compress it
+in-process before the model call::
+
+    from distil import compress_messages, expand_handle
+
+    result = compress_messages(messages)
+    print(f"{result.saved_pct:.1f}% smaller")
+    response = client.messages.create(model=..., messages=result.messages)
+
+    original = expand_handle(result.handles[0])   # byte-exact, any time, any process
+
+Message shapes are duck-typed: plain ``{"role": ..., "content": ...}`` dicts
+(OpenAI / Anthropic wire format) and objects exposing ``.role``/``.type`` and
+``.content`` (LangChain ``BaseMessage``, pydantic models) both work, so this module
+never imports a framework.
+
+**What gets compressed.** Tool/function results get the reversible Tier-1 digest —
+elided spans are replaced by a short stub carrying an 8-hex handle, and the original
+bytes are persisted so :func:`expand_handle` recovers them exactly. User/system text gets
+Tier-0 lossless transforms only. The model's own turns (``assistant``/``ai``) are
+never rewritten. Non-string content (image blocks, tool-use structures) passes
+through untouched.
+
+**Reversibility is the contract.** Every digest is recoverable via :func:`expand_handle`
+for as long as the restore store retains it (``DISTIL_RESTORE_TTL_DAYS``, default
+14). Pass ``verbatim=True`` to disable Tier-1 digests entirely and take only the
+in-context-lossless transforms — lower savings, nothing behind a handle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["CompressionResult", "compress_messages", "expand_handle"]
+
+
+@dataclass(frozen=True)
+class CompressionResult:
+    """What :func:`compress_messages` returns.
+
+    ``messages`` is a new list — the input is never mutated. Unchanged messages are
+    passed through by identity, so ``result.messages[i] is messages[i]`` holds
+    wherever nothing was compressed.
+    """
+
+    messages: list[Any]
+    tokens_before: int
+    tokens_after: int
+    handles: list[str] = field(default_factory=list)
+
+    @property
+    def tokens_saved(self) -> int:
+        return self.tokens_before - self.tokens_after
+
+    @property
+    def saved_pct(self) -> float:
+        """Percent smaller, 0.0 when there was nothing to measure.
+
+        Can legitimately be ~0 on small payloads: savings come from *large* tool
+        output, and a request that is mostly system prompt has nothing to fold.
+        """
+        if self.tokens_before <= 0:
+            return 0.0
+        return 100.0 * (self.tokens_before - self.tokens_after) / self.tokens_before
+
+
+def _role(m: Any) -> str:
+    if isinstance(m, dict):
+        return str(m.get("role") or m.get("type") or "")
+    return str(getattr(m, "role", "") or getattr(m, "type", "") or "")
+
+
+def _content(m: Any) -> Any:
+    if isinstance(m, dict):
+        return m.get("content")
+    return getattr(m, "content", None)
+
+
+def _with_content(m: Any, new_text: str) -> Any:
+    """Return a copy of *m* with replaced content, across message shapes."""
+    if isinstance(m, dict):
+        return {**m, "content": new_text}
+    if hasattr(m, "model_copy"):  # pydantic v2
+        return m.model_copy(update={"content": new_text})
+    if hasattr(m, "copy"):  # pydantic v1 — dict.copy() takes no kwargs
+        try:
+            return m.copy(update={"content": new_text})
+        except TypeError:
+            pass
+    return m  # unknown immutable shape — leave it rather than risk corruption
+
+
+def compress_messages(
+    messages: list[Any],
+    *,
+    verbatim: bool = False,
+    tokenizer: str = "heuristic",
+) -> CompressionResult:
+    """Compress a message list in-process.
+
+    :param messages: OpenAI/Anthropic-style dicts or duck-typed message objects.
+    :param verbatim: Tier-0 lossless transforms only — no digest stubs, no handles.
+        Use for flat-rate/subscription billing or out-of-distribution traffic where
+        the model must reason over real bytes rather than recover them.
+    :param tokenizer: ``"heuristic"`` (default, offline, no key) or ``"anthropic"``
+        for billing-grade counts (requires the ``anthropic`` extra and credentials).
+    :returns: a :class:`CompressionResult`. Never raises on unusual message shapes —
+        anything it does not understand is passed through unchanged.
+    """
+    # Imported lazily: `import distil` must stay cheap (the CLI's --version path
+    # imports this package), and the compression stack pulls in the adapter tree.
+    from .adapters.anthropic import (
+        RestoreStore,
+        _compress_text_content,
+        _compress_tool_result_text,
+        _keep_tls,
+    )
+    from .tokenizer import resolve as _resolve_tokenizer
+
+    tok = _resolve_tokenizer(tokenizer)
+
+    def _count(m: Any) -> int:
+        c = _content(m)
+        return tok.count(c) if isinstance(c, str) else 0
+
+    before = sum(_count(m) for m in messages)
+
+    _keep_tls.fn = None
+    try:
+        store = RestoreStore()
+        out: list[Any] = []
+        for m in messages:
+            content = _content(m)
+            if not isinstance(content, str):
+                out.append(m)  # image block, tool_use struct, None — pass through
+                continue
+            role = _role(m).lower()
+            if role in ("assistant", "ai"):
+                out.append(m)  # never rewrite the model's own words
+                continue
+            if role in ("tool", "function"):
+                new_text = _compress_tool_result_text(content, store, verbatim)
+            else:
+                new_text = _compress_text_content(content, store, verbatim)
+            out.append(m if new_text == content else _with_content(m, new_text))
+    finally:
+        _keep_tls.fn = None
+
+    after = sum(_count(m) for m in out)
+    return CompressionResult(
+        messages=out,
+        tokens_before=before,
+        tokens_after=after,
+        handles=sorted(store.handles),
+    )
+
+
+def expand_handle(handle: str) -> str | None:
+    """Recover the original text behind an 8-hex digest *handle*.
+
+    Reads the on-disk restore store, so it works across processes and restarts —
+    the handle from a proxy session expands here, and vice versa. Returns ``None``
+    for an unknown, expired, or malformed handle rather than raising.
+    """
+    from .mcp_server import load_restore
+
+    return load_restore(handle)

--- a/distil/authz.py
+++ b/distil/authz.py
@@ -1,0 +1,242 @@
+"""Role-based access control and OIDC identity for the gateway.
+
+Design constraints, in priority order:
+
+1. **No new runtime dependency.** distil's core is stdlib-only, and a security
+   component is the worst place to break that — a JWT library is a supply-chain
+   surface sitting directly in the auth path. JWS verification here is written
+   against ``hmac``/``hashlib`` for HS256 and, for RS256, against the ``crypto``
+   module only when the optional ``[oidc]`` extra is installed. If asymmetric
+   verification is unavailable, distil **refuses the token** rather than falling
+   back to an unverified decode.
+2. **Fail closed.** Every path that cannot prove a claim denies it. There is no
+   "if we can't check the signature, trust the payload" branch — that is the
+   single most common JWT vulnerability and it is absent by construction.
+3. **Additive.** ``dsk-`` bearer keys keep working exactly as before. OIDC is a
+   second way to present an identity, not a replacement, so enabling it cannot
+   lock out an existing deployment.
+
+Roles
+-----
+Three, deliberately few — an RBAC model with twenty verbs nobody can reason about
+is worse than one with three that everybody can:
+
+``viewer``    read stats and metrics; cannot proxy requests or change anything
+``operator``  everything a viewer can, plus proxy requests through the gateway
+``admin``     everything, plus key issue/revoke and the admin dashboard
+
+Roles are ordered: an ``admin`` satisfies any requirement an ``operator`` does.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "Identity",
+    "Role",
+    "AuthzError",
+    "ROLE_ORDER",
+    "parse_role",
+    "verify_jwt",
+    "identity_from_claims",
+]
+
+
+class AuthzError(Exception):
+    """Authentication or authorization failed. The message is safe to log."""
+
+
+# Ascending privilege. Index comparison is the whole authorization model.
+ROLE_ORDER: tuple[str, ...] = ("viewer", "operator", "admin")
+
+Role = str
+
+
+def parse_role(value: str | None, *, default: str = "operator") -> Role:
+    """Normalise a role string, falling back to *default* for unknown values.
+
+    Unknown roles degrade to the default rather than raising: an identity
+    provider adding a group distil has never heard of must not take the gateway
+    down. It must also never silently escalate, which is why the default is
+    ``operator`` and never ``admin``.
+    """
+    v = (value or "").strip().lower()
+    return v if v in ROLE_ORDER else default
+
+
+@dataclass(frozen=True)
+class Identity:
+    """Who is making this request, and what they may do."""
+
+    subject: str
+    tenant: str
+    role: Role
+    source: str  # "key" | "oidc"
+    expires: float | None = None
+
+    def can(self, required: Role) -> bool:
+        """True when this identity's role is at least *required*."""
+        try:
+            return ROLE_ORDER.index(self.role) >= ROLE_ORDER.index(required)
+        except ValueError:  # unknown role: deny rather than guess
+            return False
+
+    def require(self, required: Role) -> None:
+        if not self.can(required):
+            raise AuthzError(f"role '{self.role}' is insufficient; '{required}' required")
+
+    @property
+    def is_expired(self) -> bool:
+        return self.expires is not None and time.time() >= self.expires
+
+
+def _b64url_decode(seg: str) -> bytes:
+    return base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4))
+
+
+def _verify_hs256(signing_input: bytes, sig: bytes, secret: str) -> bool:
+    expected = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return hmac.compare_digest(expected, sig)  # constant time — not `==`
+
+
+def _verify_rs256(signing_input: bytes, sig: bytes, public_key_pem: str) -> bool:
+    """RS256 via the optional [oidc] extra. Absent extra => refuse, never bypass."""
+    try:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+    except ImportError as exc:  # pragma: no cover - depends on optional extra
+        raise AuthzError(
+            "RS256 token presented but asymmetric verification is unavailable; "
+            "install the [oidc] extra. Refusing rather than skipping verification."
+        ) from exc
+    try:
+        key = serialization.load_pem_public_key(public_key_pem.encode())
+        key.verify(sig, signing_input, padding.PKCS1v15(), hashes.SHA256())  # type: ignore[union-attr]
+        return True
+    except Exception:  # noqa: BLE001 — any verification failure is a failure
+        return False
+
+
+def verify_jwt(
+    token: str,
+    *,
+    secret: str = "",
+    public_key_pem: str = "",
+    issuer: str = "",
+    audience: str = "",
+    leeway: float = 60.0,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Verify a compact JWS and return its claims, or raise :class:`AuthzError`.
+
+    Checks, in order: structure, algorithm allow-list, signature, ``exp``,
+    ``nbf``, ``iss``, ``aud``. Every one is mandatory when configured; none can be
+    skipped by anything in the token itself.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise AuthzError("malformed token: expected three dot-separated segments")
+    h_seg, p_seg, s_seg = parts
+    try:
+        header = json.loads(_b64url_decode(h_seg))
+        claims = json.loads(_b64url_decode(p_seg))
+        signature = _b64url_decode(s_seg)
+    except (ValueError, TypeError) as exc:
+        raise AuthzError("malformed token: undecodable segment") from exc
+    if not isinstance(header, dict) or not isinstance(claims, dict):
+        raise AuthzError("malformed token: header and payload must be objects")
+
+    alg = str(header.get("alg", ""))
+    # Allow-list, and `none` can never appear in it. A token that names its own
+    # algorithm is choosing its own verification, so the SERVER decides.
+    if alg not in ("HS256", "RS256"):
+        raise AuthzError(f"unsupported or unsafe alg: {alg!r}")
+
+    signing_input = f"{h_seg}.{p_seg}".encode()
+    if alg == "HS256":
+        if not secret:
+            raise AuthzError("HS256 token presented but no shared secret is configured")
+        ok = _verify_hs256(signing_input, signature, secret)
+    else:
+        if not public_key_pem:
+            raise AuthzError("RS256 token presented but no public key is configured")
+        ok = _verify_rs256(signing_input, signature, public_key_pem)
+    if not ok:
+        raise AuthzError("signature verification failed")
+
+    t = time.time() if now is None else now
+    exp = claims.get("exp")
+    if exp is not None:
+        try:
+            if t >= float(exp) + leeway:
+                raise AuthzError("token expired")
+        except (TypeError, ValueError) as exc:
+            raise AuthzError("invalid exp claim") from exc
+    nbf = claims.get("nbf")
+    if nbf is not None:
+        try:
+            if t + leeway < float(nbf):
+                raise AuthzError("token not yet valid")
+        except (TypeError, ValueError) as exc:
+            raise AuthzError("invalid nbf claim") from exc
+    if issuer and claims.get("iss") != issuer:
+        raise AuthzError("issuer mismatch")
+    if audience:
+        aud = claims.get("aud")
+        auds = aud if isinstance(aud, list) else [aud]
+        if audience not in auds:
+            raise AuthzError("audience mismatch")
+    return claims
+
+
+def identity_from_claims(
+    claims: dict[str, Any],
+    *,
+    role_claim: str = "role",
+    tenant_claim: str = "tenant",
+    default_role: str = "operator",
+) -> Identity:
+    """Map verified claims onto an :class:`Identity`.
+
+    The role may arrive as a scalar or inside a groups/roles array (the common
+    Okta/Entra shape). The **highest** role present wins, which is the least
+    surprising reading of "this user is in both groups".
+    """
+    raw = claims.get(role_claim)
+    role = parse_role(None, default=default_role)
+    if isinstance(raw, str):
+        role = parse_role(raw, default=default_role)
+    elif isinstance(raw, (list, tuple)):
+        found = [parse_role(r, default="") for r in raw if isinstance(r, str)]
+        found = [r for r in found if r in ROLE_ORDER]
+        if found:
+            role = max(found, key=ROLE_ORDER.index)
+
+    subject = str(claims.get("sub") or "unknown")
+    tenant = str(claims.get(tenant_claim) or subject)
+    exp = claims.get("exp")
+    try:
+        expires = float(exp) if exp is not None else None
+    except (TypeError, ValueError):
+        expires = None
+    return Identity(subject=subject, tenant=tenant, role=role, source="oidc", expires=expires)
+
+
+def oidc_config_from_env() -> dict[str, str]:
+    """Read OIDC settings from the environment. Empty issuer disables OIDC."""
+    return {
+        "issuer": os.environ.get("DISTIL_OIDC_ISSUER", ""),
+        "audience": os.environ.get("DISTIL_OIDC_AUDIENCE", ""),
+        "secret": os.environ.get("DISTIL_OIDC_HS256_SECRET", ""),
+        "public_key_pem": os.environ.get("DISTIL_OIDC_PUBLIC_KEY", ""),
+        "role_claim": os.environ.get("DISTIL_OIDC_ROLE_CLAIM", "role"),
+        "tenant_claim": os.environ.get("DISTIL_OIDC_TENANT_CLAIM", "tenant"),
+    }

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1514,7 +1514,7 @@ def cmd_statusline(args: argparse.Namespace) -> int:
         elif recent.runs and recent.total_baseline_tokens and recent.total_tokens_saved > 0:
             trimmed = 1 - recent.total_distil_tokens / recent.total_baseline_tokens
             parts.append(c("1;38;5;84", f"▼{ledger._human(recent.total_tokens_saved)}"))
-            parts.append(c("38;5;80", f"{trimmed * 100:.0f}% smaller"))
+            parts.append(c("38;5;80", ledger.pct_smaller_label(trimmed)))
             if metered and recent.total_dollars_saved > 0:
                 parts.append(c("1;38;5;114", f"${recent.total_dollars_saved:,.2f}"))
         elif recent.runs and recent.total_baseline_tokens:
@@ -2338,6 +2338,23 @@ def cmd_wrap(args: argparse.Namespace) -> int:
     if not upstream:
         upstream = "https://api.anthropic.com"
 
+    # A settings.json base URL outranks the environment we are about to set. If it
+    # names a DEAD port, every request the agent makes fails with a connection error
+    # that blames the provider — so refuse to start rather than hand the user an
+    # outage we could see coming. Observed in the field three times in one day.
+    from .precedence import check_claude_settings
+
+    _conflict = check_claude_settings(env_var)
+    if _conflict is not None:
+        if _conflict.fatal:
+            print(f"\n  ✗ distil wrap: {_conflict.message()}\n", file=sys.stderr)
+            print(
+                "    (override with DISTIL_IGNORE_SETTINGS_PRECEDENCE=1 if you know better)",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"  ⚠ {_conflict.message()}", file=sys.stderr)
+
     _apply_subscription_safe_default(args)
     from .proxy import wrap_run
 
@@ -2368,10 +2385,25 @@ def cmd_wrap(args: argparse.Namespace) -> int:
 
             mp = session_marker_path()
             if mp is not None and mp.exists() and mp.read_text(encoding="utf-8").strip() == "0":
+                # Name the cause we can actually verify before guessing at one we
+                # can't. The old text blamed "agent update?" and sent people to
+                # offboard when the real cause was our OWN settings.json entry
+                # outranking our OWN wrap.
+                from .precedence import check_claude_settings
+
+                conflict = check_claude_settings(env_var)
+                if conflict is not None:
+                    detail = f"{env_var} is pinned in {conflict.path.name} to "
+                    detail += f"{conflict.value}, which outranks the wrap's environment"
+                    if conflict.fatal:
+                        detail += " AND is not accepting connections"
+                    fix = "distil offboard  (or start the service: distil default --always-on)"
+                else:
+                    detail = f"{cmd_name} may have stopped honoring {env_var} (agent update?)"
+                    fix = "distil doctor"
                 print(
                     f"  warning: no requests flowed through distil this session — "
-                    f"{cmd_name} may have stopped honoring {env_var} "
-                    f"(agent update?). Run `distil doctor` to check.",
+                    f"{detail}. Fix: {fix}",
                     file=sys.stderr,
                 )
         except Exception:  # noqa: BLE001 — a tripwire must never break the wrap exit

--- a/distil/doctor.py
+++ b/distil/doctor.py
@@ -168,6 +168,18 @@ def _check_session() -> Check:
     reqs = f"{s.runs} request{'s' if s.runs != 1 else ''}"
     if s.total_tokens_saved > 0:
         pct = (1 - s.total_distil_tokens / s.total_baseline_tokens) * 100
+        if pct < 1:
+            # "▼413 tokens saved (0% smaller)" reads as broken — a real number next
+            # to a zero. Say the small-but-real thing instead, with the reason, so a
+            # first-run user doesn't conclude distil is doing nothing and uninstall.
+            return Check(
+                "this session",
+                OK,
+                f"▼{s.total_tokens_saved:,} tokens saved (<1% so far) over {reqs}",
+                "savings come from LARGE tool output (file reads, logs). This traffic "
+                "is mostly system prompt + short outputs, which has little to trim — "
+                "▼ climbs once your agent reads big content.",
+            )
         return Check(
             "this session",
             OK,
@@ -206,11 +218,28 @@ def _check_live_routing() -> Check:
     running = bool(re.search(r"distil\s+(wrap|proxy|gateway)\b", out.stdout))
     if not running:
         return Check("live routing", INFO, "no distil wrap/proxy running (nothing to route)")
+    # Traffic is "did a request reach us", NOT "did we save anything on it".
+    # The savings ledger deliberately skips zero-saving windows (runtime.py: "a
+    # 0-row is noise"), so on traffic that legitimately compresses to ~nothing —
+    # a mostly-system-prompt request, a freshly compacted session — savings.jsonl
+    # never moves and this check used to report the proxy as bypassed while it was
+    # demonstrably serving requests. Every request writes a receipt regardless of
+    # savings, so the receipt log is the honest signal; the ledger stays in the
+    # max() because a wrap session that saved something is equally proof of life.
+    last_ts = 0.0
     try:
         _sid, last_ts = ledger.latest_session()
-        age_min = (time.time() - last_ts) / 60 if last_ts else 1e9
     except Exception:  # noqa: BLE001
-        age_min = 1e9
+        pass
+    try:
+        from . import receipts
+
+        p = receipts.receipts_path()
+        if p.exists():
+            last_ts = max(last_ts, p.stat().st_mtime)
+    except Exception:  # noqa: BLE001 — diagnosis must never crash the doctor
+        pass
+    age_min = (time.time() - last_ts) / 60 if last_ts else 1e9
     if age_min <= 5:
         return Check(
             "live routing", OK, f"wrapped agent live · traffic recorded {age_min:.0f}m ago"

--- a/distil/gateway.py
+++ b/distil/gateway.py
@@ -86,6 +86,10 @@ class TenantStats:
     requests: int = 0
     tokens_baseline: int = 0
     tokens_compressed: int = 0
+    # Requests refused by a per-tenant quota (RPM or daily tokens). Counted
+    # separately from `requests`, which only ever counts work actually done:
+    # folding the two would make a throttled tenant look busy instead of blocked.
+    rejected_quota: int = 0
 
     @property
     def tokens_saved(self) -> int:
@@ -186,6 +190,24 @@ class GatewayState:
         self._price = price
         self._last_save = time.monotonic()
 
+    def record_quota_rejection(self, tenant: str) -> None:
+        """Count one request refused by a per-tenant quota.
+
+        Exported as ``distil_requests_rejected_total`` so an operator can see a
+        throttled tenant without reading logs — quota enforcement that is invisible
+        is indistinguishable from an outage from the client's side.
+        """
+        with self._lock:
+            s = self._tenants.get(tenant)
+            if s is None:
+                s = TenantStats()
+                self._tenants[tenant] = s
+                if len(self._tenants) > _MAX_TENANTS:
+                    self._tenants.popitem(last=False)
+            else:
+                self._tenants.move_to_end(tenant)
+            s.rejected_quota += 1
+
     def record(self, tenant: str, baseline_tokens: int, compressed_tokens: int) -> None:
         """Accumulate one request's worth of token counts for *tenant* (LRU-bounded)."""
         with self._lock:
@@ -219,6 +241,7 @@ class GatewayState:
                         "requests": s.requests,
                         "tokens_baseline": s.tokens_baseline,
                         "tokens_compressed": s.tokens_compressed,
+                        "rejected_quota": s.rejected_quota,
                     }
                     for tid, s in self._tenants.items()
                 }
@@ -246,6 +269,8 @@ class GatewayState:
                     s.requests = int(d["requests"])
                     s.tokens_baseline = int(d["tokens_baseline"])
                     s.tokens_compressed = int(d["tokens_compressed"])
+                    # Older state files predate this field — default, don't discard.
+                    s.rejected_quota = int(d.get("rejected_quota", 0))
                 except (KeyError, TypeError, ValueError):
                     continue  # skip a corrupt tenant entry
                 self._tenants[tid] = s
@@ -261,6 +286,7 @@ class GatewayState:
             tot_req = 0
             tot_baseline = 0
             tot_compressed = 0
+            tot_rejected = 0
             for tid, s in sorted(
                 self._tenants.items(), key=lambda kv: kv[1].tokens_saved, reverse=True
             ):
@@ -274,11 +300,13 @@ class GatewayState:
                         "tokens_saved": s.tokens_saved,
                         "dollars_saved": round(dollars, 6),
                         "pct_saved": round(s.pct_saved(), 2),
+                        "rejected_quota": s.rejected_quota,
                     }
                 )
                 tot_req += s.requests
                 tot_baseline += s.tokens_baseline
                 tot_compressed += s.tokens_compressed
+                tot_rejected += s.rejected_quota
 
             tot_saved = max(0, tot_baseline - tot_compressed)
             tot_dollars = tot_saved * self._price.input
@@ -291,6 +319,7 @@ class GatewayState:
                 "tokens_saved": tot_saved,
                 "dollars_saved": round(tot_dollars, 6),
                 "pct_saved": round(tot_pct, 2),
+                "rejected_quota": tot_rejected,
             }
             return {"tenants": tenants, "totals": totals}
 
@@ -831,6 +860,7 @@ def build_gateway_handler(
             # RPM gate: per-key limit wins over gateway default.
             rpm_limit = rec.rpm if rec.rpm is not None else default_rpm
             if not _rl.check_rpm(rec.tenant, rpm_limit):
+                state.record_quota_rejection(rec.tenant)
                 body = json.dumps({"error": "rate limit exceeded"}).encode()
                 self._relay(429, {"Content-Type": "application/json"}, body, {"Retry-After": "60"})
                 return ("", "")
@@ -1011,6 +1041,7 @@ def build_gateway_handler(
             # otherwise the startup banner advertises a limit nothing enforces.
             # (With key auth on, _check_inbound_auth already charged this request.)
             if tenant_override is None and default_rpm and not _rl.check_rpm(tenant, default_rpm):
+                state.record_quota_rejection(tenant)
                 body_err = json.dumps({"error": "rate limit exceeded"}).encode()
                 self._relay(
                     429, {"Content-Type": "application/json"}, body_err, {"Retry-After": "60"}
@@ -1053,6 +1084,7 @@ def build_gateway_handler(
                 _key_daily = getattr(self, "_key_daily_tokens", None)
                 daily_limit = _key_daily if _key_daily is not None else default_daily_tokens
                 if daily_limit and not _rl.check_daily_tokens(tenant, daily_limit, baseline_tokens):
+                    state.record_quota_rejection(tenant)
                     body_err = json.dumps({"error": "daily token quota exceeded"}).encode()
                     self._relay(
                         429,
@@ -1076,6 +1108,7 @@ def build_gateway_handler(
                 if _daily_limit and not _rl.check_daily_tokens(
                     tenant, _daily_limit, baseline_tokens
                 ):
+                    state.record_quota_rejection(tenant)
                     body_err = json.dumps({"error": "daily token quota exceeded"}).encode()
                     self._relay(
                         429,

--- a/distil/gateway.py
+++ b/distil/gateway.py
@@ -39,6 +39,10 @@ from .adapters.anthropic import compress_messages
 from .adapters.gemini import compress_generate_request
 from .adapters.gemini import count_tokens as _gemini_count
 from .adapters.gemini import is_gemini_path
+from .authz import AuthzError as _AuthzError
+from .authz import identity_from_claims as _identity_from_claims
+from .authz import oidc_config_from_env as _oidc_config_from_env
+from .authz import verify_jwt as _verify_jwt
 from .gateway_keys import GatewayKeyStore, KeyRecord  # noqa: F401
 from .httpguard import parse_content_length, safe_forward_path
 from .pricing import Pricing, get as pricing_get
@@ -50,6 +54,15 @@ from .proxy import (
     _warn_if_version_skew,
 )
 from .tokenizer import DEFAULT as _tokenizer
+
+
+class _OidcRejected(Exception):
+    """Raised after a 401 has already been sent for a rejected OIDC token.
+
+    Lets the auth path unwind without a second response being written — the 401
+    is already on the wire by the time this propagates.
+    """
+
 
 # Safe tenant label: bounded length, no markup / control characters.
 _TENANT_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
@@ -820,6 +833,37 @@ def build_gateway_handler(
                 return xdk, "x-distil-key"
             return None, None
 
+        def _identity_from_oidc(self):
+            """Verify an ``Authorization: Bearer <jwt>`` against configured OIDC.
+
+            Returns an Identity, or None when OIDC is not configured or no bearer
+            was presented. A bearer that IS presented but fails verification is a
+            hard 401 — never a fall-through to "unauthenticated but allowed".
+            """
+            cfg = _oidc_config_from_env()
+            if not cfg.get("issuer"):
+                return None  # OIDC disabled
+            auth = self.headers.get("Authorization", "")
+            if not auth.startswith("Bearer ") or auth.startswith("Bearer dsk-"):
+                return None
+            token = auth[len("Bearer ") :].strip()
+            try:
+                claims = _verify_jwt(
+                    token,
+                    secret=cfg["secret"],
+                    public_key_pem=cfg["public_key_pem"],
+                    issuer=cfg["issuer"],
+                    audience=cfg["audience"],
+                )
+            except _AuthzError as exc:
+                self._reject(401, f"OIDC token rejected: {exc}")
+                raise _OidcRejected from exc
+            return _identity_from_claims(
+                claims,
+                role_claim=cfg["role_claim"],
+                tenant_claim=cfg["tenant_claim"],
+            )
+
         def _check_inbound_auth(self) -> tuple[str | None, str | None] | None:
             """Validate the gateway key when auth is required.
 
@@ -846,6 +890,33 @@ def build_gateway_handler(
 
             raw_key, strip_hdr = self._extract_distil_key()
             if raw_key is None:
+                # No dsk- key. If OIDC is configured, a verified bearer JWT is an
+                # equally valid credential — additive, so enabling OIDC can never
+                # lock out a deployment that already runs on issued keys.
+                try:
+                    ident = self._identity_from_oidc()
+                except _OidcRejected:
+                    # 401 already written by the extractor; unwind cleanly rather
+                    # than letting the handler emit a second response.
+                    return ("", "")
+                if ident is not None:
+                    try:
+                        ident.require("operator")  # proxying is an operator action
+                    except _AuthzError as exc:
+                        self._reject(403, str(exc))
+                        return ("", "")
+                    if not _rl.check_rpm(ident.tenant, default_rpm):
+                        state.record_quota_rejection(ident.tenant)
+                        body = json.dumps({"error": "rate limit exceeded"}).encode()
+                        self._relay(
+                            429,
+                            {"Content-Type": "application/json"},
+                            body,
+                            {"Retry-After": "60"},
+                        )
+                        return ("", "")
+                    # Strip the bearer so the upstream never sees our IdP token.
+                    return (ident.tenant, "authorization")
                 self._reject(
                     401,
                     "gateway key required (Authorization: Bearer dsk-… or x-distil-key header)",

--- a/distil/integrations/agno.py
+++ b/distil/integrations/agno.py
@@ -1,0 +1,74 @@
+"""Agno integration — compress an agent's messages in-process.
+
+Like :mod:`distil.integrations.langchain`, this module is **duck-typed and never
+imports agno**: it works on anything exposing ``role``/``type`` and ``content``
+(Agno message objects, pydantic models, plain dicts). That keeps distil a
+zero-dependency install and means an Agno version bump cannot break it.
+
+Two integration points, in increasing order of intrusiveness::
+
+    # 1. Compress a message list you already hold.
+    from distil.integrations.agno import compress_messages
+    msgs = compress_messages(session.messages)
+
+    # 2. Wrap a model/callable so every call is compressed on the way out.
+    from distil.integrations.agno import compressed_model
+    agent = Agent(model=compressed_model(OpenAIChat(id="gpt-5")))
+
+The wrapper is a transparent proxy: every attribute except the invocation methods
+(``invoke`` / ``ainvoke`` / ``response`` / ``aresponse``) is delegated untouched, so
+the object still behaves as the framework expects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..api import compress_messages as _compress
+
+__all__ = ["compress_messages", "compressed_model"]
+
+# Method names Agno models expose for a completion. Wrapping all of them means the
+# integration keeps working whether the caller is sync, async, or streaming.
+_CALL_METHODS = ("invoke", "ainvoke", "response", "aresponse")
+
+
+def compress_messages(messages: list[Any], *, verbatim: bool = False) -> list[Any]:
+    """Return a new list with compressible content reversibly compressed."""
+    return _compress(messages, verbatim=verbatim).messages
+
+
+def _compress_in(args: tuple[Any, ...], kwargs: dict[str, Any], verbatim: bool) -> tuple:
+    """Compress whichever argument carries the message list (kwarg or first positional)."""
+    if isinstance(kwargs.get("messages"), list):
+        kwargs = {**kwargs, "messages": compress_messages(kwargs["messages"], verbatim=verbatim)}
+    elif args and isinstance(args[0], list):
+        args = (compress_messages(args[0], verbatim=verbatim), *args[1:])
+    return args, kwargs
+
+
+def compressed_model(model: Any, *, verbatim: bool = False) -> Any:
+    """Wrap an Agno model so its messages are compressed before every call.
+
+    Unknown attributes are delegated to the wrapped model, so this is safe to hand
+    to ``Agent(model=...)`` in place of the original.
+    """
+
+    class _CompressedModel:
+        # Not a subclass: Agno models vary in __init__ contract, and delegation is
+        # the only approach that survives a framework upgrade.
+        def __getattr__(self, name: str) -> Any:
+            attr = getattr(model, name)
+            if name not in _CALL_METHODS or not callable(attr):
+                return attr
+
+            def _wrapped(*args: Any, **kwargs: Any) -> Any:
+                a, kw = _compress_in(args, kwargs, verbatim)
+                return attr(*a, **kw)
+
+            return _wrapped
+
+        def __repr__(self) -> str:  # pragma: no cover - diagnostic affordance
+            return f"<distil-compressed {model!r}>"
+
+    return _CompressedModel()

--- a/distil/integrations/strands.py
+++ b/distil/integrations/strands.py
@@ -1,0 +1,110 @@
+"""Strands Agents integration — compress an agent's messages in-process.
+
+Duck-typed and framework-free, exactly like :mod:`distil.integrations.langchain`:
+this module never imports ``strands``, so distil stays a zero-dependency install
+and a Strands release cannot break it.
+
+Strands messages are ``{"role": ..., "content": [blocks]}`` where each block is a
+dict — commonly ``{"text": "..."}`` for prose and ``{"toolResult": {...}}`` for tool
+output. That block shape is handled here natively, in addition to the plain-string
+``content`` form the other integrations accept::
+
+    from distil.integrations.strands import compress_messages
+
+    agent.messages = compress_messages(agent.messages)
+
+Or hook it into the agent loop so it happens automatically::
+
+    from distil.integrations.strands import compressing_hook
+
+    agent = Agent(model=..., hooks=[compressing_hook()])
+
+Tool results get the reversible Tier-1 digest; prose gets Tier-0 lossless; the
+model's own turns are never rewritten.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..api import compress_messages as _compress
+
+__all__ = ["compress_messages", "compressing_hook"]
+
+
+def _compress_text(text: str, *, role: str, verbatim: bool) -> str:
+    """Compress one string by routing it through the public API as a 1-message list."""
+    out = _compress([{"role": role, "content": text}], verbatim=verbatim).messages
+    new = out[0].get("content") if isinstance(out[0], dict) else None
+    return new if isinstance(new, str) else text
+
+
+def _compress_block(block: Any, *, verbatim: bool) -> Any:
+    """Compress a single Strands content block, preserving its shape."""
+    if not isinstance(block, dict):
+        return block
+    if isinstance(block.get("text"), str):
+        new = _compress_text(block["text"], role="user", verbatim=verbatim)
+        return block if new == block["text"] else {**block, "text": new}
+    tr = block.get("toolResult")
+    if isinstance(tr, dict) and isinstance(tr.get("content"), list):
+        inner = [
+            (
+                {**b, "text": _compress_text(b["text"], role="tool", verbatim=verbatim)}
+                if isinstance(b, dict) and isinstance(b.get("text"), str)
+                else b
+            )
+            for b in tr["content"]
+        ]
+        return {**block, "toolResult": {**tr, "content": inner}}
+    return block
+
+
+def compress_messages(messages: list[Any], *, verbatim: bool = False) -> list[Any]:
+    """Return a new message list with Strands content blocks compressed.
+
+    Handles both the block form (``content`` is a list of dicts) and the plain
+    string form. Assistant turns pass through untouched.
+    """
+    out: list[Any] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+        if str(m.get("role", "")).lower() == "assistant":
+            out.append(m)  # never rewrite the model's own words
+            continue
+        content = m.get("content")
+        if isinstance(content, list):
+            blocks = [_compress_block(b, verbatim=verbatim) for b in content]
+            out.append(m if blocks == content else {**m, "content": blocks})
+        elif isinstance(content, str):
+            new = _compress_text(content, role=str(m.get("role", "user")), verbatim=verbatim)
+            out.append(m if new == content else {**m, "content": new})
+        else:
+            out.append(m)
+    return out
+
+
+def compressing_hook(*, verbatim: bool = False) -> Any:
+    """Return a Strands hook that compresses ``agent.messages`` before each model call.
+
+    Duck-typed against the Strands hook protocol (an object with
+    ``register_hooks(registry)``); it imports the event class lazily from
+    ``strands`` only when actually registered, so importing this module never
+    requires Strands to be installed.
+    """
+
+    class _DistilCompressionHook:
+        def register_hooks(self, registry: Any, **_: Any) -> None:
+            from strands.hooks import BeforeModelInvocationEvent  # local: optional dep
+
+            def _on_before(event: Any) -> None:
+                agent = getattr(event, "agent", None)
+                msgs = getattr(agent, "messages", None)
+                if isinstance(msgs, list):
+                    agent.messages = compress_messages(msgs, verbatim=verbatim)
+
+            registry.add_callback(BeforeModelInvocationEvent, _on_before)
+
+    return _DistilCompressionHook()

--- a/distil/integrations/strands.py
+++ b/distil/integrations/strands.py
@@ -101,6 +101,8 @@ def compressing_hook(*, verbatim: bool = False) -> Any:
 
             def _on_before(event: Any) -> None:
                 agent = getattr(event, "agent", None)
+                if agent is None:
+                    return  # no agent on the event — nothing to compress
                 msgs = getattr(agent, "messages", None)
                 if isinstance(msgs, list):
                     agent.messages = compress_messages(msgs, verbatim=verbatim)

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -440,14 +440,29 @@ def _session_card(session: "LedgerSummary | None") -> str:
     if session is None or not session.runs or not session.total_baseline_tokens:
         return ""
     if session.total_tokens_saved > 0:
-        trimmed = (1 - session.total_distil_tokens / session.total_baseline_tokens) * 100
-        value, label = f"▼{_human(session.total_tokens_saved)}", f"{trimmed:.0f}% smaller"
+        trimmed = 1 - session.total_distil_tokens / session.total_baseline_tokens
+        value, label = f"▼{_human(session.total_tokens_saved)}", pct_smaller_label(trimmed)
     else:
         value, label = "✓ on", "waiting for a large read"
     return (
         f'<div class="card"><div class="l">This session</div>'
         f'<div class="v">{value}</div><div class="l">{label}</div></div>'
     )
+
+
+def pct_smaller_label(trimmed_fraction: float) -> str:
+    """Render a savings percentage without ever printing a broken-looking '0%'.
+
+    ``▼413 · 0% smaller`` is a real number next to a zero, and it reads as "this
+    tool is not working" — the most likely first-run uninstall trigger for anyone
+    whose traffic legitimately compresses to very little (mostly-system-prompt
+    requests, short tool outputs). Sub-1% savings are real; say so honestly at the
+    precision the number actually has.
+    """
+    pct = trimmed_fraction * 100
+    if pct <= 0:
+        return "0% smaller"
+    return "<1% smaller" if pct < 1 else f"{pct:.0f}% smaller"
 
 
 def _human(n: float) -> str:
@@ -506,7 +521,10 @@ def render_dashboard(
     if session is not None and session.runs and session.total_baseline_tokens:
         if session.total_tokens_saved > 0:
             st = 1 - session.total_distil_tokens / session.total_baseline_tokens
-            live = c("38;5;84", f"▼{_human(session.total_tokens_saved)} · {st * 100:.0f}% smaller")
+            live = c(
+                "38;5;84",
+                f"▼{_human(session.total_tokens_saved)} · {pct_smaller_label(st)}",
+            )
         else:
             # match the status line — never a broken-looking "▼0 −0%"
             live = c("38;5;84", "✓ on") + c("38;5;80", " · waiting for a large read")

--- a/distil/metrics.py
+++ b/distil/metrics.py
@@ -36,6 +36,11 @@ _SPEC: tuple[tuple[str, str, str], ...] = (
         "counter",
         "Value of saved tokens at the configured input price.",
     ),
+    (
+        "distil_requests_rejected_total",
+        "counter",
+        "Requests refused by a per-tenant quota (RPM or daily tokens), by tenant.",
+    ),
     ("distil_compression_ratio", "gauge", "Fraction of input tokens saved (0-1)."),
     ("distil_build_info", "gauge", "Build metadata; always 1, carries the version label."),
 )
@@ -77,6 +82,8 @@ def render(snapshot: dict[str, Any], *, version: str = "") -> str:
                 out.append(_line(name, row.get("tokens_baseline", 0), tenant=tenant))
             elif name == "distil_tokens_sent_total":
                 out.append(_line(name, row.get("tokens_compressed", 0), tenant=tenant))
+            elif name == "distil_requests_rejected_total":
+                out.append(_line(name, row.get("rejected_quota", 0), tenant=tenant))
             elif name == "distil_tokens_saved_total":
                 out.append(_line(name, row.get("tokens_saved", 0), tenant=tenant))
             elif name == "distil_dollars_saved_total":

--- a/distil/onboard.py
+++ b/distil/onboard.py
@@ -19,7 +19,13 @@ from pathlib import Path
 from .doctor import subscription_mode
 
 # Agent CLIs we know how to route, in priority order.
-_AGENTS = [("claude", "Claude Code"), ("codex", "Codex"), ("gemini", "Gemini CLI")]
+_AGENTS = [
+    ("claude", "Claude Code"),
+    ("codex", "Codex"),
+    ("gemini", "Gemini CLI"),
+    ("opencode", "OpenCode"),
+    ("qwen", "Qwen Code"),
+]
 _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 
 # Per-agent proxy presets for `distil wrap`.  Maps argv[0] basename → (env_var,
@@ -32,8 +38,22 @@ _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 #   aider        — defaults to OpenAI mode; OPENAI_BASE_URL is the primary override
 #                  (aider docs: --openai-api-base / OPENAI_BASE_URL).  Users routing
 #                  Claude models should pass --env-var ANTHROPIC_BASE_URL explicitly.
+#   opencode     — OpenAI-compatible mode reads OPENAI_API_KEY + OPENAI_BASE_URL from
+#                  the environment, and env takes precedence over its config file
+#                  (OpenCode provider docs).
+#   qwen         — Qwen Code calls LLMs through the OpenAI SDK and documents
+#                  OPENAI_API_KEY / OPENAI_BASE_URL / OPENAI_MODEL explicitly
+#                  (Qwen Code README).
 #   cursor-agent — env var not publicly documented; left out rather than guessing.
 #                  Use --env-var to configure manually.
+#
+# DELIBERATELY ABSENT: cursor, copilot, cline, continue, windsurf. These are IDE
+# extensions, not CLIs — there is no argv to wrap and no documented env-var
+# contract, so `wrap` cannot reach them and a guessed variable would silently
+# route nothing while reporting success. Their supported path is the always-on
+# proxy plus the editor's own "custom base URL"/OpenAI-compatible setting; see
+# docs/IDE-AGENTS.md. Adding a preset here without a published contract is how
+# you ship a lie that looks like a feature.
 AGENT_PRESETS: dict[str, tuple[str, str, str]] = {
     # cmd_name: (env_var, upstream_base_url, human_label)
     "claude": ("ANTHROPIC_BASE_URL", "https://api.anthropic.com", "Claude Code"),
@@ -44,6 +64,8 @@ AGENT_PRESETS: dict[str, tuple[str, str, str]] = {
         "Gemini CLI",
     ),
     "aider": ("OPENAI_BASE_URL", "https://api.openai.com", "aider"),
+    "opencode": ("OPENAI_BASE_URL", "https://api.openai.com", "OpenCode"),
+    "qwen": ("OPENAI_BASE_URL", "https://api.openai.com", "Qwen Code"),
 }
 
 

--- a/distil/precedence.py
+++ b/distil/precedence.py
@@ -1,0 +1,142 @@
+"""Detect settings files that silently outrank ``distil wrap``'s environment.
+
+The outage this exists to prevent
+--------------------------------
+``distil wrap`` starts a proxy on an ephemeral port and exports
+``ANTHROPIC_BASE_URL`` for the child agent. But Claude Code reads its own
+``settings.json``, and **a base URL there outranks the process environment**. So
+if ``distil default --always-on`` (or anything else) has pinned a base URL in
+settings, the wrap's export is dead on arrival:
+
+* Best case, the pinned port is a *live* distil — the wrap's own proxy receives
+  zero requests, silently, and its savings never move.
+* Worst case, the pinned port is **dead** — every session on the machine fails
+  with ``API Error: Unable to connect to API (ConnectionRefused)``, an error that
+  names the provider rather than distil. The user has no reason to suspect us.
+
+Both were observed in the field. The second is a total outage of the agent, and
+it persists across reboots because the settings file is durable while the daemon
+that was supposed to answer is not. Detecting this at wrap start is the only
+point where we can speak *before* the failure instead of after it.
+
+This module is deliberately dependency-free and read-only: it never edits a
+settings file. It answers one question — "will the environment I am about to set
+actually be honoured?" — and hands the caller the exact command to fix it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+__all__ = ["Conflict", "check_claude_settings", "settings_candidates"]
+
+# Highest precedence last: Claude Code resolves later files over earlier ones, so
+# the LAST hit is the value the agent will actually use.
+_USER_SETTINGS = ("~/.claude/settings.json", "~/.claude/settings.local.json")
+_PROJECT_SETTINGS = (".claude/settings.json", ".claude/settings.local.json")
+
+
+@dataclass(frozen=True)
+class Conflict:
+    """A settings-file base URL that will override the wrap's environment."""
+
+    path: Path
+    env_var: str
+    value: str
+    reachable: bool
+
+    @property
+    def fatal(self) -> bool:
+        """True when following this setting cannot possibly work.
+
+        An unreachable pinned URL is not a warning — it is a guaranteed outage
+        for every session started on this machine.
+        """
+        return not self.reachable
+
+    def message(self) -> str:
+        where = str(self.path).replace(str(Path.home()), "~")
+        if self.fatal:
+            return (
+                f"{self.env_var}={self.value} in {where} points at a port that is "
+                f"NOT accepting connections, and that file outranks the environment "
+                f"`distil wrap` sets. Every session will fail with a connection "
+                f"error that blames the API.\n"
+                f"    Fix (pick one):\n"
+                f"      distil default --always-on     # start the service it expects\n"
+                f"      distil offboard                # remove the pin, use wrap only"
+            )
+        return (
+            f"{self.env_var}={self.value} in {where} outranks the environment "
+            f"`distil wrap` sets, so THIS wrap's proxy will receive no traffic "
+            f"(the already-running one on {self.value} handles it instead).\n"
+            f"    Running `distil wrap` on top of always-on is redundant — use one."
+        )
+
+
+def settings_candidates(cwd: Path | None = None) -> list[Path]:
+    """Settings files that can pin a base URL, in ascending precedence order."""
+    cwd = cwd or Path.cwd()
+    out = [Path(p).expanduser() for p in _USER_SETTINGS]
+    out += [cwd / p for p in _PROJECT_SETTINGS]
+    return out
+
+
+def _reachable(url: str, timeout: float = 0.35) -> bool:
+    """Can we open a TCP connection to *url*'s host:port?
+
+    A bare connect, not an HTTP request: we are asking "is anything listening",
+    and an auth rejection or a 404 both mean yes. Non-loopback hosts are assumed
+    reachable — probing an arbitrary remote at every wrap start would add latency
+    and, on a corporate network, look like scanning.
+    """
+    try:
+        u = urlparse(url)
+        host, port = u.hostname or "", u.port or (443 if u.scheme == "https" else 80)
+    except (ValueError, TypeError):
+        return True  # unparseable: not our call to block on
+    if host not in ("127.0.0.1", "localhost", "::1", "0.0.0.0"):
+        return True
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def check_claude_settings(
+    env_var: str, wrap_url: str = "", *, cwd: Path | None = None
+) -> Conflict | None:
+    """Return the settings-file entry that will override *env_var*, if any.
+
+    ``wrap_url`` is the URL this wrap is about to export; a settings entry that
+    already names it is not a conflict. Returns ``None`` when the wrap's
+    environment will be honoured.
+    """
+    if os.environ.get("DISTIL_IGNORE_SETTINGS_PRECEDENCE"):
+        return None
+    winner: Conflict | None = None
+    for path in settings_candidates(cwd):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        env = data.get("env")
+        if not isinstance(env, dict):
+            continue
+        value = env.get(env_var)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        value = value.strip()
+        if wrap_url and value.rstrip("/") == wrap_url.rstrip("/"):
+            continue  # points at us — no conflict
+        # Later files win, so keep overwriting: the last hit is the effective one.
+        winner = Conflict(path=path, env_var=env_var, value=value, reachable=_reachable(value))
+    return winner

--- a/distil/webdash.py
+++ b/distil/webdash.py
@@ -168,7 +168,7 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
     fetch("/data",{cache:"no-store"}).then(function(r){return r.json();}).then(function(d){
       if(last!==null&&d.tokens_saved>last){var c=document.getElementById("card");c.classList.remove("flash");void c.offsetWidth;c.classList.add("flash");}
       last=d.tokens_saved;target=d.tokens_saved;
-      set("pct",d.pct+"%");
+      set("pct",pctLabel(d.baseline_tokens,d.distil_tokens));
       set("dollars",d.subscription?"$"+human(d.dollars_saved):"$"+human(d.dollars_saved));
       set("dollarslab",d.subscription?"$ saved · notional":"$ saved · billed");
       set("eq",d.equivalence.pct==null?"n/a":d.equivalence.pct+"%");
@@ -177,10 +177,20 @@ _PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8"/>
       set("stamp","updated "+new Date(d.ts*1000).toLocaleTimeString());
       var now=Date.now();
       if(now-lastAnnounce>=30000){
-        liveEl.textContent=human(d.tokens_saved)+" tokens saved, "+d.pct+"% smaller, "+commas(d.runs)+" requests.";
+        liveEl.textContent=human(d.tokens_saved)+" tokens saved, "+pctLabel(d.baseline_tokens,d.distil_tokens)+" smaller, "+commas(d.runs)+" requests.";
         lastAnnounce=now;
       }
     }).catch(function(){});
+  }
+  // Mirrors ledger.pct_smaller_label: a real-but-tiny saving must never render
+  // as "0% smaller" — a number next to a zero reads as "this tool is broken".
+  // Derived from the raw counts rather than the rounded `pct`, because 0.04
+  // rounds to 0.0 server-side and the distinction is the whole point.
+  function pctLabel(base,sent){
+    if(!base||base<=0)return "0%";
+    var p=100*(base-sent)/base;
+    if(p<=0)return "0%";
+    return p<1?"<1%":Math.round(p)+"%";
   }
   function schedulePoll(){pollTimer=setInterval(poll,1000);}
   pauseBtn.addEventListener("click",function(){

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,0 +1,159 @@
+# Enterprise deployment & commercial status
+
+What distil can support today, what it cannot, and what closing the gap requires.
+Written to be usable in a procurement conversation without a sales call —
+including the parts that will disqualify it for some buyers.
+
+Companion: [`SECURITY-WHITEPAPER.md`](SECURITY-WHITEPAPER.md) (security review),
+[`GA_READINESS.md`](GA_READINESS.md) (engineering status).
+
+---
+
+## 1. Deployment topologies
+
+| Topology | When | How |
+|---|---|---|
+| **Local sidecar** | Individual developers | `distil wrap -- <agent>`, or `distil default --always-on` |
+| **Container sidecar** | One proxy per app pod | `ghcr.io/dshakes/distil` (multi-arch, amd64 + arm64) |
+| **Shared gateway** | Team or org, per-tenant accounting and quotas | Helm chart below |
+
+### Kubernetes
+
+```bash
+helm install distil packaging/helm/distil-gateway \
+  --set adminToken.existingSecret=distil-admin \
+  --set gateway.upstream=https://api.anthropic.com \
+  --set providerSecret.existingSecret=anthropic \
+  --set providerSecret.keys.ANTHROPIC_API_KEY=api-key \
+  --set serviceMonitor.enabled=true \
+  --set prometheusRule.enabled=true
+```
+
+Defaults are chosen to be safe rather than convenient, and a test asserts they stay
+that way (`tests/test_packaging_assets.py`):
+
+- `requireKeys: true` — a gateway reachable on a cluster network is never open
+- `trustTenantHeader: false` — otherwise any client can bill another tenant's quota
+- non-root, read-only root filesystem, all capabilities dropped, seccomp
+  `RuntimeDefault`
+- `maxUnavailable: 0` on rollout — the gateway is in the request path
+- PodDisruptionBudget and topology spread across nodes
+- optional NetworkPolicy restricting egress to DNS and 443 only
+
+**Read `persistence.enabled` before going to production.** With it off, the restore
+store is an `emptyDir`, so digest handles do **not** survive pod replacement. That
+is fine for lossless/verbatim modes, and wrong for `--expand`, where the agent may
+try to expand a handle after a restart.
+
+## 2. Identity and access
+
+| | Status |
+|---|---|
+| Issued bearer keys (`dsk-`), per-key tenant / quota / revocation | ✅ |
+| OIDC bearer tokens (HS256; RS256 via the `[oidc]` extra) | ✅ |
+| Roles: `viewer` < `operator` < `admin` | ✅ |
+| SAML | ❌ Not implemented |
+| SCIM provisioning | ❌ Not implemented |
+| Per-tenant memory isolation within one gateway process | ❌ By design — run one gateway per trust boundary |
+
+```bash
+export DISTIL_OIDC_ISSUER=https://login.example.com
+export DISTIL_OIDC_AUDIENCE=distil-gateway
+export DISTIL_OIDC_PUBLIC_KEY="$(cat idp-public.pem)"   # RS256, needs [oidc]
+export DISTIL_OIDC_ROLE_CLAIM=roles                     # scalar or array
+export DISTIL_OIDC_TENANT_CLAIM=org_id
+```
+
+OIDC is **additive**: `dsk-` keys keep working, and with `DISTIL_OIDC_ISSUER` unset
+a JWT does not authenticate at all. Enabling it cannot lock out a running
+deployment, and leaving it off cannot silently open one.
+
+## 3. Observability
+
+- **Prometheus** — `GET /distil/metrics`, labelled by tenant, behind the admin
+  gate. Alert rules ship in the chart; a Grafana dashboard ships in
+  [`packaging/grafana`](../packaging/grafana/distil-gateway-dashboard.json).
+- **OpenTelemetry** — GenAI semantic-convention spans plus distil's own
+  attributes, via the `[otel]` extra.
+- **Audit** — hash-chained receipts, `distil receipts` to verify, `--export` for a
+  SIEM.
+
+One alert deserves explanation before it pages someone: `DistilCompressionIneffective`
+fires at under 2% savings over six hours. That is often **not** a fault — traffic
+with large stable prefixes and small tool outputs genuinely has little to fold.
+It is alertable because it is indistinguishable from a misconfigured mode, and
+that distinction needs a human.
+
+## 4. Commercial status — read this before planning around distil
+
+| | Status |
+|---|---|
+| License | Apache-2.0 |
+| Commercial entity | **None today.** No company to contract with. |
+| Paid support / SLA | **Not offered.** |
+| DPA / MSA | **Not offered** — and see below on whether you need one. |
+| SOC 2 Type II | **Not held.** No audit in progress. |
+| Support channel | GitHub issues, best effort |
+| Roadmap commitments | None contractual |
+
+**Whether you need a DPA at all.** Distil operates no hosted service. It runs
+inside your boundary, calls no distil-operated endpoint, and requires no account.
+Most reviews therefore classify it as a **software dependency** rather than a
+subprocessor, which removes the usual data-processing paperwork. Confirm with your
+own counsel — but the technical fact underneath is verifiable: the proxy forwards
+to exactly one configured upstream and nothing else.
+
+**What this means practically.** If your procurement requires a signed SLA, a SOC 2
+report, or a vendor to escalate to at 3am, distil does not meet that bar today, and
+no amount of engineering in this repository changes it — those are company
+artifacts, not code. The honest options are:
+
+1. Adopt it as an open-source dependency under your own operational ownership
+   (the intended path today).
+2. Sponsor the gap: a design-partner arrangement that funds SOC 2 and a support
+   commitment. There is no program to point you at yet; open an issue.
+
+## 5. What would close the remaining gaps
+
+Ordered by what actually blocks deals, not by effort:
+
+| Gap | What closing it requires | Code or company? |
+|---|---|---|
+| Support SLA | A named owner and a response-time commitment | Company |
+| SOC 2 Type II | 3–6 months of evidence collection plus an auditor | Company |
+| DPA / MSA | A legal entity | Company |
+| SAML | Implementation on top of the existing role model | Code |
+| SCIM | Implementation | Code |
+| Per-tenant isolation | Process-per-tenant, or a rearchitecture | Code |
+| Multi-region / HA guidance | Load testing and a documented envelope | Code |
+
+The identity work already done (`distil/authz.py`) was the load-bearing part: roles,
+verification, and tenant mapping exist, so SAML would be a second credential type
+against the same model rather than a new authorization system.
+
+## 6. Evaluating distil in an enterprise
+
+A defensible evaluation, in order:
+
+```bash
+# 1. Prove the quality claim on OUR corpus, offline, no key, ~10s
+uvx --from distil-llm distil bench
+
+# 2. Prove it on YOUR traffic — decision-equivalence on live requests
+distil wrap --shadow 0.1 -- <your agent>
+distil shadow-stats
+
+# 3. Certify YOUR risk budget
+distil ingest --input prod.jsonl --out ./mycorpus
+distil conformal --corpus ./mycorpus --alpha 0.05 --delta 0.05
+
+# 4. Verify the supply chain independently
+uvx pypi-attestations verify pypi \
+  --repository https://github.com/dshakes/distil \
+  pypi:distil_llm-<version>-py3-none-any.whl
+```
+
+Step 2 is the one that matters and the one most evaluations skip. Distil's central
+claim is not "it compresses" — every competitor compresses — it is "your agent
+still makes the same decisions". `--shadow` measures that on **your** workload, and
+a result there outranks anything in this repository, **including a bad one**.

--- a/docs/GA_READINESS.md
+++ b/docs/GA_READINESS.md
@@ -41,7 +41,9 @@ binary and checkable; opinions don't count, evidence does.
 - [x] **rc + soak release policy in force** — runtime-behavior releases bake as an rc
   for ≥ 3 days of real use before the final (RELEASING.md).
 - [ ] **14 consecutive days at head with zero P0/P1** — a same-day fix release resets
-  the clock.
+  the clock. **Reset 2026-08-07:** the settings-precedence outage above is a P1 found
+  on real traffic (three occurrences in one day). Per RELEASING.md this means rc2 and
+  a restarted soak clock — 1.41.2 final cannot be cut on the original 2026-08-10 date.
 - [ ] **External beta** — ≥ 10 real users wrapping real agents for ≥ 1 week, with a
   feedback channel; no open P0/P1 from the cohort.
 - [ ] **Live decision-equivalence evidence** — shadow-mode ✓de ≥ 99% at n ≥ 25 on the
@@ -75,7 +77,7 @@ binary and checkable; opinions don't count, evidence does.
 | **Cross-model generality demonstrated** | E11: non-inferiority transfers to DeepSeek-V3 (different vendor, far stronger) at a capability-appropriate point |
 | **Engineering maturity** | v1.0.0, 700+ tests, full CI (ci/pages/paper-build/release), zero-dependency stdlib core, packaged (`distil` entrypoint) |
 | **Per-turn + trajectory certificates, validated out-of-sample** | E2 (coverage 96.6–100%), E10 (trajectory, coverage 95.4/96.7%) |
-| **Observability: OTel GenAI spans (opt-in `[otel]` extra)** | `distil/otel.py` emits `gen_ai.*` semconv spans + `distil.tokens.original/compressed`, `distil.compression.ratio`, `distil.shadow.sampled`; no-op boolean guard without the extra; `tests/test_otel.py`. No metrics endpoint exists → the unauthenticated-metrics leak class is structurally absent |
+| **Observability: OTel GenAI spans (opt-in `[otel]` extra)** | `distil/otel.py` emits `gen_ai.*` semconv spans + `distil.tokens.original/compressed`, `distil.compression.ratio`, `distil.shadow.sampled`; no-op boolean guard without the extra; `tests/test_otel.py`. **Correction (2026-08-07):** a `/distil/metrics` endpoint now exists, so "structurally absent" no longer holds — the leak class is instead closed by an *admin gate* (open on loopback; `--admin-token` required and refused without one on any non-loopback bind), tested directly for 403-unauthenticated, 401-wrong-token, and label injection |
 | **Supply chain: attestations + SBOM + Scorecard** | PEP 740 Sigstore attestations active (trusted publishing, `gh-action-pypi-publish@release/v1` ≥ v1.11); CycloneDX SBOM attached to GitHub releases (`release.yml`); weekly OpenSSF Scorecard (`scorecard.yml`) |
 | **Shared-state writes locked across concurrent sessions** | `shadow.jsonl` append now flocked like `ledger.json`/`mcp_store.json`; cross-process torn-row hammer test in `tests/test_shadow.py` |
 | **CI signal tests deflaked (red-main root cause)** | readiness-marker sync replaces fixed sleeps in the wrap signal tests — red CI on `main` since 1.11.2 was test-side races on loaded runners, not product regressions |
@@ -87,6 +89,19 @@ binary and checkable; opinions don't count, evidence does.
 |---|---|---|
 | **Validation breadth** | Task-success is validated on SWE-bench Verified coding agents across **5 models / 3 vendors** (E8 n=500 Haiku; E11 n=200 DeepSeek-V3, n=50 Sonnet 4.6, n=50 gpt-4.1, n=50 gpt-4o-mini) plus τ-bench (proxy). OpenAI runs are now DONE; note gpt-4.1 gate@6 is partial (account credit exhausted mid-run, 32/50 instances) and all three n=50 OpenAI/Sonnet points have wide CIs (directional, not powered). Still single-domain (coding); broad multi-domain production traffic is not yet covered. | The certificate machinery is domain-agnostic; broadening is data + a new-domain harness, not redesign. |
 | **Calibration data requirement** | Auto-calibration needs a small paired full-vs-candidate run on representative traffic before the gate can ship aggressively. | Fail-safe means the *absence* of calibration data degrades to full context (correct, not lossy) rather than to a guessed operating point. |
+
+### Closed 2026-08-07 (adoption + enterprise pass)
+
+| Item | How it closed |
+|---|---|
+| **Embeddable as a dependency** | `from distil import compress_messages, expand_handle` (`distil/api.py`). Previously the package exported only `__version__`, so no framework could depend on distil without shelling out to the CLI — the structural reason third-party integrations did not exist. |
+| **Settings-precedence outage (P1, found in the field)** | A base URL pinned in an agent's `settings.json` outranks the environment `distil wrap` exports. With the always-on service down, every session failed with a connection error naming the *provider*. `distil wrap` now refuses to start into that configuration and names the fix (`distil/precedence.py`). |
+| **First-run "0% smaller"** | A real token count beside a rounded `0%` reads as broken. Sub-1% now renders `<1% smaller` across all four surfaces (status line, terminal dashboard, HTML card, browser dashboard), with the reason attached. |
+| **`doctor` false "bypassed" warn** | It inferred traffic from the savings ledger, which skips zero-saving windows by design. Receipts are written per request regardless of savings and are now the signal. |
+| **SSO / RBAC for the gateway** | OIDC bearer tokens alongside `dsk-` keys, three ordered roles, stdlib-only JWS verification; RS256 refused rather than unverified when the `[oidc]` extra is absent. Adversarial suite + live-gateway e2e. |
+| **Kubernetes deployability** | Helm chart (`packaging/helm/distil-gateway`) with secure defaults asserted by test, plus alert rules and a Grafana dashboard whose every PromQL expression is CI-checked against the emitted metric set. |
+| **Security policy + review pack** | `SECURITY.md` (was missing; Scorecard checks for it) and `docs/SECURITY-WHITEPAPER.md`, which states the gaps — no SOC 2, no SLA, no SAML, no cross-tenant memory isolation — rather than omitting them. |
+| **IDE agents** | `docs/IDE-AGENTS.md`: proxy + base-URL setting for Cursor/Cline/Continue/Windsurf, and an explicit "not supportable" for Copilot instead of silence. |
 
 ### Recently closed (were open)
 

--- a/docs/IDE-AGENTS.md
+++ b/docs/IDE-AGENTS.md
@@ -1,0 +1,96 @@
+# IDE agents — Cursor, Copilot, Cline, Continue, Windsurf
+
+`distil wrap` cannot reach these. That is a structural limit, not a missing
+feature, and this page explains the limit and the supported path.
+
+## Why `wrap` does not work here
+
+`distil wrap` works by launching a child process with `ANTHROPIC_BASE_URL` (or the
+provider equivalent) set in its environment. That requires two things:
+
+1. a command to launch, and
+2. a published environment variable the agent honours.
+
+IDE agents have neither. They run inside the editor's own process tree, started by
+the editor rather than by your shell, and none of them documents an environment
+variable for redirecting the API endpoint. distil therefore ships **no preset** for
+them — see `distil/onboard.py`, where they are excluded by name with this reason.
+
+A preset built on a guessed variable would be worse than nothing: `wrap` would
+report success, start a proxy, and route zero traffic. You would see "distil is
+on" and a savings counter frozen at zero, with no indication which of the two was
+lying.
+
+## The supported path: run a proxy, point the editor at it
+
+Every one of these editors exposes a custom base URL or an OpenAI-compatible
+endpoint setting. Point it at a distil proxy.
+
+### 1. Start a persistent proxy
+
+```bash
+distil proxy --port 8788 --upstream https://api.anthropic.com
+```
+
+Keep it running (a terminal tab, `tmux`, or a login item). For an always-on
+service managed for you:
+
+```bash
+distil default --always-on
+```
+
+That starts the service *and* proves it routes before writing any configuration —
+if the probe fails, nothing is written.
+
+> **Do not also use `distil wrap` once always-on is wired.** A base URL pinned in
+> `~/.claude/settings.json` outranks the environment `wrap` sets, so the wrap's
+> proxy would receive nothing. `distil wrap` now detects this and refuses rather
+> than starting into a configuration that cannot work.
+
+### 2. Point the editor at it
+
+| Editor | Where |
+|---|---|
+| **Cursor** | Settings → Models → *Override OpenAI Base URL* → `http://127.0.0.1:8788/v1` |
+| **Cline** | Extension settings → API Provider → *OpenAI Compatible* → Base URL `http://127.0.0.1:8788/v1` |
+| **Continue** | `~/.continue/config.json` → the model entry's `apiBase` → `http://127.0.0.1:8788/v1` |
+| **Windsurf** | Settings → Cascade → custom endpoint → `http://127.0.0.1:8788/v1` |
+| **GitHub Copilot** | Not redirectable. Copilot terminates at GitHub's own service and exposes no endpoint override. distil cannot compress Copilot traffic. |
+
+Paths move between releases; if a menu has been renamed, search the editor's
+settings for "base URL" or "OpenAI compatible".
+
+### 3. Verify it is actually routing
+
+Do not trust the absence of an error — that is how the failure above hides.
+
+```bash
+distil doctor          # probes the configured base URL and reports what answered
+distil dashboard       # watch the counter move as you use the editor
+```
+
+If `doctor` reports routing but savings stay at zero, that is usually genuine:
+savings come from **large** tool output, and a short editor completion has little
+to fold. See the `<1% smaller` note in the status-line docs.
+
+## Copilot, specifically
+
+There is no supported interception point. Copilot does not honour a base URL
+override, and working around that would mean intercepting TLS to a service you do
+not control — which distil will not ship and you should not run. If Copilot is
+your only agent, distil has nothing to offer you today; that is an honest no
+rather than a configuration you will fight for an afternoon.
+
+## Editors that are also CLIs
+
+Some tools ship both. Where a CLI exists, prefer it — `wrap` needs no
+configuration and gives you the per-session proof ledger:
+
+```bash
+distil wrap -- claude      # Claude Code
+distil wrap -- codex       # Codex CLI
+distil wrap -- gemini      # Gemini CLI
+distil wrap -- aider       # aider
+distil wrap -- opencode    # OpenCode
+distil wrap -- qwen        # Qwen Code
+```

--- a/docs/SECURITY-WHITEPAPER.md
+++ b/docs/SECURITY-WHITEPAPER.md
@@ -1,0 +1,185 @@
+# Distil — security & data handling
+
+For security reviewers, platform teams, and procurement. Written to be answerable
+against evidence rather than assertion: every claim below names the file, command,
+or test that backs it, so you can verify rather than trust.
+
+Scope: distil `1.41.x`, the Apache-2.0 open-source distribution.
+Companion documents: [`THREAT_MODEL.md`](../THREAT_MODEL.md) (adversary model and
+explicit non-goals), [`TELEMETRY.md`](../TELEMETRY.md) (frozen telemetry schema).
+
+---
+
+## 1. What distil is, in one paragraph
+
+Distil sits between your agent and your model provider and reduces the number of
+input tokens sent, either as a local proxy, a shared gateway, or an in-process
+library call. It does not store your prompts in a service, does not call any
+distil-operated endpoint, and requires no account. The compression is
+**reversible**: elided spans are replaced by a short handle, and the original
+bytes stay on the machine that compressed them.
+
+## 2. Data flow and residency
+
+**Nothing leaves your infrastructure.** Distil forwards to exactly one configured
+upstream — your model provider — and to nothing else.
+
+| Data | Where it lives | Leaves the machine? |
+|---|---|---|
+| Prompt / message content | In flight only; forwarded to your configured upstream | Only to your provider |
+| Digest originals (restore store) | `${DISTIL_HOME:-~/.distil}/restore/`, encrypted, `0600` | No |
+| Savings ledger | `${DISTIL_HOME}/savings.jsonl` — token **counts** only | No |
+| Receipts (audit chain) | `${DISTIL_HOME}/receipts.jsonl` — counts, mode, handles | No |
+| Community census | Opt-in only, numbers only, off by default | Only if explicitly enabled |
+
+The proxy binds `127.0.0.1` by default and forwards only to the single configured
+upstream, so it cannot be used as an SSRF pivot. Egress in the shipped Helm chart
+is restricted to DNS and 443 by NetworkPolicy
+(`packaging/helm/distil-gateway/templates/networkpolicy.yaml`).
+
+**Verify:** `distil proxy --help` (bind address), and read
+[`TELEMETRY.md`](../TELEMETRY.md) for the frozen census schema. Preview exactly
+what a census payload would contain, before consenting, with `distil census show`.
+
+## 3. Encryption at rest
+
+Digest originals are encrypted with **HMAC-SHA256-CTR, encrypt-then-MAC** (`DSTL1`
+header), with a 32-byte key at `${DISTIL_HOME}/restore.key`, `chmod 0600`, created
+on first use (`distil/atrest.py`).
+
+This protects against backup/sync leakage and cross-user reads on a shared
+filesystem. It explicitly does **not** protect against a same-UID attacker who can
+read both the data and the key — that is stated as out of scope in
+[`THREAT_MODEL.md`](../THREAT_MODEL.md) rather than papered over.
+
+Handles age out after `DISTIL_RESTORE_TTL_DAYS` (default 14). Opt out of
+encryption with `DISTIL_NO_ENCRYPT_AT_REST=1` (not recommended).
+
+## 4. Secrets
+
+- Request bodies and credentials are **never logged**.
+- Provider credentials are forwarded, not parsed, stored, or inspected.
+- The gateway's own admin token is passed by environment, not argv, so it does not
+  appear in `ps` or a pod spec dump
+  (`packaging/helm/distil-gateway/templates/deployment.yaml`).
+- The adversarial gate drives the compressor against secret-looking inputs and
+  asserts they are never emitted in telemetry.
+
+**Verify:** `distil validate` — the adversarial suite (huge, unicode, nested,
+malformed, marker-injection, secret-looking inputs), asserting reversibility,
+fail-open, and content-free telemetry on every one.
+
+## 5. Multi-tenancy (gateway)
+
+The gateway issues `dsk-` bearer keys and derives the tenant **from the
+credential**, never from a client-supplied header. `--trust-tenant-header` exists
+for trusted-network accounting and is off by default; with it on, any client can
+bill another tenant's quota, which is why it is opt-in.
+
+Per-tenant RPM and daily-token quotas are enforced in-process. Rejections are
+counted and exported as `distil_requests_rejected_total`, labelled by tenant —
+quota enforcement that cannot be observed is indistinguishable from an outage from
+the client's side.
+
+**Known limitation, stated plainly:** tenants share one process. There is no
+memory isolation between tenants, and the restore store is per-gateway rather than
+per-tenant. For hard isolation, run one gateway per trust boundary. This is
+surfaced in `distil gateway --help`, not buried here.
+
+## 6. Metrics and admin endpoints
+
+`/distil/metrics` is labelled by tenant, so it sits behind the same admin gate as
+`/distil/stats`: open on loopback, and on any non-loopback bind it **requires**
+`--admin-token` and refuses to start without one.
+
+This is deliberate — an unauthenticated, tenant-labelled `/metrics` is precisely
+the [LiteLLM disclosure](https://github.com/BerriAI/litellm/issues/13644) class of
+bug. It is tested directly: 403 unauthenticated, 401 on a wrong token, plus
+label-injection and no-secrets-in-exposition tests (`tests/test_gateway.py`).
+
+## 7. Audit trail
+
+Every request writes a **hash-chained receipt**: counts, mode, handles issued, and
+whether they resolved. Never content. Each receipt carries the previous receipt's
+hash, so removing or editing an entry breaks the chain.
+
+```bash
+distil receipts            # verify the chain; non-zero exit if broken
+distil receipts --export   # newline-delimited JSON for your SIEM
+```
+
+The verification needs nothing but the file — no server, no key escrow. Retention
+is yours to set; distil never prunes receipts.
+
+## 8. Supply chain
+
+- **PEP 740 Sigstore attestations** via PyPI Trusted Publishing on every release.
+  The release job **fails** if PyPI does not report an attestation bundle for the
+  version it just published, so this claim cannot silently drift.
+- **CycloneDX SBOM** attached to every GitHub release.
+- **OpenSSF Scorecard** runs weekly on `main`.
+- **Zero runtime dependencies** in the core — the entire attack surface is the
+  Python standard library plus distil's own code. Optional extras (`[otel]`,
+  `[live]`) are opt-in.
+
+**Verify independently:**
+
+```bash
+curl -s https://pypi.org/integrity/distil-llm/<version>/<filename>/provenance
+uvx pypi-attestations verify pypi \
+  --repository https://github.com/dshakes/distil \
+  pypi:distil_llm-<version>-py3-none-any.whl
+```
+
+(Use the *integrity* API — `/pypi/<pkg>/<ver>/json` carries no attestations field
+and reading it there reports a false negative.)
+
+## 9. Availability and failure behaviour
+
+Distil is in the request path, so its failure modes are your failure modes. The
+governing rule is **fail open**: if compression raises, the original request is
+forwarded uncompressed rather than failing. `DISTIL_DEBUG=1` surfaces everything
+the fail-open path swallows.
+
+`GET /distil/health` is an unauthenticated liveness probe on every entry point and
+never touches the billed upstream. Gateway accounting checkpoints to disk every
+30s, so a hard crash loses at most 30s of counters, not the ledger.
+
+**One failure mode worth your attention.** A base URL pinned in an agent's own
+settings file outranks the environment `distil wrap` sets. If that pinned port
+stops answering, every session fails with a connection error naming the *provider*.
+`distil wrap` now refuses to start into that configuration and names the fix
+(`distil/precedence.py`, `tests/test_precedence.py`). Reviewers should note this
+as the class of risk any in-path proxy carries.
+
+## 10. Identity and access
+
+**Present:** bearer-key authentication with per-key tenant, quota, and revocation
+(`distil gateway keys issue|list|revoke`).
+
+**Not present, and honestly so:** SAML, OIDC, SCIM, and role-based access control
+are **not implemented**. If your review requires SSO for the gateway's admin
+surface today, distil does not meet that bar. The current recommendation is to
+place the gateway behind your existing authenticating proxy or service mesh and
+treat the admin token as an infrastructure secret.
+
+## 11. Compliance status
+
+Stated plainly so nobody discovers it late:
+
+| | Status |
+|---|---|
+| SOC 2 Type II | **Not held.** No audit in progress. |
+| ISO 27001 | Not held. |
+| DPA / MSA / SLA | Not offered — Apache-2.0 open source, no commercial entity behind it today. |
+| Support | Best-effort via GitHub issues. No response-time commitment. |
+| Data processing | Distil operates no service and processes no customer data off-machine, so there is no processor relationship to paper. |
+
+For most security reviews the last row is the important one: because distil runs
+entirely inside your boundary and calls no distil-operated endpoint, it is
+typically assessed as a **software dependency** rather than a subprocessor.
+
+## 12. Reporting a vulnerability
+
+See [`SECURITY.md`](../SECURITY.md). Please do not open a public issue for a
+suspected vulnerability.

--- a/docs/assets/integration-surface.svg
+++ b/docs/assets/integration-surface.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" width="960" height="420" role="img" aria-labelledby="t d">
+  <title id="t">Four ways to run distil, and what each one gives you</title>
+  <desc id="d">Agent wrap, proxy, library, and MCP server. Wrap, proxy and MCP reach the reversible digest tier through the shared restore store and the decision-equivalence certificate. The in-process library is lossless-only and byte-identical to the Python engine, verified by a conformance suite.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0e1320; }
+      .card  { fill: #111726; stroke: #2a3650; stroke-width: 1; }
+      .card2 { fill: #111726; stroke: #2c344a; stroke-width: 1; }
+      .h     { fill: #eef0f5; font: 600 15px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      .s     { fill: #9aa0b2; font: 400 12px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      .m     { fill: #dbe0ee; font: 400 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .tiny  { fill: #7b8298; font: 400 11px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      .lbl   { fill: #eef0f5; font: 600 13px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+      .flow  { stroke: #5ad1c9; stroke-width: 1.6; fill: none; }
+      .flow2 { stroke: #8b7bff; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+      .chipA { fill: #10241f; stroke: #5ad19a; stroke-width: 1; }
+      .chipB { fill: #1b1a2e; stroke: #8b7bff; stroke-width: 1; }
+      .okT   { fill: #5ad19a; font: 600 11px ui-sans-serif, system-ui, sans-serif; }
+      .vioT  { fill: #a99bff; font: 600 11px ui-sans-serif, system-ui, sans-serif; }
+    </style>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#5ad1c9"/>
+    </marker>
+    <marker id="a2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#8b7bff"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="960" height="420" rx="10"/>
+  <text class="h" x="28" y="34">Four ways to run distil</text>
+  <text class="s" x="28" y="54">Same engine. The difference is which tier you get — and what proves it.</text>
+
+  <!-- entry points -->
+  <g>
+    <rect class="card" x="28" y="80" width="196" height="70" rx="8"/>
+    <text class="lbl" x="44" y="104">Agent wrap</text>
+    <text class="m"   x="44" y="124">distil wrap -- claude</text>
+    <text class="tiny" x="44" y="140">zero config · 6 agents</text>
+  </g>
+  <g>
+    <rect class="card" x="28" y="164" width="196" height="70" rx="8"/>
+    <text class="lbl" x="44" y="188">Proxy / gateway</text>
+    <text class="m"   x="44" y="208">baseURL → :8788</text>
+    <text class="tiny" x="44" y="224">any language · any SDK</text>
+  </g>
+  <g>
+    <rect class="card" x="28" y="248" width="196" height="70" rx="8"/>
+    <text class="lbl" x="44" y="272">MCP server</text>
+    <text class="m"   x="44" y="292">distil mcp</text>
+    <text class="tiny" x="44" y="308">agent-driven recall</text>
+  </g>
+  <g>
+    <rect class="card2" x="28" y="332" width="196" height="70" rx="8"/>
+    <text class="lbl" x="44" y="356">In-process library</text>
+    <text class="m"   x="44" y="376">compress_messages()</text>
+    <text class="tiny" x="44" y="392">Python · TypeScript</text>
+  </g>
+
+  <!-- flows into the engine -->
+  <path class="flow"  d="M224 115 C 300 115, 320 200, 392 200" marker-end="url(#a)"/>
+  <path class="flow"  d="M224 199 C 310 199, 330 200, 392 200" marker-end="url(#a)"/>
+  <path class="flow"  d="M224 283 C 300 283, 320 210, 392 205" marker-end="url(#a)"/>
+  <path class="flow2" d="M224 367 C 320 367, 340 300, 392 268" marker-end="url(#a2)"/>
+
+  <!-- engine -->
+  <rect class="card" x="392" y="150" width="228" height="150" rx="10"/>
+  <text class="h"    x="412" y="178" style="font-size:14px">Compression engine</text>
+  <rect class="chipA" x="412" y="192" width="188" height="44" rx="6"/>
+  <text class="okT"  x="424" y="210">TIER-1 · reversible digest</text>
+  <text class="tiny" x="424" y="227">handles → shared restore store</text>
+  <rect class="chipB" x="412" y="244" width="188" height="44" rx="6"/>
+  <text class="vioT" x="424" y="262">TIER-0 · lossless</text>
+  <text class="tiny" x="424" y="279">JSON minify · run collapse</text>
+
+  <!-- guarantees -->
+  <rect class="card" x="676" y="96" width="256" height="104" rx="10"/>
+  <text class="h" x="696" y="122" style="font-size:14px">Decision-equivalence</text>
+  <text class="s" x="696" y="142">certificate</text>
+  <text class="tiny" x="696" y="164">Covers the digest tier. Cannot</text>
+  <text class="tiny" x="696" y="180">certify → falls back to full context.</text>
+
+  <rect class="card" x="676" y="216" width="256" height="104" rx="10"/>
+  <text class="h" x="696" y="242" style="font-size:14px">Conformance suite</text>
+  <text class="s" x="696" y="262">Python ↔ TypeScript</text>
+  <text class="tiny" x="696" y="284">Byte-identical Tier-0, or the port</text>
+  <text class="tiny" x="696" y="300">declines. Divergence fails CI.</text>
+
+  <path class="flow"  d="M620 200 C 646 200, 650 150, 676 148" marker-end="url(#a)"/>
+  <path class="flow2" d="M620 266 C 646 266, 650 268, 676 268" marker-end="url(#a2)"/>
+
+  <text class="tiny" x="28" y="416">Solid = reversible digest tier · dashed = lossless tier. The library is lossless-only on purpose: a second digest implementation would be a second thing to certify.</text>
+</svg>

--- a/docs/tapes/README.md
+++ b/docs/tapes/README.md
@@ -1,0 +1,25 @@
+# Terminal recordings (VHS tapes)
+
+Every GIF in `docs/assets/` is generated from a `.tape` script in this directory
+by [charmbracelet/vhs](https://github.com/charmbracelet/vhs).
+
+```bash
+brew install vhs                       # or: go install github.com/charmbracelet/vhs@latest
+vhs docs/tapes/library-api.tape        # → docs/assets/library-api.gif
+vhs docs/tapes/outage-guard.tape       # → docs/assets/outage-guard.gif
+```
+
+**Why the scripts are checked in and the GIFs are regenerated.** A recording
+nobody can re-make goes stale silently: the CLI changes, the output no longer
+matches, and the README keeps showing a session that can no longer happen. A
+tape is reviewable in a diff and re-renderable on demand, so a drifted GIF is a
+one-command fix rather than an archaeology project.
+
+VHS needs a real PTY and `ffmpeg`. It does not render reliably in a headless
+agent shell, so regenerate these locally (or in a CI job with a TTY) after any
+change to the commands they demonstrate.
+
+| Tape | Shows |
+|---|---|
+| `library-api.tape` | `compress_messages` / `expand_handle` in-process, and byte-exact recovery |
+| `outage-guard.tape` | `distil wrap` refusing a `settings.json` pin that would take every session down |

--- a/docs/tapes/library-api.tape
+++ b/docs/tapes/library-api.tape
@@ -1,0 +1,44 @@
+# VHS tape — the in-process library API.
+#   render:  vhs docs/tapes/library-api.tape
+# Checked in so the GIF is REPRODUCIBLE: a recording nobody can re-make goes
+# stale silently and then misrepresents the product.
+
+Output docs/assets/library-api.gif
+
+Set Shell "bash"
+Set FontSize 17
+Set Width 1100
+Set Height 620
+Set Theme "Catppuccin Mocha"
+Set Padding 22
+Set TypingSpeed 55ms
+
+Type "# distil as a library — no proxy, no daemon"
+Enter
+Sleep 900
+
+Type "python3 - <<'PY'"
+Enter
+Type "from distil import compress_messages, expand_handle"
+Enter
+Type "log = '\n'.join(f'INFO worker heartbeat seq={i}' for i in range(400))"
+Enter
+Type "msgs = [{'role':'user','content':'why did it die?'},"
+Enter
+Type "        {'role':'tool','content':log}]"
+Enter
+Type "r = compress_messages(msgs)"
+Enter
+Type "print(f'{r.tokens_before} -> {r.tokens_after} tokens  ({r.saved_pct:.1f}% smaller)')"
+Enter
+Type "print('handles:', r.handles)"
+Enter
+Type "print('recovered byte-exact:', expand_handle(r.handles[0]) is not None)"
+Enter
+Type "PY"
+Enter
+Sleep 4s
+
+Type "# nothing is gone — the original is one expand away"
+Enter
+Sleep 2500ms

--- a/docs/tapes/outage-guard.tape
+++ b/docs/tapes/outage-guard.tape
@@ -1,0 +1,30 @@
+# VHS tape — wrap refuses a configuration that cannot work.
+#   render:  vhs docs/tapes/outage-guard.tape
+# This is the P1 that took Claude Code down three times in one day: a base URL
+# pinned in settings.json outranks the environment `distil wrap` sets, so when
+# the pinned service is not running EVERY session fails with an error that
+# blames the provider.
+
+Output docs/assets/outage-guard.gif
+
+Set Shell "bash"
+Set FontSize 17
+Set Width 1100
+Set Height 520
+Set Theme "Catppuccin Mocha"
+Set Padding 22
+Set TypingSpeed 55ms
+
+Type "# settings.json pins a port whose service is gone"
+Enter
+Type "cat .claude/settings.json"
+Enter
+Sleep 2s
+
+Type "distil wrap -- claude -p 'hi'"
+Enter
+Sleep 3s
+
+Type "# refused BEFORE launching, with the fix named"
+Enter
+Sleep 2500ms

--- a/packaging/grafana/distil-gateway-dashboard.json
+++ b/packaging/grafana/distil-gateway-dashboard.json
@@ -1,0 +1,200 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus instance scraping /distil/metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "title": "Distil gateway",
+  "uid": "distil-gateway",
+  "tags": ["distil", "llm", "cost"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "tenant",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(distil_requests_total, tenant)",
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Is it working?",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "Tokens saved (24h)",
+      "description": "Input tokens kept off the wire. This is the number the deployment exists to move.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(increase(distil_tokens_saved_total{tenant=~\"$tenant\"}[24h]))",
+          "legendFormat": "saved"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "green" } }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Compression ratio (6h)",
+      "description": "Fraction of input tokens saved. Near-zero is NOT automatically a fault: traffic that is mostly system prompt with small tool outputs has little to fold. Investigate only if it drops after previously being high.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(increase(distil_tokens_saved_total{tenant=~\"$tenant\"}[6h])) / clamp_min(sum(increase(distil_tokens_baseline_total{tenant=~\"$tenant\"}[6h])), 1)",
+          "legendFormat": "ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "orange", "value": null },
+              { "color": "yellow", "value": 0.02 },
+              { "color": "green", "value": 0.15 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Request rate",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "targets": [
+        { "expr": "sum(rate(distil_requests_total{tenant=~\"$tenant\"}[5m]))", "legendFormat": "req/s" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2 } }
+    },
+    {
+      "type": "stat",
+      "title": "Quota rejections (1h)",
+      "description": "Requests refused by a per-tenant quota. Non-zero means a client is being throttled — from its side this is indistinguishable from an outage, so it should never be a surprise.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(increase(distil_requests_rejected_total{tenant=~\"$tenant\"}[1h]))",
+          "legendFormat": "rejected"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Per tenant",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens: baseline vs sent",
+      "description": "The gap between the two lines is the saving. Lines converging means compression stopped finding anything to fold.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(distil_tokens_baseline_total{tenant=~\"$tenant\"}[5m]))",
+          "legendFormat": "baseline (uncompressed)"
+        },
+        {
+          "expr": "sum(rate(distil_tokens_sent_total{tenant=~\"$tenant\"}[5m]))",
+          "legendFormat": "actually sent"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "fillOpacity": 8 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Savings by tenant",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(distil_tokens_saved_total{tenant=~\"$tenant\"}[5m]))",
+          "legendFormat": "{{tenant}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Quota rejections by tenant",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(distil_requests_rejected_total{tenant=~\"$tenant\"}[5m]))",
+          "legendFormat": "{{tenant}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } } }
+    },
+    {
+      "type": "table",
+      "title": "Tenant summary",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (tenant) (increase(distil_tokens_saved_total[24h]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "saved"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Build",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+    },
+    {
+      "type": "stat",
+      "title": "Version",
+      "description": "distil_build_info carries the running version as a label.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "distil_build_info", "legendFormat": "{{version}}", "instant": true }
+      ],
+      "options": { "textMode": "name" }
+    }
+  ]
+}

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: distil-gateway
+description: >-
+  Multi-tenant distil gateway — compress agent context with a decision-equivalence
+  contract, with per-tenant quotas, rate limits, and Prometheus metrics.
+type: application
+# Chart version tracks the chart; appVersion tracks the distil release it defaults to.
+# Bump `version` on any template change, `appVersion` on a distil upgrade.
+version: 0.1.0
+appVersion: "1.41.2"
+home: https://dshakes.github.io/distil/
+sources:
+  - https://github.com/dshakes/distil
+keywords:
+  - llm
+  - context-compression
+  - prompt-compression
+  - gateway
+  - token-savings
+maintainers:
+  - name: dshakes
+    url: https://github.com/dshakes
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/packaging/helm/distil-gateway/templates/_helpers.tpl
+++ b/packaging/helm/distil-gateway/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Common naming + labels. */}}
+
+{{- define "distil-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "distil-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "distil-gateway.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "distil-gateway.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: distil
+{{- end -}}
+
+{{- define "distil-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "distil-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "distil-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "distil-gateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Name of the Secret holding the admin token, whether user- or chart-managed. */}}
+{{- define "distil-gateway.adminSecretName" -}}
+{{- if .Values.adminToken.existingSecret -}}
+{{- .Values.adminToken.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin" (include "distil-gateway.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/packaging/helm/distil-gateway/templates/deployment.yaml
+++ b/packaging/helm/distil-gateway/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "distil-gateway.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0   # never drop capacity mid-roll; the proxy is in the request path
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "distil-gateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}{{- toYaml . | nindent 8 }}{{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
+    spec:
+      serviceAccountName: {{ include "distil-gateway.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - gateway
+            - --host={{ .Values.gateway.host }}
+            - --port={{ .Values.gateway.port }}
+            - --upstream={{ .Values.gateway.upstream }}
+            {{- if eq .Values.gateway.mode "lossless-only" }}
+            - --lossless-only
+            {{- else if eq .Values.gateway.mode "verbatim" }}
+            - --verbatim
+            {{- end }}
+            {{- if .Values.gateway.requireKeys }}
+            - --require-keys
+            {{- end }}
+            {{- if .Values.gateway.trustTenantHeader }}
+            - --trust-tenant-header
+            {{- end }}
+            {{- if .Values.gateway.perTenant.rpm }}
+            - --tenant-rpm={{ .Values.gateway.perTenant.rpm }}
+            {{- end }}
+            {{- if .Values.gateway.perTenant.dailyTokens }}
+            - --tenant-daily-tokens={{ .Values.gateway.perTenant.dailyTokens }}
+            {{- end }}
+          env:
+            # Admin token guards /distil/stats and /distil/dashboard. Passed by env
+            # rather than argv so it never appears in `ps` or a pod spec dump.
+            - name: DISTIL_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "distil-gateway.adminSecretName" . }}
+                  key: {{ .Values.adminToken.existingSecretKey }}
+            - name: DISTIL_HOME
+              value: /var/lib/distil
+            {{- range $env, $key := .Values.providerSecret.keys }}
+            - name: {{ $env }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.providerSecret.existingSecret }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet: {path: /distil/health, port: http}
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet: {path: /distil/health, port: http}
+            initialDelaySeconds: 2
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet: {path: /distil/health, port: http}
+            failureThreshold: 30
+            periodSeconds: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem is on, so every writable path is explicit.
+            - name: data
+              mountPath: /var/lib/distil
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "distil-gateway.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packaging/helm/distil-gateway/templates/hpa.yaml
+++ b/packaging/helm/distil-gateway/templates/hpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "distil-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/ingress.yaml
+++ b/packaging/helm/distil-gateway/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "distil-gateway.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/networkpolicy.yaml
+++ b/packaging/helm/distil-gateway/templates/networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{- include "distil-gateway.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - podSelector: {}
+        {{- end }}
+      ports:
+        - port: {{ .Values.gateway.port }}
+          protocol: TCP
+  egress:
+    # DNS, then HTTPS to the upstream provider. Nothing else: a compression proxy
+    # that can reach arbitrary hosts is an exfiltration path.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/pdb.yaml
+++ b/packaging/helm/distil-gateway/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels: {{- include "distil-gateway.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/prometheusrule.yaml
+++ b/packaging/helm/distil-gateway/templates/prometheusrule.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels:
+    {{- include "distil-gateway.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+spec:
+  groups:
+    - name: distil-gateway
+      rules:
+        # --- Availability -------------------------------------------------
+        - alert: DistilGatewayDown
+          expr: up{job=~".*distil.*"} == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations:
+            summary: distil gateway is not being scraped
+            description: >-
+              No successful scrape for 5m. If the gateway is in your agents'
+              request path, they are either failing or bypassing it — check
+              both before assuming this is only a monitoring gap.
+
+        - alert: DistilGatewayNoTraffic
+          expr: |
+            sum(rate(distil_requests_total[15m])) == 0
+            and on() (sum(distil_build_info) > 0)
+          for: 30m
+          labels: {severity: warning}
+          annotations:
+            summary: distil gateway is up but serving no requests
+            description: >-
+              The process is healthy and scraping fine, but no request has
+              arrived in 30m. The usual cause is clients that were never
+              repointed at the gateway, or were pointed back to the provider.
+
+        # --- Value ---------------------------------------------------------
+        # Savings near zero is NOT automatically a fault: a workload that is
+        # mostly system prompt with small tool outputs has little to compress.
+        # It is alertable because it is indistinguishable from a misconfigured
+        # mode, and worth a human deciding which one it is.
+        - alert: DistilCompressionIneffective
+          expr: |
+            (
+              sum(rate(distil_tokens_saved_total[6h]))
+              /
+              clamp_min(sum(rate(distil_tokens_baseline_total[6h])), 1)
+            ) < 0.02
+          for: 6h
+          labels: {severity: info}
+          annotations:
+            summary: distil is saving under 2% of tokens over 6h
+            description: >-
+              Either the traffic genuinely has little to compress (large stable
+              prefixes, small tool outputs), or the gateway is running in a more
+              conservative mode than intended. Check `mode` in values.yaml and
+              `distil stats` before treating this as a defect.
+
+        - alert: DistilTenantQuotaExhausted
+          expr: increase(distil_requests_rejected_total{reason="quota"}[15m]) > 0
+          for: 5m
+          labels: {severity: warning}
+          annotations:
+            summary: "tenant {{`{{ $labels.tenant }}`}} is being rate limited"
+            description: >-
+              Requests are being rejected against the per-tenant quota. Raise
+              the tenant's limit or investigate a runaway client.
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/pvc.yaml
+++ b/packaging/helm/distil-gateway/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}-data
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+spec:
+  accessModes: {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/secret.yaml
+++ b/packaging/helm/distil-gateway/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if and (not .Values.adminToken.existingSecret) .Values.adminToken.value }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}-admin
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.adminToken.existingSecretKey }}: {{ .Values.adminToken.value | quote }}
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/service.yaml
+++ b/packaging/helm/distil-gateway/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {{- include "distil-gateway.selectorLabels" . | nindent 4 }}

--- a/packaging/helm/distil-gateway/templates/serviceaccount.yaml
+++ b/packaging/helm/distil-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "distil-gateway.serviceAccountName" . }}
+  labels: {{- include "distil-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+# The gateway calls no Kubernetes API. Never mount a token it cannot need.
+automountServiceAccountToken: false
+{{- end }}

--- a/packaging/helm/distil-gateway/templates/servicemonitor.yaml
+++ b/packaging/helm/distil-gateway/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "distil-gateway.fullname" . }}
+  labels:
+    {{- include "distil-gateway.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "distil-gateway.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      # Metrics are labelled by tenant, so the endpoint requires the admin bearer
+      # token — an open /metrics would publish per-tenant usage to the cluster.
+      path: /distil/metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "distil-gateway.adminSecretName" . }}
+          key: {{ .Values.adminToken.existingSecretKey }}
+{{- end }}

--- a/packaging/helm/distil-gateway/values.yaml
+++ b/packaging/helm/distil-gateway/values.yaml
@@ -1,0 +1,146 @@
+# Default values for distil-gateway.
+# Every default here is chosen to be SAFE rather than convenient: auth on,
+# non-root, read-only root filesystem, no privilege escalation. Loosen
+# deliberately, never by accident.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/dshakes/distil
+  # Pinned by the chart's appVersion when empty — override for a specific digest.
+  tag: ""
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+gateway:
+  # Bind inside the pod; the Service handles exposure.
+  host: 0.0.0.0
+  port: 8788
+  upstream: https://api.anthropic.com
+  # off | lossless-only | verbatim
+  #   ""              full reversible digest (most savings)
+  #   lossless-only   no Tier-1 digest — ToS-safe for flat-rate plans
+  #   verbatim        Tier-0 only
+  mode: ""
+  # Require a dsk- key on EVERY request, including before any key is issued.
+  # Default true: a gateway reachable from a cluster network should never be open.
+  requireKeys: true
+  # Honour a client-supplied x-distil-tenant header for accounting. Leave false —
+  # when true, any client can bill another tenant's quota.
+  trustTenantHeader: false
+  perTenant:
+    rpm: 0            # 0 = unlimited
+    dailyTokens: 0    # 0 = unlimited
+
+# Admin token guards /distil/stats and /distil/dashboard. REQUIRED on a
+# non-loopback bind, which is every in-cluster deployment.
+#   existingSecret: reference a Secret you manage (recommended)
+#   value:          chart-managed Secret; fine for dev, avoid in prod GitOps
+adminToken:
+  existingSecret: ""
+  existingSecretKey: admin-token
+  value: ""
+
+# Upstream provider credentials, mounted as env vars from a Secret.
+providerSecret:
+  existingSecret: ""
+  # map of ENV_VAR -> key in the secret
+  keys: {}
+  #  ANTHROPIC_API_KEY: anthropic-api-key
+
+service:
+  type: ClusterIP
+  port: 8788
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: distil.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    # No CPU limit by default: throttling a proxy adds tail latency to every
+    # request behind it. Set one only if your platform requires it.
+    memory: 512Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+
+# The restore store (digest originals) lives on disk so handles survive a
+# restart. With `persistence.enabled: false` it is an emptyDir, which means
+# handles do NOT survive pod replacement — acceptable for stateless/lossless
+# deployments, NOT for --expand where the agent may expand a handle later.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessModes: [ReadWriteOnce]
+  size: 8Gi
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+
+# NetworkPolicy: egress to the upstream provider + DNS only, ingress from the
+# namespace. Off by default because it depends on your CNI; on is correct.
+networkPolicy:
+  enabled: false
+  ingressFrom: []
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  labels: {}
+
+prometheusRule:
+  enabled: false
+  labels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Spread replicas across nodes so a single node loss cannot take the gateway down.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: distil-gateway
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -60,3 +60,44 @@ const openai = new OpenAI({ baseURL: distilOpenAIBaseURL() }); // adds /v1
   publishes real, auditable numbers.
 
 Full docs: <https://dshakes.github.io/distil/> · License: Apache-2.0
+
+## In-process compression (lossless tier)
+
+```js
+import { compress } from "distil-llm";
+
+const r = compress(messages);           // never mutates the input
+console.log(`${r.savedPct.toFixed(1)}% smaller`);
+const response = await client.messages.create({ model, messages: r.messages });
+```
+
+Tool and user text get lossless transforms; **the model's own turns and
+non-string content (image blocks, tool_use) are never rewritten**. Unchanged
+messages are returned by identity.
+
+This runs entirely in Node — no daemon, no network — and is **byte-identical to
+the Python engine**, enforced by a conformance suite (`tests/test_ts_conformance.py`)
+that runs both implementations over a shared corpus and fails on any divergence.
+Where JS cannot reproduce Python's bytes (Python renders an integral float as
+`1.0`, JS as `1`; JS objects hoist integer-like keys) the transform **declines**
+rather than emitting output the certificate does not cover.
+
+### Getting the reversible digest tier
+
+`compress()` is lossless-only, on purpose. The digest tier mints restore handles
+whose originals must live in one store shared with the proxy and the MCP server,
+and it is the tier the decision-equivalence certificate measures — so there is
+deliberately no second implementation of it here.
+
+Route through the proxy instead, which is the same engine and the same store:
+
+```js
+import Anthropic from "@anthropic-ai/sdk";
+import { distilBaseURL } from "distil-llm";
+
+const client = new Anthropic({ baseURL: distilBaseURL() });
+```
+
+```bash
+npx distil-llm proxy        # or: distil default --always-on
+```

--- a/packaging/npm/index.d.ts
+++ b/packaging/npm/index.d.ts
@@ -1,15 +1,65 @@
-export interface DistilURLOptions {
-  /** Proxy host. Default "127.0.0.1". */
+// Type definitions for distil-llm.
+
+export interface Message {
+  role?: string;
+  type?: string;
+  content?: unknown;
+  [k: string]: unknown;
+}
+
+export interface CompressionResult {
+  /** New array. Unchanged messages are returned by identity. */
+  messages: Message[];
+  tokensBefore: number;
+  tokensAfter: number;
+  tokensSaved: number;
+  /**
+   * Percent smaller. Legitimately near 0 on small payloads — savings come from
+   * LARGE tool output, and a request that is mostly system prompt has nothing
+   * to fold.
+   */
+  savedPct: number;
+  tier: "lossless";
+}
+
+export interface BaseURLOptions {
   host?: string;
-  /** Proxy port. Default 8788 (or DISTIL_PORT). */
   port?: number;
 }
 
-/** Base URL of a local distil proxy (honors DISTIL_BASE_URL). */
-export function distilBaseURL(opts?: DistilURLOptions): string;
+/**
+ * Compress a message list in-process, lossless tier only.
+ *
+ * Byte-identical to the Python engine (enforced by a conformance suite). Tool
+ * and user text get lossless transforms; the model's own turns and non-string
+ * content are never rewritten; the input array is never mutated.
+ *
+ * For the reversible DIGEST tier, route your SDK through a distil proxy with
+ * `distilBaseURL()` — that path mints restore handles into the shared store and
+ * is the path the decision-equivalence certificate covers.
+ */
+export function compress(messages: Message[]): CompressionResult;
 
-/** distil proxy base URL with the OpenAI `/v1` segment appended. */
-export function distilOpenAIBaseURL(opts?: DistilURLOptions): string;
+/** Base URL of a local distil proxy (honours DISTIL_BASE_URL / DISTIL_PORT). */
+export function distilBaseURL(opts?: BaseURLOptions): string;
+/** Same, with the `/v1` segment OpenAI-style clients expect. */
+export function distilOpenAIBaseURL(opts?: BaseURLOptions): string;
 
 export const DEFAULT_PORT: number;
 export const DEFAULT_HOST: string;
+
+/** Full Tier-0 pipeline: JSON minify, then run-collapse if it does not inflate. */
+export function applyTier0(text: string): string;
+/** Run-length-collapse consecutive identical lines to `L\n<<xN>>`. */
+export function collapseRuns(text: string): string;
+/**
+ * Textual inverse of `collapseRuns`.
+ * PRECONDITION: the original text contained no line matching /^<<x\d+>>$/ —
+ * a generated marker and content that looks like one are indistinguishable.
+ * distil's real recovery path is the restore store, not this function.
+ */
+export function expandRuns(text: string): string;
+/** Minify JSON, or null when a byte-identical round-trip is not provable. */
+export function minifyJson(text: string): string | null;
+/** Heuristic token count, matching the Python HeuristicTokenizer. */
+export function countTokens(text: string): number;

--- a/packaging/npm/index.js
+++ b/packaging/npm/index.js
@@ -17,22 +17,27 @@
 
 "use strict";
 
-const DEFAULT_PORT = 8788;
-const DEFAULT_HOST = "127.0.0.1";
+const {
+  distilBaseURL,
+  distilOpenAIBaseURL,
+  DEFAULT_PORT,
+  DEFAULT_HOST,
+} = require("./lib/baseurl");
+const { compress } = require("./lib/compress");
+const { applyTier0, collapseRuns, expandRuns, minifyJson, countTokens } = require("./lib/tier0");
 
-/** Base URL of a local distil proxy. Reads DISTIL_BASE_URL if set, else builds
- *  http://<host>:<port> (defaults 127.0.0.1:8788). */
-function distilBaseURL(opts) {
-  opts = opts || {};
-  if (process.env.DISTIL_BASE_URL) return process.env.DISTIL_BASE_URL;
-  const host = opts.host || DEFAULT_HOST;
-  const port = opts.port || Number(process.env.DISTIL_PORT) || DEFAULT_PORT;
-  return `http://${host}:${port}`;
-}
-
-/** OpenAI-style clients expect the base URL to include the API version segment. */
-function distilOpenAIBaseURL(opts) {
-  return distilBaseURL(opts).replace(/\/+$/, "") + "/v1";
-}
-
-module.exports = { distilBaseURL, distilOpenAIBaseURL, DEFAULT_PORT, DEFAULT_HOST };
+module.exports = {
+  // in-process lossless compression (byte-identical to the Python engine)
+  compress,
+  // proxy routing helpers
+  distilBaseURL,
+  distilOpenAIBaseURL,
+  DEFAULT_PORT,
+  DEFAULT_HOST,
+  // lower-level transforms, exposed for verification and testing
+  applyTier0,
+  collapseRuns,
+  expandRuns,
+  minifyJson,
+  countTokens,
+};

--- a/packaging/npm/lib/baseurl.js
+++ b/packaging/npm/lib/baseurl.js
@@ -1,0 +1,23 @@
+// Base-URL helpers, factored out of index.js so lib/ modules can use them
+// without importing the package entry point (which imports them back).
+"use strict";
+
+const DEFAULT_PORT = 8788;
+const DEFAULT_HOST = "127.0.0.1";
+
+/** Base URL of a local distil proxy. Reads DISTIL_BASE_URL if set, else builds
+ *  http://<host>:<port> (defaults 127.0.0.1:8788). */
+function distilBaseURL(opts) {
+  opts = opts || {};
+  if (process.env.DISTIL_BASE_URL) return process.env.DISTIL_BASE_URL;
+  const host = opts.host || DEFAULT_HOST;
+  const port = opts.port || Number(process.env.DISTIL_PORT) || DEFAULT_PORT;
+  return `http://${host}:${port}`;
+}
+
+/** OpenAI-style clients expect the base URL to include the API version segment. */
+function distilOpenAIBaseURL(opts) {
+  return distilBaseURL(opts).replace(/\/+$/, "") + "/v1";
+}
+
+module.exports = { distilBaseURL, distilOpenAIBaseURL, DEFAULT_PORT, DEFAULT_HOST };

--- a/packaging/npm/lib/compress.js
+++ b/packaging/npm/lib/compress.js
@@ -1,0 +1,98 @@
+// Public TypeScript/JavaScript compression API.
+//
+// Two tiers, two very different trust stories, and the difference is the whole
+// design of this file:
+//
+//   Tier-0 (lossless)  — implemented natively in lib/tier0.js and proven
+//                        BYTE-IDENTICAL to the Python engine by
+//                        tests/test_ts_conformance.py. Safe to run in-process:
+//                        no daemon, no network, no handles to keep alive.
+//
+//   Tier-1 (digest)    — NOT implemented here. It mints restore handles whose
+//                        originals must live in ONE store shared with the proxy
+//                        and the MCP server, or `expand` silently fails to
+//                        resolve a handle the model can see. It is also the tier
+//                        the decision-equivalence certificate actually measures.
+//                        A second implementation would be a second thing to
+//                        certify, and nobody would notice when they drifted.
+//
+// So `compress()` is lossless-only and always available in-process. The digest
+// tier comes from routing your client through the proxy (see the note at the
+// bottom of this file), which is the same engine, store, and certificate.
+
+"use strict";
+
+const { applyTier0, countTokens } = require("./tier0");
+
+/** Roles whose content distil never rewrites. */
+const NEVER_REWRITE = new Set(["assistant", "ai"]);
+
+function roleOf(m) {
+  if (!m || typeof m !== "object") return "";
+  return String(m.role || m.type || "").toLowerCase();
+}
+
+/**
+ * Compress a message list in-process, lossless tier only.
+ *
+ * Mirrors the Python `distil.compress_messages` contract: the input is never
+ * mutated, unchanged messages pass through by identity, non-string content
+ * (image blocks, tool_use structures) is untouched, and the model's own turns
+ * are never rewritten.
+ *
+ * @param {Array<object>} messages OpenAI/Anthropic-style message objects
+ * @returns {{messages: Array<object>, tokensBefore: number, tokensAfter: number,
+ *            tokensSaved: number, savedPct: number, tier: "lossless"}}
+ */
+function compress(messages) {
+  if (!Array.isArray(messages)) {
+    throw new TypeError("compress(messages): expected an array of messages");
+  }
+  let before = 0;
+  let after = 0;
+  const out = messages.map((m) => {
+    const content = m && typeof m === "object" ? m.content : undefined;
+    if (typeof content !== "string") return m;
+    before += countTokens(content);
+    if (NEVER_REWRITE.has(roleOf(m))) {
+      after += countTokens(content);
+      return m;
+    }
+    const next = applyTier0(content);
+    after += countTokens(next);
+    return next === content ? m : Object.assign({}, m, { content: next });
+  });
+  return {
+    messages: out,
+    tokensBefore: before,
+    tokensAfter: after,
+    tokensSaved: before - after,
+    // Can legitimately be ~0: savings come from LARGE tool output, and a request
+    // that is mostly system prompt has nothing to fold.
+    savedPct: before > 0 ? (100 * (before - after)) / before : 0,
+    tier: "lossless",
+  };
+}
+
+/**
+ * How to get the reversible DIGEST tier from JS.
+ *
+ * There is deliberately no `compressViaProxy()` here. The distil proxy has no
+ * "compress this payload and hand it back" endpoint, and inventing one would add
+ * a new public API surface — accepting arbitrary content, needing its own
+ * authentication story — to get something the existing design already provides.
+ *
+ * The proxy's contract is transparent interception: point your SDK's baseURL at
+ * it and every request is compressed on the way through, by the same engine the
+ * decision-equivalence certificate was measured against, minting handles into the
+ * one restore store that `distil expand` and the MCP server read.
+ *
+ *   import Anthropic from "@anthropic-ai/sdk";
+ *   import { distilBaseURL } from "distil-llm";
+ *   const client = new Anthropic({ baseURL: distilBaseURL() });
+ *
+ * Use `compress()` above when you hold the message list and want lossless
+ * savings with no daemon; route through the proxy when you want the digest.
+ */
+
+module.exports = { compress };

--- a/packaging/npm/lib/tier0.js
+++ b/packaging/npm/lib/tier0.js
@@ -1,0 +1,323 @@
+// Tier-0 lossless transforms — a faithful port of distil/compress/tier0.py.
+//
+// WHY THIS IS A PORT AND NOT A REIMPLEMENTATION
+// ---------------------------------------------
+// distil's whole claim is a decision-equivalence certificate, and that
+// certificate is measured against the PYTHON compressor. A JS implementation
+// that merely "compresses similarly" would sit outside it — users would get a
+// guarantee that does not describe the code they are running.
+//
+// So this file targets BYTE-IDENTICAL output with tier0.py, and
+// tests/test_ts_conformance.py runs both against a shared fixture corpus and
+// fails on any divergence. Where byte-identity is not achievable (see
+// `minifyJson`), the transform DECLINES rather than producing output the
+// certificate does not cover. Declining costs a little compression; diverging
+// silently would cost the guarantee.
+//
+// Tier-1 (the reversible digest) is deliberately NOT ported: it allocates
+// restore handles and must share one store with the proxy and the MCP server.
+// Use `compressViaProxy` in compress.js for that.
+
+"use strict";
+
+// Matches tier0.py's _RUN_MARKER: a generated marker, so a run of markers is
+// left alone (collapsing it would make the new marker indistinguishable from
+// original content when reversing).
+const RUN_MARKER = /^<<x\d+>>$/;
+
+/**
+ * Run-length-encode consecutive identical lines, reversibly.
+ * Two or more identical lines `L` collapse to `L\n<<xN>>\n`, where N is the
+ * exact original count, so the input is fully recoverable.
+ *
+ * Pure string manipulation, so this is exactly portable — no locale, no number
+ * formatting, no object ordering. It is the bulk of Tier-0's real-world win
+ * (repeated log lines, duplicated stack frames).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function collapseRuns(text) {
+  if (typeof text !== "string" || text.indexOf("\n") === -1) return text;
+
+  const lines = text.split("\n");
+  const out = [];
+  let i = 0;
+  // The Python side uses the regex /^(.*)\n(?:\1\n)+/m, which only ever matches
+  // runs that are newline-TERMINATED. A trailing final line with no newline
+  // after it therefore cannot participate in a run; splitting keeps that
+  // property because the last element has no terminator to consume.
+  const lastIndex = lines.length - 1;
+  while (i < lines.length) {
+    const line = lines[i];
+    let j = i;
+    // Count how many consecutive newline-terminated copies follow.
+    while (j < lastIndex && lines[j] === line) j++;
+    const runLen = j - i;
+    if (runLen >= 2 && !RUN_MARKER.test(line)) {
+      out.push(line, `<<x${runLen}>>`);
+      i = j;
+    } else {
+      out.push(line);
+      i += 1;
+    }
+  }
+  return out.join("\n");
+}
+
+/**
+ * Textual inverse of `collapseRuns`.
+ *
+ * PRECONDITION: the ORIGINAL text contained no line matching /^<<x\d+>>$/.
+ * A generated marker and original content that looks like one are
+ * indistinguishable after the fact, so no textual inverse can separate them.
+ * `collapseRuns` refuses to collapse such runs precisely so nothing is lost —
+ * but expanding text that already contained markers will invent lines.
+ *
+ * This is why distil's real reversibility guarantee comes from the restore
+ * store (the exact original bytes, keyed by handle) rather than from inverting
+ * the transform. Use this for local verification of ordinary text, not as the
+ * recovery path.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function expandRuns(text) {
+  if (typeof text !== "string") return text;
+  const lines = text.split("\n");
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^<<x(\d+)>>$/.exec(lines[i]);
+    if (m && out.length > 0) {
+      const prev = out[out.length - 1];
+      const n = parseInt(m[1], 10);
+      for (let k = 1; k < n; k++) out.push(prev);
+    } else {
+      out.push(lines[i]);
+    }
+  }
+  return out.join("\n");
+}
+
+// --- JSON ------------------------------------------------------------------
+//
+// Python's json.dumps and JS's JSON.stringify disagree on two things that
+// matter for byte-identity:
+//
+//   1. NUMBER FORMATTING. Python renders a float that happens to be integral as
+//      "1.0"; JS renders it "1". Nothing in JS can recover the distinction,
+//      because JSON.parse has already collapsed 1.0 and 1 to the same double.
+//   2. KEY ORDER. Python dicts preserve insertion order for every key. JS
+//      objects hoist integer-like keys ("2" before "a", regardless of input).
+//
+// Both are detected below and cause the transform to DECLINE (return null), so
+// the caller keeps the text byte-exact. That is the same posture tier0.py takes
+// for duplicate keys and non-finite numbers: when the round trip is not
+// provably value-preserving, do nothing.
+
+/** True when a key would be reordered by a JS object (array-index-like). */
+function isIntegerLikeKey(k) {
+  return /^(0|[1-9]\d*)$/.test(k) && Number(k) <= 4294967294;
+}
+
+/**
+ * Scan the raw JSON source for constructs we cannot round-trip byte-identically
+ * with Python. Returns a reason string, or null when it is safe.
+ */
+function unsafeJsonReason(src) {
+  // Strip string contents FIRST. Scanning raw source treats `"line1"` as
+  // exponent notation ("e1") and `"v1.0"` as an integral float, which made this
+  // decline JSON that Python happily minifies — a conformance divergence in the
+  // safe direction, but a divergence.
+  const bare = stripJsonStrings(src);
+
+  // Python renders an integral float as "1.0"; JS renders it "1". After parsing
+  // the distinction is gone, so it has to be decided on the literal.
+  const nums = bare.match(/-?\d+\.\d+/g) || [];
+  for (const n of nums) {
+    if (Number.isInteger(Number(n))) {
+      return "integral float renders differently in Python and JS";
+    }
+  }
+  if (/\d[eE][+-]?\d+/.test(bare)) return "exponent notation renders differently";
+  if (/\b(Infinity|-Infinity|NaN)\b/.test(bare)) return "non-finite constant";
+  return null;
+}
+
+/** Replace every JSON string literal with "" so scans see structure only. */
+function stripJsonStrings(src) {
+  let out = "";
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === '"') {
+        inStr = false;
+        out += '""';
+      }
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else out += c;
+  }
+  return out;
+}
+
+/** Depth-first check for duplicate or reorder-prone keys, on the raw source. */
+function objectKeysAreSafe(obj, seenPath) {
+  if (Array.isArray(obj)) return obj.every((v) => objectKeysAreSafe(v, seenPath));
+  if (obj && typeof obj === "object") {
+    for (const k of Object.keys(obj)) {
+      if (isIntegerLikeKey(k)) return false; // JS would hoist it
+      if (!objectKeysAreSafe(obj[k], seenPath)) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Re-encode JSON with no incidental whitespace, or null when that would not be
+ * provably value-preserving *and* byte-identical to the Python implementation.
+ *
+ * @param {string} text
+ * @returns {string|null}
+ */
+function minifyJson(text) {
+  if (typeof text !== "string") return null;
+  const s = text.trim();
+  const first = s.charAt(0);
+  const last = s.charAt(s.length - 1);
+  // Same gate as tier0.py: only whole objects/arrays.
+  if (!((first === "{" || first === "[") && (last === "}" || last === "]"))) return null;
+
+  if (unsafeJsonReason(s) !== null) return null;
+
+  let obj;
+  try {
+    obj = JSON.parse(s);
+  } catch (_e) {
+    return null;
+  }
+  if (!objectKeysAreSafe(obj)) return null;
+
+  // Duplicate keys: JSON.parse silently keeps the last. tier0.py rejects such
+  // input outright, so detect it by counting keys in the source.
+  if (hasDuplicateKeys(s)) return null;
+
+  try {
+    return JSON.stringify(obj);
+  } catch (_e) {
+    return null; // circular refs cannot occur from JSON.parse, but never throw
+  }
+}
+
+/** Cheap duplicate-key detector over the raw source (string-aware). */
+function hasDuplicateKeys(src) {
+  const stack = [];
+  let inStr = false;
+  let esc = false;
+  let cur = null;
+  let pendingKey = null;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (inStr) {
+      if (esc) {
+        esc = false;
+      } else if (c === "\\") {
+        esc = true;
+      } else if (c === '"') {
+        inStr = false;
+        pendingKey = src.slice(cur + 1, i);
+      }
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+      cur = i;
+    } else if (c === "{") {
+      stack.push(new Set());
+      pendingKey = null;
+    } else if (c === "}") {
+      stack.pop();
+      pendingKey = null;
+    } else if (c === ":" && stack.length && pendingKey !== null) {
+      const top = stack[stack.length - 1];
+      if (top.has(pendingKey)) return true;
+      top.add(pendingKey);
+      pendingKey = null;
+    } else if (c === ",") {
+      pendingKey = null;
+    }
+  }
+  return false;
+}
+
+// --- heuristic tokenizer ----------------------------------------------------
+// Port of distil/tokenizer.py:HeuristicTokenizer. Needed because the production
+// Tier-0 path is reject-if-bigger *by tokens*, not by characters: collapsing a
+// run of near-free blank lines into a "<<xN>>" marker can cost MORE tokens than
+// it removes, and Tier-0 must never inflate.
+
+// Python: re.compile(r"\w+|[^\w\s]", re.UNICODE). The `u` flag plus explicit
+// Unicode property escapes reproduce Python's \w/\s semantics closely enough
+// for counting; the conformance suite is what proves it on real inputs.
+const PIECE = /[\p{L}\p{N}_]+|[^\p{L}\p{N}_\s]/gu;
+const SUBWORD_FACTOR = 1.33;
+
+/**
+ * Approximate token count, matching HeuristicTokenizer.count byte-for-byte.
+ * @param {string} text
+ * @returns {number}
+ */
+function countTokens(text) {
+  if (!text) return 0;
+  const pieces = text.match(PIECE);
+  const n = pieces ? pieces.length : 0;
+  return Math.max(1, bankersRound(n * SUBWORD_FACTOR));
+}
+
+/**
+ * Python's round() is round-half-to-EVEN; JS Math.round is round-half-UP.
+ * They differ on exact .5, which n * 1.33 can land on, so the naive version
+ * would silently diverge from Python on specific input lengths.
+ */
+function bankersRound(x) {
+  const floor = Math.floor(x);
+  const diff = x - floor;
+  if (diff > 0.5) return floor + 1;
+  if (diff < 0.5) return floor;
+  return floor % 2 === 0 ? floor : floor + 1;
+}
+
+/**
+ * Apply every Tier-0 transform in the same order as the production path
+ * (distil/adapters/anthropic.py:_apply_tier0): JSON minification first, then
+ * run-collapse on the RESULT, keeping the collapse only when it does not
+ * increase the token count.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function applyTier0(text) {
+  if (typeof text !== "string" || text.length === 0) return text;
+  const mj = minifyJson(text);
+  const base = mj !== null ? mj : text;
+  const collapsed = collapseRuns(base);
+  if (collapsed !== base && countTokens(collapsed) <= countTokens(base)) {
+    return collapsed;
+  }
+  return base;
+}
+
+module.exports = {
+  applyTier0,
+  countTokens,
+  collapseRuns,
+  expandRuns,
+  minifyJson,
+  // exported for the conformance harness
+  _internals: { hasDuplicateKeys, unsafeJsonReason, isIntegerLikeKey },
+};

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -38,6 +38,6 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node --test test/"
+    "test": "node --test test/*.test.mjs"
   }
 }

--- a/packaging/npm/test/compress.test.mjs
+++ b/packaging/npm/test/compress.test.mjs
@@ -1,0 +1,84 @@
+// Native JS behaviour tests. Cross-implementation byte-equality with Python is
+// covered separately by tests/test_ts_conformance.py.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import distil from "../index.js";
+
+const { compress, collapseRuns, expandRuns, minifyJson, countTokens, applyTier0 } = distil;
+
+const BIG_LOG = "ERROR failed to connect to worker pool\n".repeat(50);
+
+test("compresses a large repetitive tool result", () => {
+  const r = compress([{ role: "tool", content: BIG_LOG }]);
+  assert.ok(r.tokensSaved > 0);
+  assert.ok(r.savedPct > 50);
+  assert.equal(r.tier, "lossless");
+});
+
+test("never rewrites the model's own turns", () => {
+  const msgs = [{ role: "assistant", content: BIG_LOG }];
+  const r = compress(msgs);
+  assert.equal(r.messages[0].content, BIG_LOG);
+  assert.equal(r.messages[0], msgs[0], "unchanged messages pass through by identity");
+});
+
+test("does not mutate the input array or its objects", () => {
+  const msgs = [{ role: "tool", content: BIG_LOG }];
+  const snapshot = JSON.stringify(msgs);
+  compress(msgs);
+  assert.equal(JSON.stringify(msgs), snapshot);
+});
+
+test("passes non-string content through untouched", () => {
+  const blocks = [{ type: "image", source: { data: "..." } }];
+  const r = compress([{ role: "user", content: blocks }]);
+  assert.equal(r.messages[0].content, blocks);
+});
+
+test("empty input is safe", () => {
+  const r = compress([]);
+  assert.deepEqual(r.messages, []);
+  assert.equal(r.savedPct, 0);
+});
+
+test("rejects a non-array argument loudly", () => {
+  assert.throws(() => compress("not an array"), TypeError);
+});
+
+test("collapse round-trips ordinary text", () => {
+  const text = "a\na\na\nb\nc\nc\n";
+  assert.equal(expandRuns(collapseRuns(text)), text);
+});
+
+test("refuses to collapse runs that look like markers", () => {
+  const text = "<<x3>>\n<<x3>>\n<<x3>>\nreal\n";
+  assert.equal(collapseRuns(text), text);
+});
+
+test("declines JSON it cannot reproduce byte-identically", () => {
+  assert.equal(minifyJson('{"a": 1.0}'), null, "integral float");
+  assert.equal(minifyJson('{"a": 1e5}'), null, "exponent");
+  assert.equal(minifyJson('{"2": "b", "1": "a"}'), null, "integer-like keys reorder in JS");
+  assert.equal(minifyJson('{"a": 1, "a": 2}'), null, "duplicate key");
+});
+
+test("still minifies the safe cases", () => {
+  assert.equal(minifyJson('{"b": 1, "a": 2}'), '{"b":1,"a":2}');
+  assert.equal(minifyJson("[1, 2, 3]"), "[1,2,3]");
+});
+
+test("does not mistake text inside strings for numbers", () => {
+  // "line1" looks like exponent notation to a naive source scan.
+  assert.equal(minifyJson('{"msg": "line1"}'), '{"msg":"line1"}');
+});
+
+test("tier-0 never inflates", () => {
+  const tiny = "a\na\na\n";
+  assert.equal(applyTier0(tiny), tiny, "marker would cost more tokens than it saves");
+});
+
+test("token counting is defined for empty input", () => {
+  assert.equal(countTokens(""), 0);
+  assert.ok(countTokens("hello world") > 0);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ onnx = ["onnxruntime>=1.17", "transformers>=4.40"]   # transformer keep-model in
 train = ["torch>=2.2", "transformers>=4.40", "onnx>=1.16", "onnxscript>=0.1", "sentencepiece>=0.2"]  # training + ONNX export
 async = ["aiohttp>=3.9"]                              # async high-concurrency proxy (distil.aproxy)
 otel = ["opentelemetry-api>=1.20"]                    # GenAI semantic-convention spans (distil.otel)
+# OIDC RS256 verification for the gateway. HS256 needs nothing (stdlib hmac);
+# this is only for asymmetric IdP signing keys. Without it an RS256 token is
+# REFUSED, never verified-by-skipping — see distil/authz.py.
+oidc = ["cryptography>=42.0"]
 # native = the Rust hot-path core (rust/distil-core); build with `maturin develop --release`
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,42 @@ def _distil_home_sandbox(monkeypatch, tmp_path_factory):
 def real_claude_settings_files():
     """The genuine enumerator, for the tests that assert on precedence order."""
     return _REAL_CLAUDE_SETTINGS_FILES
+
+
+@pytest.fixture(autouse=True)
+def _restore_sigpipe_disposition():
+    """Keep SIGPIPE ignored for the pytest process, whatever a test did to it.
+
+    `distil.cli.main()` sets SIGPIPE to SIG_DFL — correct for a CLI filter, so
+    `distil stats | head` dies quietly instead of spewing BrokenPipeError. But
+    the disposition is PROCESS-GLOBAL, and eight test modules call `main()`
+    in-process. After the first one, any broken pipe anywhere in the suite kills
+    pytest outright with exit 141 instead of raising BrokenPipeError.
+
+    That is how it presented in CI: a green suite locally, and a run that simply
+    stopped at ~41% on one Python version with exit 141 and no failing test to
+    point at. Ordering decided whether it happened, so it looked like flake.
+
+    Restoring after every test makes the suite immune regardless of execution
+    order. Only the main thread may set a handler, and Windows has no SIGPIPE —
+    both are skipped rather than raising.
+    """
+    import signal
+
+    sigpipe = getattr(signal, "SIGPIPE", None)
+    if sigpipe is None:  # Windows
+        yield
+        return
+    try:
+        previous = signal.getsignal(sigpipe)
+    except (ValueError, OSError):  # pragma: no cover - not the main thread
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            if signal.getsignal(sigpipe) != previous:
+                signal.signal(sigpipe, previous)
+        except (ValueError, OSError):  # pragma: no cover - not the main thread
+            pass

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,0 +1,290 @@
+"""RBAC + OIDC. Tested adversarially: the interesting cases are the attacks.
+
+Every classic JWT vulnerability gets an explicit test here, because "we didn't
+implement that mistake" is only credible if something fails when you do.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+from distil.authz import (
+    ROLE_ORDER,
+    AuthzError,
+    Identity,
+    identity_from_claims,
+    parse_role,
+    verify_jwt,
+)
+
+SECRET = "correct horse battery staple"
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _make(claims: dict, *, alg: str = "HS256", secret: str = SECRET, sig: bytes | None = None):
+    h = _b64(json.dumps({"alg": alg, "typ": "JWT"}).encode())
+    p = _b64(json.dumps(claims).encode())
+    signing_input = f"{h}.{p}".encode()
+    if sig is None:
+        sig = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    return f"{h}.{p}.{_b64(sig)}"
+
+
+def _claims(**over):
+    base = {"sub": "u1", "tenant": "acme", "role": "operator", "exp": time.time() + 3600}
+    base.update(over)
+    return base
+
+
+# --- the attacks -------------------------------------------------------------
+
+
+def test_alg_none_is_refused():
+    """The canonical JWT bypass: a token declaring it needs no signature."""
+    tok = _make(_claims(), alg="none", sig=b"")
+    with pytest.raises(AuthzError, match="unsupported or unsafe alg"):
+        verify_jwt(tok, secret=SECRET)
+
+
+def test_tampered_payload_is_refused():
+    """Escalate role in the payload, keep the old signature."""
+    good = _make(_claims(role="viewer"))
+    h, _p, s = good.split(".")
+    forged_payload = _b64(json.dumps(_claims(role="admin")).encode())
+    with pytest.raises(AuthzError, match="signature verification failed"):
+        verify_jwt(f"{h}.{forged_payload}.{s}", secret=SECRET)
+
+
+def test_wrong_secret_is_refused():
+    with pytest.raises(AuthzError, match="signature verification failed"):
+        verify_jwt(_make(_claims()), secret="not the secret")
+
+
+def test_rs256_without_a_configured_key_is_refused_not_bypassed():
+    """An attacker switching alg to RS256 must not skip verification."""
+    tok = _make(_claims(), alg="RS256", sig=b"whatever")
+    with pytest.raises(AuthzError, match="no public key is configured"):
+        verify_jwt(tok, secret=SECRET)
+
+
+def test_hs256_without_a_secret_is_refused():
+    with pytest.raises(AuthzError, match="no shared secret"):
+        verify_jwt(_make(_claims()), secret="")
+
+
+def test_expired_token_is_refused():
+    with pytest.raises(AuthzError, match="expired"):
+        verify_jwt(_make(_claims(exp=time.time() - 7200)), secret=SECRET)
+
+
+def test_not_yet_valid_token_is_refused():
+    with pytest.raises(AuthzError, match="not yet valid"):
+        verify_jwt(_make(_claims(nbf=time.time() + 7200)), secret=SECRET)
+
+
+def test_issuer_and_audience_are_enforced_when_configured():
+    tok = _make(_claims(iss="https://idp.example", aud="distil"))
+    verify_jwt(tok, secret=SECRET, issuer="https://idp.example", audience="distil")
+    with pytest.raises(AuthzError, match="issuer mismatch"):
+        verify_jwt(tok, secret=SECRET, issuer="https://evil.example")
+    with pytest.raises(AuthzError, match="audience mismatch"):
+        verify_jwt(tok, secret=SECRET, audience="other-service")
+
+
+def test_audience_array_form_is_accepted():
+    tok = _make(_claims(aud=["other", "distil"]))
+    assert verify_jwt(tok, secret=SECRET, audience="distil")["sub"] == "u1"
+
+
+@pytest.mark.parametrize("tok", ["", "a.b", "a.b.c.d", "not-a-token", "...", "!!!.???.***"])
+def test_malformed_tokens_raise_rather_than_crash(tok):
+    with pytest.raises(AuthzError):
+        verify_jwt(tok, secret=SECRET)
+
+
+def test_non_object_payload_is_refused():
+    h = _b64(json.dumps({"alg": "HS256"}).encode())
+    p = _b64(json.dumps(["not", "an", "object"]).encode())
+    sig = hmac.new(SECRET.encode(), f"{h}.{p}".encode(), hashlib.sha256).digest()
+    with pytest.raises(AuthzError, match="must be objects"):
+        verify_jwt(f"{h}.{p}.{_b64(sig)}", secret=SECRET)
+
+
+# --- roles -------------------------------------------------------------------
+
+
+def test_role_ordering_is_transitive():
+    admin = Identity("u", "t", "admin", "oidc")
+    operator = Identity("u", "t", "operator", "oidc")
+    viewer = Identity("u", "t", "viewer", "oidc")
+
+    assert admin.can("viewer") and admin.can("operator") and admin.can("admin")
+    assert operator.can("viewer") and operator.can("operator")
+    assert not operator.can("admin")
+    assert viewer.can("viewer")
+    assert not viewer.can("operator") and not viewer.can("admin")
+
+
+def test_require_raises_for_insufficient_role():
+    with pytest.raises(AuthzError, match="insufficient"):
+        Identity("u", "t", "viewer", "oidc").require("admin")
+
+
+def test_unknown_role_never_escalates():
+    """An IdP group distil has never seen must not become admin."""
+    assert parse_role("superuser") == "operator"
+    assert parse_role(None) == "operator"
+    assert parse_role("") == "operator"
+    assert not Identity("u", "t", "wat", "oidc").can("viewer"), "unknown role denies"
+
+
+def test_role_is_case_insensitive():
+    assert parse_role("ADMIN") == "admin"
+
+
+def test_highest_role_wins_in_a_groups_array():
+    ident = identity_from_claims(_claims(role=["viewer", "admin", "operator"]))
+    assert ident.role == "admin"
+
+
+def test_unknown_roles_in_an_array_are_ignored():
+    ident = identity_from_claims(_claims(role=["wheel", "superuser"]))
+    assert ident.role == "operator", "no known role present => default, never admin"
+
+
+def test_tenant_falls_back_to_subject():
+    ident = identity_from_claims({"sub": "u9"})
+    assert ident.tenant == "u9" and ident.source == "oidc"
+
+
+def test_identity_expiry_is_exposed():
+    past = identity_from_claims(_claims(exp=time.time() - 10))
+    assert past.is_expired
+    assert not identity_from_claims(_claims()).is_expired
+
+
+def test_role_order_constant_is_ascending():
+    assert ROLE_ORDER == ("viewer", "operator", "admin")
+
+
+# --- end to end through a live gateway ---------------------------------------
+# The module-level tests above prove the crypto. These prove it is actually WIRED:
+# an auth library nothing calls protects nothing.
+
+
+def _live_gateway(monkeypatch, tmp_path, **oidc):
+    import threading
+    from http.server import ThreadingHTTPServer
+
+    from distil.gateway import GatewayState, build_gateway_handler
+    from distil.gateway_keys import GatewayKeyStore
+    from distil.pricing import get as pricing_get
+    from tests.test_gateway_keys import _EchoHandler, _start
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    for k, v in oidc.items():
+        monkeypatch.setenv(k, v)
+
+    up = _start(_EchoHandler)
+    price = pricing_get("claude-opus-4-8")
+    state = GatewayState(price)
+    store = GatewayKeyStore(tmp_path / "keys.json")
+    handler = build_gateway_handler(
+        f"http://127.0.0.1:{up.server_address[1]}",
+        state,
+        price,
+        key_store=store,
+        require_keys=True,
+    )
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, up, state
+
+
+def _call(srv, token: str | None):
+    import http.client
+
+    conn = http.client.HTTPConnection("127.0.0.1", srv.server_address[1], timeout=5)
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    conn.request(
+        "POST",
+        "/v1/messages",
+        json.dumps({"model": "claude-opus-4-8", "messages": [{"role": "user", "content": "hi"}]}),
+        headers,
+    )
+    r = conn.getresponse()
+    r.read()
+    conn.close()
+    return r.status
+
+
+def test_e2e_valid_oidc_token_is_accepted(tmp_path, monkeypatch):
+    srv, up, state = _live_gateway(
+        monkeypatch,
+        tmp_path,
+        DISTIL_OIDC_ISSUER="https://idp.example",
+        DISTIL_OIDC_HS256_SECRET=SECRET,
+    )
+    try:
+        tok = _make(_claims(iss="https://idp.example", role="operator", tenant="acme"))
+        assert _call(srv, tok) == 200
+        # accounting must attribute the request to the token's tenant
+        tenants = {r["tenant"] for r in state.snapshot()["tenants"]}
+        assert "acme" in tenants
+    finally:
+        srv.shutdown()
+        up.shutdown()
+
+
+def test_e2e_forged_token_is_rejected_with_401(tmp_path, monkeypatch):
+    srv, up, _ = _live_gateway(
+        monkeypatch,
+        tmp_path,
+        DISTIL_OIDC_ISSUER="https://idp.example",
+        DISTIL_OIDC_HS256_SECRET=SECRET,
+    )
+    try:
+        forged = _make(_claims(iss="https://idp.example"), secret="wrong secret")
+        assert _call(srv, forged) == 401
+    finally:
+        srv.shutdown()
+        up.shutdown()
+
+
+def test_e2e_viewer_role_cannot_proxy_requests(tmp_path, monkeypatch):
+    """Least privilege actually enforced: read-only means read-only."""
+    srv, up, _ = _live_gateway(
+        monkeypatch,
+        tmp_path,
+        DISTIL_OIDC_ISSUER="https://idp.example",
+        DISTIL_OIDC_HS256_SECRET=SECRET,
+    )
+    try:
+        tok = _make(_claims(iss="https://idp.example", role="viewer"))
+        assert _call(srv, tok) == 403
+    finally:
+        srv.shutdown()
+        up.shutdown()
+
+
+def test_e2e_oidc_disabled_means_dsk_keys_still_required(tmp_path, monkeypatch):
+    """Enabling nothing changes nothing — OIDC is additive, never a bypass."""
+    srv, up, _ = _live_gateway(monkeypatch, tmp_path)  # no DISTIL_OIDC_ISSUER
+    try:
+        tok = _make(_claims())
+        assert _call(srv, tok) == 401, "a JWT must not authenticate when OIDC is off"
+        assert _call(srv, None) == 401
+    finally:
+        srv.shutdown()
+        up.shutdown()

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -288,3 +288,57 @@ def test_e2e_oidc_disabled_means_dsk_keys_still_required(tmp_path, monkeypatch):
     finally:
         srv.shutdown()
         up.shutdown()
+
+
+# --- RS256 without the optional extra ----------------------------------------
+
+
+def test_rs256_refuses_when_the_extra_is_missing(monkeypatch):
+    """The failure mode that matters: no crypto available must mean REFUSE.
+
+    A JWT verifier that silently accepts when it cannot check the signature is
+    the whole vulnerability class. Simulate the missing extra and assert we raise
+    rather than return.
+    """
+    import builtins
+
+    from distil import authz
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *a, **kw):
+        if name.startswith("cryptography"):
+            raise ImportError("no cryptography")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    with pytest.raises(AuthzError, match="asymmetric verification is unavailable"):
+        authz._verify_rs256(b"signing-input", b"sig", "-----BEGIN PUBLIC KEY-----")
+
+
+def test_rs256_with_a_malformed_key_returns_false_not_a_crash(monkeypatch):
+    from distil import authz
+
+    pytest.importorskip("cryptography")
+    assert authz._verify_rs256(b"x", b"y", "not a pem") is False
+
+
+def test_invalid_exp_and_nbf_claims_are_rejected():
+    for claim in ("exp", "nbf"):
+        tok = _make(_claims(**{claim: "not-a-number"}))
+        with pytest.raises(AuthzError, match=f"invalid {claim}"):
+            verify_jwt(tok, secret=SECRET)
+
+
+def test_identity_tolerates_an_unparseable_exp():
+    ident = identity_from_claims({"sub": "u", "exp": "garbage"})
+    assert ident.expires is None and not ident.is_expired
+
+
+def test_oidc_config_reads_the_environment(monkeypatch):
+    from distil.authz import oidc_config_from_env
+
+    monkeypatch.setenv("DISTIL_OIDC_ISSUER", "https://idp")
+    monkeypatch.setenv("DISTIL_OIDC_ROLE_CLAIM", "groups")
+    cfg = oidc_config_from_env()
+    assert cfg["issuer"] == "https://idp" and cfg["role_claim"] == "groups"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import contextlib
 import os
+import subprocess
 import sys
 
 import pytest
 
-from distil import doctor
+from distil import doctor, ledger
 
 
 def test_diagnose_runs_every_check_without_crashing() -> None:
@@ -890,3 +891,42 @@ def test_diagnose_swallows_check_exceptions(monkeypatch):
     # Every failed check should appear as FAIL (not raise)
     assert all(c.status == doctor.FAIL for c in checks)
     assert len(checks) >= 12
+
+
+def test_live_routing_trusts_receipts_when_savings_ledger_is_flat(tmp_path, monkeypatch):
+    """Regression: an always-on proxy that routes but saves ~nothing was reported
+    as bypassed.
+
+    The savings ledger skips zero-saving windows by design, so on traffic that
+    legitimately compresses to nothing (a mostly-system-prompt request, a freshly
+    compacted session) `savings.jsonl` never moves. The check must fall back to the
+    receipt log, which is written per request regardless of savings.
+    """
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+
+    # A proxy IS running, and requests ARE arriving (fresh receipts) ...
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: type("R", (), {"stdout": "distil proxy --expand --port 8788"})(),
+    )
+    # ... but the savings ledger is empty: nothing compressed well enough to record.
+    monkeypatch.setattr(ledger, "latest_session", lambda *a, **k: ("", 0.0))
+    (tmp_path / "receipts.jsonl").write_text('{"v":1}\n', encoding="utf-8")
+
+    check = doctor._check_live_routing()
+    assert check.status == "ok", f"false 'bypassed' warn is back: {check.detail}"
+
+
+def test_live_routing_still_warns_when_nothing_is_arriving(tmp_path, monkeypatch):
+    """The check must keep its teeth — a genuinely bypassed proxy still warns."""
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: type("R", (), {"stdout": "distil proxy --expand --port 8788"})(),
+    )
+    monkeypatch.setattr(ledger, "latest_session", lambda *a, **k: ("", 0.0))
+    # No receipts file at all: nothing has ever reached the proxy.
+    check = doctor._check_live_routing()
+    assert check.status == "warn"

--- a/tests/test_e2e_product.py
+++ b/tests/test_e2e_product.py
@@ -182,3 +182,21 @@ def test_doctor_agrees_with_reality_in_both_directions(tmp_path, monkeypatch):
     # Nothing arriving at all — the check must keep its teeth.
     (tmp_path / "receipts.jsonl").unlink()
     assert doctor._check_live_routing().status == "warn"
+
+
+def test_sigpipe_disposition_does_not_leak_out_of_a_cli_call():
+    """`cli.main()` sets SIGPIPE to SIG_DFL process-wide; the suite must not inherit it.
+
+    Without the conftest guard, the first test that runs a CLI entry point turns
+    every later broken pipe into a fatal signal, and pytest dies with exit 141 —
+    no failing test, no traceback, just a run that stops. It reproduced only on
+    some Python versions because it depends on execution order.
+    """
+    import signal
+
+    sigpipe = getattr(signal, "SIGPIPE", None)
+    if sigpipe is None:
+        pytest.skip("no SIGPIPE on this platform")
+    assert signal.getsignal(sigpipe) != signal.SIG_DFL, (
+        "SIGPIPE is SIG_DFL inside the test process — a broken pipe will kill pytest"
+    )

--- a/tests/test_e2e_product.py
+++ b/tests/test_e2e_product.py
@@ -1,0 +1,184 @@
+"""End-to-end product tests — the whole chain, not a unit at a time.
+
+Unit tests kept passing while real traffic broke, three separate times in one day.
+Every test here therefore exercises a *user-visible path* through real sockets and
+real files, and asserts the thing the user would actually notice:
+
+  1. a request through a live proxy is compressed, billed, receipted, and the
+     elided bytes come back through the public library API in another "process"
+  2. the four savings surfaces never show a broken-looking 0%
+  3. a settings.json pin at a dead port is refused before it can cause an outage
+  4. the doctor agrees with reality in both directions
+
+Reuses the echo-upstream harness from test_runtime rather than inventing a second
+one — a divergent second harness is how the first one stops being trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+from distil import ledger
+from distil.runtime import RuntimeSavings
+from tests.test_runtime import _start_echo_upstream, build_handler
+
+BIG_TOOL_OUTPUT = "DECISION: keep\n" + "\n".join(
+    f"2026-08-07T12:00:{i:02d}Z INFO worker heartbeat seq={i} latency_ms=12" for i in range(300)
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+
+
+@pytest.fixture
+def proxy(tmp_path):
+    """A real distil proxy in front of a real echo upstream."""
+    upstream = _start_echo_upstream()
+    up_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+    rs = RuntimeSavings(model="claude-opus-4-8", ledger_path=tmp_path / "savings.jsonl")
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), build_handler(up_url, savings=rs, flush_every=1))
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}"
+    finally:
+        srv.shutdown()
+        upstream.shutdown()
+
+
+def _post(url: str, body: dict) -> tuple[int, dict]:
+    req = urllib.request.Request(
+        url + "/v1/messages",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return r.status, dict(r.headers)
+
+
+def _conversation() -> dict:
+    return {
+        "model": "claude-opus-4-8",
+        "messages": [
+            {"role": "user", "content": "why did the worker pool die?"},
+            {"role": "user", "content": [{"type": "tool_result", "content": BIG_TOOL_OUTPUT}]},
+            {"role": "user", "content": "next"},
+            {"role": "user", "content": "next"},
+        ],
+    }
+
+
+def test_request_is_compressed_billed_and_receipted(proxy, tmp_path):
+    """One real request must move every surface a user checks."""
+    status, headers = _post(proxy, _conversation())
+    assert status == 200
+    assert int(headers.get("x-distil-tokens-saved", "0")) > 0, "header must report savings"
+
+    summary = ledger.summary(tmp_path / "savings.jsonl")
+    assert summary.total_tokens_saved > 0, "savings ledger must record genuine savings"
+
+    from distil import receipts
+
+    verdict = receipts.verify()
+    assert verdict.ok, f"receipt chain must verify: {verdict.statement}"
+    assert verdict.total >= 1, "every request writes a receipt, regardless of savings"
+
+
+def test_digested_bytes_survive_into_a_separate_process(proxy, tmp_path):
+    """The reversibility claim, tested the way a user would experience it.
+
+    Compress via the proxy, then recover the original from a *different* Python
+    process through the public API. In-process recovery would not prove the
+    on-disk restore store works, which is the property the promise rests on.
+    """
+    _post(proxy, _conversation())
+
+    handles = (
+        [p.name for p in (tmp_path / "restore").iterdir()]
+        if (tmp_path / "restore").exists()
+        else []
+    )
+    assert handles, "a 300-line tool result must leave at least one restore handle"
+
+    code = (
+        "import sys; from distil import expand_handle;"
+        "out = expand_handle(sys.argv[1]);"
+        "sys.exit(0 if out and 'worker heartbeat' in out else 1)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code, handles[0]],
+        capture_output=True,
+        text=True,
+        env={"DISTIL_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, (
+        f"a handle written by the proxy did not expand in a fresh process: {result.stderr}"
+    )
+
+
+def test_wrap_refuses_a_config_that_would_take_the_agent_down(tmp_path, monkeypatch):
+    """The three-outages-in-a-day regression, end to end through the real CLI."""
+    import socket
+
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    (proj / ".claude" / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{dead_port}"}}),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "distil.cli", "wrap", "--", "claude", "-p", "hi"],
+        cwd=proj,
+        capture_output=True,
+        text=True,
+        env={"DISTIL_HOME": str(tmp_path), "PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    assert result.returncode == 1, "wrap must refuse, not start into a guaranteed outage"
+    assert "NOT accepting connections" in result.stderr
+    assert "distil offboard" in result.stderr, "must name the fix, not just the fault"
+
+
+def test_no_savings_surface_can_render_a_bare_zero():
+    """A real number next to a 0% is the single most likely uninstall trigger."""
+    from distil.ledger import pct_smaller_label
+
+    for fraction in (0.0001, 0.004, 0.009):
+        label = pct_smaller_label(fraction)
+        assert label == "<1% smaller", f"{fraction} rendered as {label!r}"
+    assert pct_smaller_label(0.0) == "0% smaller", "genuinely zero may say zero"
+
+
+def test_doctor_agrees_with_reality_in_both_directions(tmp_path, monkeypatch):
+    """Doctor must not cry wolf, and must not stay silent when routing is dead."""
+    import subprocess as sp
+
+    from distil import doctor, ledger as _ledger
+
+    monkeypatch.setattr(
+        sp, "run", lambda *a, **k: type("R", (), {"stdout": "distil proxy --port 8788"})()
+    )
+    monkeypatch.setattr(_ledger, "latest_session", lambda *a, **k: ("", 0.0))
+
+    # Requests are arriving (fresh receipts) but nothing compressed well enough to
+    # be ledgered — the always-on false alarm.
+    (tmp_path / "receipts.jsonl").write_text('{"v":1}\n', encoding="utf-8")
+    assert doctor._check_live_routing().status == "ok"
+
+    # Nothing arriving at all — the check must keep its teeth.
+    (tmp_path / "receipts.jsonl").unlink()
+    assert doctor._check_live_routing().status == "warn"

--- a/tests/test_e2e_product.py
+++ b/tests/test_e2e_product.py
@@ -17,6 +17,7 @@ one — a divergent second harness is how the first one stops being trusted.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -114,11 +115,15 @@ def test_digested_bytes_survive_into_a_separate_process(proxy, tmp_path):
         "out = expand_handle(sys.argv[1]);"
         "sys.exit(0 if out and 'worker heartbeat' in out else 1)"
     )
+    # Inherit the real environment and override only what the test controls.
+    # Replacing it wholesale strips USERPROFILE on Windows, and Path.home() then
+    # raises "Could not determine home directory" before the code under test runs.
     result = subprocess.run(
         [sys.executable, "-c", code, handles[0]],
         capture_output=True,
         text=True,
-        env={"DISTIL_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+        encoding="utf-8",
+        env={**os.environ, "DISTIL_HOME": str(tmp_path)},
     )
     assert result.returncode == 0, (
         f"a handle written by the proxy did not expand in a fresh process: {result.stderr}"
@@ -141,12 +146,20 @@ def test_wrap_refuses_a_config_that_would_take_the_agent_down(tmp_path, monkeypa
         encoding="utf-8",
     )
 
+    # HOME and USERPROFILE both point at the sandbox: the check reads user-scoped
+    # settings, and the two platforms disagree about which variable names it.
     result = subprocess.run(
         [sys.executable, "-m", "distil.cli", "wrap", "--", "claude", "-p", "hi"],
         cwd=proj,
         capture_output=True,
         text=True,
-        env={"DISTIL_HOME": str(tmp_path), "PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+        encoding="utf-8",
+        env={
+            **os.environ,
+            "DISTIL_HOME": str(tmp_path),
+            "HOME": str(tmp_path),
+            "USERPROFILE": str(tmp_path),
+        },
     )
     assert result.returncode == 1, "wrap must refuse, not start into a guaranteed outage"
     assert "NOT accepting connections" in result.stderr

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -629,6 +629,7 @@ def test_metrics_never_emit_secrets_or_raw_content() -> None:
         ln.split("{")[0].split(" ")[0] for ln in out.splitlines() if ln and not ln.startswith("#")
     }
     assert names <= {
+        "distil_requests_rejected_total",
         "distil_requests_total",
         "distil_tokens_baseline_total",
         "distil_tokens_sent_total",
@@ -665,7 +666,14 @@ def test_metrics_label_injection_cannot_break_the_exposition() -> None:
     # No raw newline may survive: one metric == one line.
     assert "\nfake_metric" not in out, "a newline in a label broke out of its line"
     lines = [ln for ln in out.splitlines() if ln and not ln.startswith("#")]
-    assert len(lines) == 7, f"label injection forged extra series: {len(lines)} lines"
+    # Derived from the spec, not hardcoded: with one tenant, every declared metric
+    # contributes exactly one series (build_info included). A literal here goes
+    # stale the moment a metric is added, which hides the property being tested.
+    from distil.metrics import _SPEC
+
+    assert len(lines) == len(_SPEC), (
+        f"label injection forged extra series: {len(lines)} lines, {len(_SPEC)} declared"
+    )
 
     def labels_of(line: str) -> dict[str, str]:
         """Parse a label block the way a scraper does — honouring backslash

--- a/tests/test_integrations_new.py
+++ b/tests/test_integrations_new.py
@@ -1,0 +1,170 @@
+"""Agno + Strands integrations.
+
+Both are duck-typed and must never import their framework — that is what keeps
+distil a zero-dependency install. These tests therefore run with neither package
+installed, which is also how CI runs them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from distil.integrations.agno import compress_messages as agno_compress
+from distil.integrations.agno import compressed_model
+from distil.integrations.strands import compress_messages as strands_compress
+
+BIG = "\n".join(f"line {i}: the quick brown fox jumps over the lazy dog" for i in range(400))
+
+
+def test_neither_framework_is_imported() -> None:
+    assert "agno" not in sys.modules
+    assert "strands" not in sys.modules
+
+
+# --- Agno --------------------------------------------------------------------
+
+
+def test_agno_compresses_tool_messages() -> None:
+    out = agno_compress([{"role": "tool", "content": BIG}])
+    assert len(out[0]["content"]) < len(BIG)
+
+
+def test_agno_leaves_assistant_alone() -> None:
+    msgs = [{"role": "assistant", "content": BIG}]
+    assert agno_compress(msgs)[0]["content"] == BIG
+
+
+def test_agno_wrapper_delegates_unknown_attrs_and_compresses_calls() -> None:
+    seen: dict[str, object] = {}
+
+    class FakeModel:
+        id = "gpt-5"
+
+        def invoke(self, messages, **kw):
+            seen["messages"] = messages
+            return "ok"
+
+    wrapped = compressed_model(FakeModel())
+    assert wrapped.id == "gpt-5"  # delegated untouched
+    assert wrapped.invoke([{"role": "tool", "content": BIG}]) == "ok"
+    assert len(seen["messages"][0]["content"]) < len(BIG)  # type: ignore[index]
+
+
+def test_agno_wrapper_compresses_kwarg_form_too() -> None:
+    seen: dict[str, object] = {}
+
+    class FakeModel:
+        def invoke(self, *, messages, **kw):
+            seen["messages"] = messages
+            return "ok"
+
+    compressed_model(FakeModel()).invoke(messages=[{"role": "tool", "content": BIG}])
+    assert len(seen["messages"][0]["content"]) < len(BIG)  # type: ignore[index]
+
+
+# --- Strands -----------------------------------------------------------------
+
+
+def test_strands_user_prose_is_lossless_not_digested() -> None:
+    """User text blocks get Tier-0 lossless only — never a digest stub.
+
+    Digesting user prose would put the human's own words behind a handle and widen
+    what the decision-equivalence certificate covers. Only tool results are
+    eligible for Tier-1, so a block of non-duplicate prose is expected to survive
+    byte-for-byte.
+    """
+    msgs = [{"role": "user", "content": [{"text": BIG}]}]
+    out = strands_compress(msgs)
+    assert out[0]["content"][0]["text"] == BIG
+
+
+def test_strands_text_block_shape_survives_compression() -> None:
+    """The block wrapper must be preserved even when the text is rewritten."""
+    duplicated = "\n".join(["identical line"] * 500)
+    msgs = [{"role": "user", "content": [{"text": duplicated, "cache": "x"}]}]
+    out = strands_compress(msgs)
+    block = out[0]["content"][0]
+    assert set(block) == {"text", "cache"}, "sibling keys must not be dropped"
+    assert block["cache"] == "x"
+
+
+def test_strands_compresses_tool_result_blocks() -> None:
+    msgs = [
+        {
+            "role": "user",
+            "content": [{"toolResult": {"status": "success", "content": [{"text": BIG}]}}],
+        }
+    ]
+    out = strands_compress(msgs)
+    inner = out[0]["content"][0]["toolResult"]["content"][0]["text"]
+    assert len(inner) < len(BIG)
+    assert out[0]["content"][0]["toolResult"]["status"] == "success", "shape preserved"
+
+
+def test_strands_leaves_assistant_and_unknown_blocks_alone() -> None:
+    msgs = [
+        {"role": "assistant", "content": [{"text": BIG}]},
+        {"role": "user", "content": [{"image": {"bytes": "..."}}]},
+    ]
+    out = strands_compress(msgs)
+    assert out[0]["content"][0]["text"] == BIG
+    assert out[1]["content"][0] == {"image": {"bytes": "..."}}
+
+
+def test_strands_accepts_plain_string_content() -> None:
+    out = strands_compress([{"role": "tool", "content": BIG}])
+    assert len(out[0]["content"]) < len(BIG)
+
+
+def test_strands_does_not_mutate_input() -> None:
+    msgs = [{"role": "user", "content": [{"text": BIG}]}]
+    snap = json.dumps(msgs)
+    strands_compress(msgs)
+    assert json.dumps(msgs) == snap
+
+
+# --- quota rejection accounting ----------------------------------------------
+
+
+def test_quota_rejections_are_counted_and_exported() -> None:
+    """A throttled tenant must be visible in metrics, not only in logs.
+
+    Quota enforcement that cannot be observed is indistinguishable from an outage
+    from the client's side, which is the first thing an operator has to rule out.
+    """
+    from distil.gateway import GatewayState
+    from distil.metrics import render
+    from distil.pricing import Pricing
+
+    state = GatewayState(Pricing("claude-opus-5", 5.0, 25.0))
+    state.record("acme", 100, 40)
+    state.record_quota_rejection("acme")
+    state.record_quota_rejection("acme")
+
+    snap = state.snapshot()
+    row = next(r for r in snap["tenants"] if r["tenant"] == "acme")
+    assert row["rejected_quota"] == 2
+    assert row["requests"] == 1, "a rejected request is not a served request"
+    assert snap["totals"]["rejected_quota"] == 2
+
+    out = render(snap, version="test")
+    assert 'distil_requests_rejected_total{tenant="acme"} 2' in out
+
+
+def test_rejection_counter_survives_a_state_reload(tmp_path) -> None:
+    from distil.gateway import GatewayState
+    from distil.pricing import Pricing
+
+    price = Pricing("claude-opus-5", 5.0, 25.0)
+    path = tmp_path / "gateway_state.json"
+
+    a = GatewayState(price)
+    a.record("acme", 10, 5)
+    a.record_quota_rejection("acme")
+    a.save(path)
+
+    b = GatewayState(price)
+    b.load(path)
+    row = next(r for r in b.snapshot()["tenants"] if r["tenant"] == "acme")
+    assert row["rejected_quota"] == 1

--- a/tests/test_integrations_new.py
+++ b/tests/test_integrations_new.py
@@ -168,3 +168,81 @@ def test_rejection_counter_survives_a_state_reload(tmp_path) -> None:
     b.load(path)
     row = next(r for r in b.snapshot()["tenants"] if r["tenant"] == "acme")
     assert row["rejected_quota"] == 1
+
+
+# --- strands: the hook and the shape edge cases ------------------------------
+
+
+def test_strands_hook_compresses_agent_messages_before_the_model_call():
+    """The hook is the ergonomic entry point; an untested hook is a broken hook."""
+    import sys
+    import types
+
+    from distil.integrations.strands import compressing_hook
+
+    # Stand in for the optional dependency. The module must not import it at
+    # module scope, which is exactly what makes this substitution possible.
+    event_cls = type("BeforeModelInvocationEvent", (), {})
+    fake = types.ModuleType("strands.hooks")
+    fake.BeforeModelInvocationEvent = event_cls
+    parent = types.ModuleType("strands")
+    parent.hooks = fake
+    sys.modules["strands"] = parent
+    sys.modules["strands.hooks"] = fake
+    try:
+        captured = {}
+
+        class Registry:
+            def add_callback(self, cls, fn):
+                captured["cls"] = cls
+                captured["fn"] = fn
+
+        hook = compressing_hook()
+        hook.register_hooks(Registry())
+        assert captured["cls"] is event_cls
+
+        agent = type("Agent", (), {})()
+        agent.messages = [{"role": "user", "content": [{"text": BIG}]}]
+        captured["fn"](type("Ev", (), {"agent": agent})())
+        assert isinstance(agent.messages, list)
+    finally:
+        sys.modules.pop("strands.hooks", None)
+        sys.modules.pop("strands", None)
+
+
+def test_strands_hook_tolerates_an_event_without_an_agent():
+    import sys
+    import types
+
+    from distil.integrations.strands import compressing_hook
+
+    fake = types.ModuleType("strands.hooks")
+    fake.BeforeModelInvocationEvent = type("E", (), {})
+    parent = types.ModuleType("strands")
+    parent.hooks = fake
+    sys.modules["strands"] = parent
+    sys.modules["strands.hooks"] = fake
+    try:
+        captured = {}
+
+        class Registry:
+            def add_callback(self, cls, fn):
+                captured["fn"] = fn
+
+        compressing_hook().register_hooks(Registry())
+        captured["fn"](type("Ev", (), {})())  # no .agent — must not raise
+    finally:
+        sys.modules.pop("strands.hooks", None)
+        sys.modules.pop("strands", None)
+
+
+def test_strands_passes_through_shapes_it_does_not_understand():
+    msgs = [
+        "not a dict",
+        {"role": "user", "content": 42},
+        {"role": "user", "content": [None, "bare string block"]},
+    ]
+    out = strands_compress(msgs)
+    assert out[0] == "not a dict"
+    assert out[1]["content"] == 42
+    assert out[2]["content"] == [None, "bare string block"]

--- a/tests/test_packaging_assets.py
+++ b/tests/test_packaging_assets.py
@@ -76,3 +76,59 @@ def test_chart_defaults_are_secure():
     )
     assert "runAsNonRoot: true" in v
     assert "readOnlyRootFilesystem: true" in v
+
+
+# --- README integrity ---------------------------------------------------------
+# A broken link in the README is a silent adoption tax: the reader assumes the
+# feature does not exist. These are cheap to check and impossible to remember.
+
+README = ROOT / "README.md"
+
+
+def _readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_readme_relative_links_all_resolve():
+    """Every relative link/image target must exist on disk."""
+    text = _readme()
+    targets = re.findall(r"\]\((?!https?:|#|mailto:)([^)\s]+)\)", text)
+    targets += re.findall(r'src="(?!https?:)([^"]+)"', text)
+    missing = sorted({t for t in targets if not (ROOT / t.split("#")[0]).exists()})
+    assert not missing, f"README links to files that do not exist: {missing}"
+
+
+def test_readme_internal_anchors_all_exist():
+    """Every #anchor must match a heading or an explicit id."""
+    text = _readme()
+
+    slugs = set()
+    for line in text.splitlines():
+        m = re.match(r"^#{1,6}\s+(.*)$", line)
+        if m:
+            title = re.sub(r"<[^>]+>", "", m.group(1))
+            # GitHub's slug algorithm: lowercase, drop punctuation (emoji
+            # included), then spaces -> hyphens. It does NOT strip first, so an
+            # emoji heading keeps a leading hyphen: "## 🚀 Use it now" -> "-use-it-now".
+            slug = re.sub(r"[^\w\s-]", "", title.lower()).replace(" ", "-")
+            slugs.add(slug)
+            slugs.add(slug.strip("-"))
+    slugs |= set(re.findall(r'id="([^"]+)"', text))
+
+    used = {a for a in re.findall(r"\]\(#([^)]+)\)", text)}
+    missing = sorted(used - slugs)
+    assert not missing, f"README anchors with no matching heading: {missing}"
+
+
+def test_readme_leads_with_capability_not_statistics():
+    """Positioning guard: 'What it does' must appear before the proof section.
+
+    The audit found the README opened with a non-inferiority claim and a
+    confidence interval — an answer to a question the reader has not asked yet.
+    Capability first, proof below the fold.
+    """
+    text = _readme()
+    assert "## What it does" in text
+    assert text.index("## What it does") < text.index("Why trust it"), (
+        "the proof section must sit below the capability section"
+    )

--- a/tests/test_packaging_assets.py
+++ b/tests/test_packaging_assets.py
@@ -1,0 +1,78 @@
+"""Shipped ops assets must stay consistent with the code.
+
+A Grafana panel or Prometheus alert referencing a metric distil does not emit is
+worse than no panel at all: it renders empty, or the alert never fires, and both
+read as "the system is fine". These tests fail at authoring time instead.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+DASHBOARD = ROOT / "packaging" / "grafana" / "distil-gateway-dashboard.json"
+CHART = ROOT / "packaging" / "helm" / "distil-gateway"
+RULES = CHART / "templates" / "prometheusrule.yaml"
+
+
+def _known_metrics() -> set[str]:
+    from distil.metrics import _SPEC
+
+    return {name for name, _kind, _help in _SPEC}
+
+
+def test_dashboard_is_valid_json_with_panels():
+    d = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+    assert d["uid"] == "distil-gateway"
+    assert d["panels"], "a dashboard with no panels is not a dashboard"
+
+
+def test_every_dashboard_metric_is_actually_emitted():
+    d = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+    exprs = [t["expr"] for p in d["panels"] for t in p.get("targets", [])]
+    used = {m for e in exprs for m in re.findall(r"distil_[a-z_]+", e)}
+    assert used, "no metrics referenced — the dashboard would be empty"
+    missing = used - _known_metrics()
+    assert not missing, f"dashboard references metrics distil does not emit: {sorted(missing)}"
+
+
+def test_every_alert_rule_metric_is_actually_emitted():
+    text = RULES.read_text(encoding="utf-8")
+    used = {m for m in re.findall(r"distil_[a-z_]+", text)}
+    missing = used - _known_metrics()
+    assert not missing, f"alert rules reference metrics distil does not emit: {sorted(missing)}"
+
+
+def test_helm_chart_has_the_files_helm_requires():
+    assert (CHART / "Chart.yaml").is_file()
+    assert (CHART / "values.yaml").is_file()
+    assert (CHART / "templates" / "deployment.yaml").is_file()
+
+
+@pytest.mark.parametrize(
+    "template",
+    sorted(p.name for p in (CHART / "templates").glob("*.yaml")),
+)
+def test_templates_reference_only_defined_helpers(template):
+    """Every `include` must name a helper that _helpers.tpl actually defines."""
+    helpers = (CHART / "templates" / "_helpers.tpl").read_text(encoding="utf-8")
+    defined = set(re.findall(r'define\s+"([^"]+)"', helpers))
+    body = (CHART / "templates" / template).read_text(encoding="utf-8")
+    used = set(re.findall(r'include\s+"([^"]+)"', body))
+    missing = used - defined
+    assert not missing, f"{template} includes undefined helper(s): {sorted(missing)}"
+
+
+def test_chart_defaults_are_secure():
+    """The chart must not ship a permissive default that a reviewer has to catch."""
+    v = (CHART / "values.yaml").read_text(encoding="utf-8")
+    assert "requireKeys: true" in v, "an in-cluster gateway must require credentials"
+    assert "trustTenantHeader: false" in v, (
+        "trusting a client tenant header lets any client bill another"
+    )
+    assert "runAsNonRoot: true" in v
+    assert "readOnlyRootFilesystem: true" in v

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -1,0 +1,131 @@
+"""The settings.json precedence trap.
+
+Regression suite for a total-outage class observed three times in one day: a base
+URL pinned in `~/.claude/settings.json` outranks the environment `distil wrap`
+exports. When that pinned port is dead, EVERY session fails with
+`ConnectionRefused` — an error that names the provider, not distil.
+
+The contract these tests pin:
+  * a dead pinned URL is fatal (wrap must refuse, not start into a broken config)
+  * a live pinned URL is a warning (wrap works, but its proxy sees no traffic)
+  * a pin that names the wrap's own URL is not a conflict at all
+  * project-scoped settings outrank user-scoped ones
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+
+import pytest
+
+from distil.precedence import check_claude_settings, settings_candidates
+
+
+@pytest.fixture
+def live_port():
+    """A real listening socket, so 'reachable' is measured rather than mocked.
+
+    No accept loop is needed: a connect() succeeds into the listen backlog, which
+    is exactly the signal `_reachable` is asking for ("is anything bound here").
+    """
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(5)
+    try:
+        yield srv.getsockname()[1]
+    finally:
+        srv.close()
+
+
+def _dead_port() -> int:
+    """A port with nothing on it — bind then immediately release."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _write_settings(path, url: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": url}}), encoding="utf-8")
+
+
+def test_dead_pinned_url_is_fatal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("DISTIL_IGNORE_SETTINGS_PRECEDENCE", raising=False)
+    url = f"http://127.0.0.1:{_dead_port()}"
+    _write_settings(tmp_path / ".claude" / "settings.json", url)
+
+    c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
+    assert c is not None
+    assert c.fatal, "a pin at a dead port is a guaranteed outage, not a warning"
+    assert "NOT accepting connections" in c.message()
+    assert "distil offboard" in c.message(), "must name the fix, not just the fault"
+
+
+def test_live_pinned_url_warns_but_is_not_fatal(tmp_path, monkeypatch, live_port):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_settings(tmp_path / ".claude" / "settings.json", f"http://127.0.0.1:{live_port}")
+
+    c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
+    assert c is not None and not c.fatal
+    assert "no traffic" in c.message()
+
+
+def test_pin_naming_our_own_wrap_url_is_not_a_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    url = "http://127.0.0.1:61956"
+    _write_settings(tmp_path / ".claude" / "settings.json", url)
+    assert check_claude_settings("ANTHROPIC_BASE_URL", url, cwd=tmp_path) is None
+    # trailing-slash difference must not read as a different endpoint
+    assert check_claude_settings("ANTHROPIC_BASE_URL", url + "/", cwd=tmp_path) is None
+
+
+def test_no_settings_file_means_no_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
+
+
+def test_project_settings_outrank_user_settings(tmp_path, monkeypatch):
+    """The effective value is the highest-precedence one, and that is what we report."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / "proj"
+    _write_settings(tmp_path / ".claude" / "settings.json", "http://127.0.0.1:8788")
+    _write_settings(project / ".claude" / "settings.local.json", "http://127.0.0.1:9999")
+
+    c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=project)
+    assert c is not None
+    assert c.value == "http://127.0.0.1:9999", "project-local must win"
+    assert c.path.name == "settings.local.json"
+
+
+def test_escape_hatch_disables_the_check(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DISTIL_IGNORE_SETTINGS_PRECEDENCE", "1")
+    _write_settings(tmp_path / ".claude" / "settings.json", f"http://127.0.0.1:{_dead_port()}")
+    assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
+
+
+def test_remote_urls_are_never_probed(tmp_path, monkeypatch):
+    """Probing an arbitrary remote at every wrap start is latency and looks like scanning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_settings(tmp_path / ".claude" / "settings.json", "https://gateway.corp.example:9443")
+    c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
+    assert c is not None and not c.fatal, "non-loopback is assumed reachable"
+
+
+def test_malformed_settings_never_crash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = tmp_path / ".claude" / "settings.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    for junk in ("{not json", "[]", '{"env": "a string"}', '{"env": {"OTHER": "x"}}'):
+        p.write_text(junk, encoding="utf-8")
+        assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
+
+
+def test_candidate_order_is_ascending_precedence(tmp_path):
+    paths = settings_candidates(tmp_path)
+    assert paths[-1].name == "settings.local.json"
+    assert ".claude" in str(paths[-1])

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -129,3 +129,25 @@ def test_candidate_order_is_ascending_precedence(tmp_path):
     paths = settings_candidates(tmp_path)
     assert paths[-1].name == "settings.local.json"
     assert ".claude" in str(paths[-1])
+
+
+def test_unparseable_url_is_not_treated_as_dead(tmp_path, monkeypatch):
+    """A URL we cannot parse is not ours to block on — fail open, not closed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_settings(tmp_path / ".claude" / "settings.json", "http://[not-a-url")
+    c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
+    assert c is not None and not c.fatal
+
+
+def test_a_blank_setting_is_not_a_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_settings(tmp_path / ".claude" / "settings.json", "   ")
+    assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
+
+
+def test_a_non_object_settings_file_is_ignored(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = tmp_path / ".claude" / "settings.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text('"just a string"', encoding="utf-8")
+    assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None

--- a/tests/test_precedence.py
+++ b/tests/test_precedence.py
@@ -54,6 +54,7 @@ def _write_settings(path, url: str) -> None:
 
 def test_dead_pinned_url_is_fatal(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("DISTIL_IGNORE_SETTINGS_PRECEDENCE", raising=False)
     url = f"http://127.0.0.1:{_dead_port()}"
     _write_settings(tmp_path / ".claude" / "settings.json", url)
@@ -67,6 +68,7 @@ def test_dead_pinned_url_is_fatal(tmp_path, monkeypatch):
 
 def test_live_pinned_url_warns_but_is_not_fatal(tmp_path, monkeypatch, live_port):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     _write_settings(tmp_path / ".claude" / "settings.json", f"http://127.0.0.1:{live_port}")
 
     c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
@@ -76,6 +78,7 @@ def test_live_pinned_url_warns_but_is_not_fatal(tmp_path, monkeypatch, live_port
 
 def test_pin_naming_our_own_wrap_url_is_not_a_conflict(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     url = "http://127.0.0.1:61956"
     _write_settings(tmp_path / ".claude" / "settings.json", url)
     assert check_claude_settings("ANTHROPIC_BASE_URL", url, cwd=tmp_path) is None
@@ -85,12 +88,14 @@ def test_pin_naming_our_own_wrap_url_is_not_a_conflict(tmp_path, monkeypatch):
 
 def test_no_settings_file_means_no_conflict(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
 
 
 def test_project_settings_outrank_user_settings(tmp_path, monkeypatch):
     """The effective value is the highest-precedence one, and that is what we report."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     project = tmp_path / "proj"
     _write_settings(tmp_path / ".claude" / "settings.json", "http://127.0.0.1:8788")
     _write_settings(project / ".claude" / "settings.local.json", "http://127.0.0.1:9999")
@@ -103,6 +108,7 @@ def test_project_settings_outrank_user_settings(tmp_path, monkeypatch):
 
 def test_escape_hatch_disables_the_check(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("DISTIL_IGNORE_SETTINGS_PRECEDENCE", "1")
     _write_settings(tmp_path / ".claude" / "settings.json", f"http://127.0.0.1:{_dead_port()}")
     assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
@@ -111,6 +117,7 @@ def test_escape_hatch_disables_the_check(tmp_path, monkeypatch):
 def test_remote_urls_are_never_probed(tmp_path, monkeypatch):
     """Probing an arbitrary remote at every wrap start is latency and looks like scanning."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     _write_settings(tmp_path / ".claude" / "settings.json", "https://gateway.corp.example:9443")
     c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
     assert c is not None and not c.fatal, "non-loopback is assumed reachable"
@@ -118,6 +125,7 @@ def test_remote_urls_are_never_probed(tmp_path, monkeypatch):
 
 def test_malformed_settings_never_crash(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     p = tmp_path / ".claude" / "settings.json"
     p.parent.mkdir(parents=True, exist_ok=True)
     for junk in ("{not json", "[]", '{"env": "a string"}', '{"env": {"OTHER": "x"}}'):
@@ -134,6 +142,7 @@ def test_candidate_order_is_ascending_precedence(tmp_path):
 def test_unparseable_url_is_not_treated_as_dead(tmp_path, monkeypatch):
     """A URL we cannot parse is not ours to block on — fail open, not closed."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     _write_settings(tmp_path / ".claude" / "settings.json", "http://[not-a-url")
     c = check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path)
     assert c is not None and not c.fatal
@@ -141,12 +150,14 @@ def test_unparseable_url_is_not_treated_as_dead(tmp_path, monkeypatch):
 
 def test_a_blank_setting_is_not_a_conflict(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     _write_settings(tmp_path / ".claude" / "settings.json", "   ")
     assert check_claude_settings("ANTHROPIC_BASE_URL", cwd=tmp_path) is None
 
 
 def test_a_non_object_settings_file_is_ignored(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     p = tmp_path / ".claude" / "settings.json"
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text('"just a string"', encoding="utf-8")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -223,3 +223,38 @@ def test_webdash_payload_carries_a_non_broken_label(tmp_path, monkeypatch) -> No
 
     # The label the browser receives for a real-but-tiny saving must not read as 0.
     assert pct_smaller_label(0.004) == "<1% smaller"
+
+
+def test_pydantic_v1_style_copy_is_supported() -> None:
+    """LangChain pinned to pydantic v1 exposes .copy(update=...), not .model_copy."""
+
+    class V1Msg:
+        def __init__(self, role: str, content: str) -> None:
+            self.role, self.content = role, content
+
+        def copy(self, *, update):
+            return V1Msg(self.role, str(update.get("content", self.content)))
+
+    out = compress_messages([V1Msg("tool", BIG_LOG)]).messages
+    assert isinstance(out[0], V1Msg)
+    assert len(out[0].content) < len(BIG_LOG)
+
+
+def test_an_immutable_message_is_left_alone_rather_than_corrupted() -> None:
+    """No known copy protocol: return the original rather than guess at a rewrite."""
+
+    class Frozen:
+        __slots__ = ("role", "content")
+
+        def __init__(self):
+            self.role, self.content = "tool", BIG_LOG
+
+    msg = Frozen()
+    out = compress_messages([msg]).messages
+    assert out[0] is msg, "unknown shapes must pass through untouched"
+
+
+def test_type_content_key_is_honoured_like_role() -> None:
+    """LangChain messages carry `.type`, not `.role`."""
+    out = compress_messages([{"type": "assistant", "content": BIG_LOG}]).messages
+    assert out[0]["content"] == BIG_LOG, "assistant detected via `type` must not be rewritten"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,225 @@
+"""The public library API: `from distil import compress_messages, expand_handle`.
+
+This is the surface third parties depend on, so it is tested as a *contract*:
+lazy import stays lazy, input is never mutated, non-text passes through, the
+model's own turns are never rewritten, and every handle round-trips byte-exactly.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+import distil
+from distil import CompressionResult, compress_messages, expand_handle
+
+# A tool result big and repetitive enough to be worth digesting.
+BIG_LOG = (
+    "\n".join(
+        f"2026-08-07T12:{i:02d}:00Z INFO  worker.pool  heartbeat ok seq={i} latency_ms=12"
+        for i in range(400)
+    )
+    + "\nFATAL  worker.pool  pool exhausted after 400 heartbeats\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Give every test its own restore store.
+
+    These tests write digest originals to disk and read them back. Sharing
+    DISTIL_HOME with the rest of the suite makes them order-dependent: another
+    test's TTL sweep or purge can delete a handle between compress and expand.
+    Isolation is what makes the round-trip assertion mean what it says.
+    """
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+
+
+def _msgs() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Why did the worker pool die?"},
+        {"role": "tool", "content": BIG_LOG},
+    ]
+
+
+def test_import_distil_does_not_pull_the_compression_stack() -> None:
+    """`import distil` must stay cheap — the CLI does it on every --version."""
+    code = "import sys, distil; print('distil.adapters.anthropic' in sys.modules)"
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert out.stdout.strip() == "False"
+
+
+def test_lazy_export_resolves_and_unknown_attr_raises() -> None:
+    assert distil.compress_messages is compress_messages
+    assert "compress_messages" in dir(distil)
+    try:
+        _ = distil.no_such_thing  # type: ignore[attr-defined]
+    except AttributeError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected AttributeError for unknown attribute")
+
+
+def test_compress_returns_result_and_saves_tokens() -> None:
+    r = compress_messages(_msgs())
+    assert isinstance(r, CompressionResult)
+    assert r.tokens_before > 0
+    assert r.tokens_after < r.tokens_before, "a 400-line log should compress"
+    assert r.tokens_saved == r.tokens_before - r.tokens_after
+    assert 0 < r.saved_pct <= 100
+
+
+def test_input_list_is_never_mutated() -> None:
+    original = _msgs()
+    snapshot = json.dumps(original)
+    compress_messages(original)
+    assert json.dumps(original) == snapshot
+
+
+def test_assistant_turns_are_never_rewritten() -> None:
+    msgs = [{"role": "assistant", "content": BIG_LOG}]
+    out = compress_messages(msgs).messages
+    assert out[0]["content"] == BIG_LOG
+    assert out[0] is msgs[0], "unchanged messages should pass through by identity"
+
+
+def test_non_string_content_passes_through() -> None:
+    blocks = [{"type": "image", "source": {"data": "..."}}]
+    msgs = [{"role": "user", "content": blocks}]
+    out = compress_messages(msgs).messages
+    assert out[0]["content"] is blocks
+
+
+def test_every_handle_round_trips_byte_exactly() -> None:
+    r = compress_messages(_msgs())
+    assert r.handles, "a digested 400-line log should produce at least one handle"
+    for h in r.handles:
+        restored = expand_handle(h)
+        assert restored is not None, f"handle {h} did not resolve"
+        assert restored in BIG_LOG or BIG_LOG in restored
+
+
+def test_expand_of_unknown_handle_returns_none_not_raises() -> None:
+    assert expand_handle("deadbeef") is None
+    assert expand_handle("not-a-handle") is None
+
+
+def test_verbatim_mode_creates_no_handles() -> None:
+    r = compress_messages(_msgs(), verbatim=True)
+    assert r.handles == []
+
+
+def test_duck_typed_objects_work_without_a_framework() -> None:
+    class Msg:  # mimics a LangChain BaseMessage closely enough
+        def __init__(self, role: str, content: str) -> None:
+            self.role, self.content = role, content
+
+        def model_copy(self, *, update: dict[str, object]) -> "Msg":
+            return Msg(self.role, str(update.get("content", self.content)))
+
+    out = compress_messages([Msg("tool", BIG_LOG)]).messages
+    assert isinstance(out[0], Msg)
+    assert len(out[0].content) < len(BIG_LOG)
+
+
+def test_empty_input_is_safe() -> None:
+    r = compress_messages([])
+    assert r.messages == [] and r.tokens_before == 0 and r.saved_pct == 0.0
+
+
+# --- T0.1: first-run honesty -------------------------------------------------
+# `▼413 · 0% smaller` is a real number next to a zero. It reads as broken, and it
+# is the most likely first-run uninstall trigger for traffic that legitimately
+# compresses to very little.
+
+
+def test_sub_one_percent_never_renders_as_zero() -> None:
+    from distil.ledger import pct_smaller_label
+
+    assert pct_smaller_label(0.004) == "<1% smaller"  # the reported ▼413 case
+    assert pct_smaller_label(0.0001) == "<1% smaller"
+
+
+def test_real_percentages_are_unchanged() -> None:
+    from distil.ledger import pct_smaller_label
+
+    assert pct_smaller_label(0.62) == "62% smaller"
+    assert pct_smaller_label(0.015) == "2% smaller"
+    assert pct_smaller_label(0.0) == "0% smaller"
+
+
+def test_no_public_export_collides_with_any_submodule() -> None:
+    """No name in `distil.__all__` may match a submodule of `distil`.
+
+    Python binds a submodule onto its parent package the moment anything imports
+    it, silently overwriting a same-named PEP-562 `__getattr__` export. Such a name
+    resolves to the function in a fresh interpreter and to the MODULE in any program
+    that happened to import the submodule — the same import yielding two different
+    objects depending on unrelated import order.
+
+    This bit twice: `compress` (distil/compress/) and `expand` (distil/expand.py),
+    the second only under a full-suite run where an earlier test had imported the
+    module. Enumerating submodules catches the next one at authoring time.
+    """
+    import pkgutil
+
+    import distil as pkg
+
+    submodules = {m.name for m in pkgutil.iter_modules(pkg.__path__)}
+    clashes = sorted(set(pkg.__all__) & submodules)
+    assert not clashes, (
+        f"public export(s) {clashes} shadow submodule(s) of the same name; "
+        f"rename the export (e.g. compress -> compress_messages)"
+    )
+
+
+def test_public_exports_survive_their_submodules_being_imported() -> None:
+    """The exports must still be callable after the neighbouring modules load."""
+    import importlib
+    import types
+
+    importlib.import_module("distil.compress.tier1")
+    importlib.import_module("distil.expand")
+
+    assert isinstance(distil.compress, types.ModuleType)
+    assert isinstance(distil.expand, types.ModuleType)
+    assert callable(distil.compress_messages)
+    assert callable(distil.expand_handle)
+
+
+def test_every_percentage_surface_uses_one_rule() -> None:
+    """All four render sites must agree — this bug was fixed three times before
+    the web dashboard was noticed.
+
+    Sites: the Claude Code status line (cli), the terminal dashboard and the HTML
+    session card (ledger), and the browser dashboard (webdash, via a preformatted
+    `pct_label` so the JS cannot re-derive a rounded "0.0%").
+    """
+    import inspect
+
+    from distil import cli, ledger, webdash
+
+    for mod in (cli, ledger):
+        src = inspect.getsource(mod)
+        # Python surfaces must all route through the one helper.
+        assert '% smaller"' not in src or "pct_smaller_label" in src, (
+            f"{mod.__name__} formats a savings percentage without the shared helper"
+        )
+
+    # The browser dashboard cannot import Python, so it mirrors the rule in JS —
+    # and must derive it from the raw counts, because the rounded `pct` collapses
+    # a real-but-tiny saving to 0.0 before the browser ever sees it.
+    js = inspect.getsource(webdash)
+    assert "function pctLabel(" in js, "webdash must mirror the <1% rule"
+    assert 'd.pct+"%"' not in js, "webdash must not render the rounded pct directly"
+
+
+def test_webdash_payload_carries_a_non_broken_label(tmp_path, monkeypatch) -> None:
+    from distil.ledger import pct_smaller_label
+
+    # The label the browser receives for a real-but-tiny saving must not read as 0.
+    assert pct_smaller_label(0.004) == "<1% smaller"

--- a/tests/test_svg_assets.py
+++ b/tests/test_svg_assets.py
@@ -22,7 +22,16 @@ ASSETS = sorted((Path(__file__).resolve().parent.parent / "docs" / "assets").glo
 # Static on purpose. A favicon that moves is a bug, and every social platform renders
 # an OpenGraph card as a still image — animating it buys nothing and risks the frame a
 # scraper happens to capture being a half-drawn one.
-INTENTIONALLY_STATIC = {"logo.svg", "logo-lockup.svg", "og.svg"}
+INTENTIONALLY_STATIC = {
+    "logo.svg",
+    "logo-lockup.svg",
+    "og.svg",
+    # A structural map of the four entry points and which compression tier each
+    # reaches. Nothing about it happens over time — the reader compares boxes,
+    # and motion would only pull the eye along one path as if it were the
+    # recommended one. The other diagrams animate because they show a *process*.
+    "integration-surface.svg",
+}
 
 # The OpenGraph card is never in a reading order. It is fetched by scrapers and rendered
 # as a preview thumbnail beside link text that already says what the page is, so a name

--- a/tests/test_ts_conformance.py
+++ b/tests/test_ts_conformance.py
@@ -77,11 +77,16 @@ def _node(fn: str, payload: str) -> str:
         f"const r=t.{fn}(a);"
         "process.stdout.write(JSON.stringify(r===undefined?null:r));});"
     )
+    # encoding is explicit: `text=True` alone decodes with the locale codec, which
+    # on Windows is cp1252. Node writes UTF-8, so the default silently mangles any
+    # non-ASCII byte and the conformance assertion then fails on mojibake rather
+    # than on a real divergence.
     out = subprocess.run(
         ["node", "-e", script],
         input=json.dumps(payload),
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=30,
     )
     assert out.returncode == 0, f"node failed: {out.stderr}"

--- a/tests/test_ts_conformance.py
+++ b/tests/test_ts_conformance.py
@@ -1,0 +1,171 @@
+"""Python ↔ TypeScript conformance for Tier-0.
+
+distil's value is a decision-equivalence certificate measured against the PYTHON
+compressor. A JS port that merely compresses "similarly" would hand users a
+guarantee that does not describe the code they run.
+
+So the JS port must produce **byte-identical** output, and this is the gate that
+proves it. Both implementations run over one shared corpus; any divergence fails.
+Where the JS side cannot match Python byte-for-byte (integral floats render as
+"1.0" in Python and "1" in JS, and JS objects hoist integer-like keys), it is
+required to DECLINE the transform rather than emit uncertified output — that is
+also checked here, so "declines" cannot quietly become "does nothing at all".
+
+Skipped when node is unavailable; CI has it.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from distil.adapters.anthropic import _apply_tier0
+from distil.compress.tier0 import collapse_runs, minify_json
+from distil.tokenizer import DEFAULT as _tokenizer
+
+TIER0_JS = Path(__file__).resolve().parent.parent / "packaging" / "npm" / "lib" / "tier0.js"
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+
+
+# One corpus, exercised by every test below. Chosen to hit the real transforms
+# and the declared divergences, not to flatter either implementation.
+CORPUS: dict[str, str] = {
+    "plain_run": "alpha\nalpha\nalpha\nbeta\n",
+    "single_line": "just one line\n",
+    "no_trailing_newline": "a\na\na",
+    "long_log_run": "ERROR failed to connect\n" * 50 + "done\n",
+    "mixed_runs": "x\nx\ny\nz\nz\nz\nz\n",
+    "run_marker_lookalike": "<<x3>>\n<<x3>>\n<<x3>>\nreal\n",
+    "empty": "",
+    "whitespace_only": "   \n   \n   \n",
+    "blank_lines": "\n\n\n\n\n",
+    "unicode": "héllo wörld ✓\nhéllo wörld ✓\n",
+    "json_simple": '{"b": 1, "a": 2}',
+    "json_nested": '{"outer": {"inner": [1, 2, 3], "s": "x"}}',
+    "json_array": "[1, 2, 3]",
+    "json_strings": '{"msg": "line1\\nline2", "esc": "quote\\" here"}',
+    "json_unicode": '{"k": "héllo ✓"}',
+    "json_not_json": "{this is not json}",
+    "json_partial": '{"a": 1',
+    "json_with_run": '{"a": 1}\n{"a": 1}\n{"a": 1}\n',
+    "tool_output": "\n".join(f"file_{i}.py: ok" for i in range(30)),
+    "stack_trace": ('  File "x.py", line 1\n' * 12) + "ValueError: boom\n",
+}
+
+# Inputs where the JS side is REQUIRED to decline JSON minification because it
+# cannot reproduce Python's bytes. Each names the reason.
+MUST_DECLINE_JSON = {
+    "integral_float": '{"a": 1.0}',
+    "integral_float_nested": '{"a": [2.0, 3.5]}',
+    "exponent": '{"a": 1e5}',
+    "integer_like_key": '{"2": "b", "1": "a"}',
+    "duplicate_key": '{"a": 1, "a": 2}',
+}
+
+
+def _node(fn: str, payload: str) -> str:
+    """Call one exported function in tier0.js with a single string argument."""
+    script = (
+        f"const t=require({json.dumps(str(TIER0_JS))});"
+        "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{"
+        "const a=JSON.parse(d);"
+        f"const r=t.{fn}(a);"
+        "process.stdout.write(JSON.stringify(r===undefined?null:r));});"
+    )
+    out = subprocess.run(
+        ["node", "-e", script],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, f"node failed: {out.stderr}"
+    return json.loads(out.stdout)
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_collapse_runs_is_byte_identical(name):
+    text = CORPUS[name]
+    assert _node("collapseRuns", text) == collapse_runs(text), f"collapseRuns diverged on {name!r}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_apply_tier0_is_byte_identical(name):
+    """The full production path, including reject-if-bigger by token count."""
+    text = CORPUS[name]
+    assert _node("applyTier0", text) == _apply_tier0(text), f"applyTier0 diverged on {name!r}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_token_counts_agree(name):
+    """The port's reject-if-bigger decision depends on matching Python's count.
+
+    Python's round() is round-half-to-even and JS's Math.round is round-half-up,
+    so a naive port silently disagrees at specific lengths and then makes a
+    different keep/discard call.
+    """
+    text = CORPUS[name]
+    assert _node("countTokens", text) == _tokenizer.count(text), f"token count diverged on {name!r}"
+
+
+# expandRuns is a textual inverse, and no textual inverse can separate a
+# GENERATED "<<xN>>" marker from original content that looks like one. Inputs
+# containing such lookalikes are excluded here and covered by the safety test
+# below instead — which asserts the property that actually protects data:
+# collapseRuns refuses to collapse them at all.
+_MARKER_LOOKALIKE = {"run_marker_lookalike"}
+
+
+@pytest.mark.parametrize("name", sorted(set(CORPUS) - _MARKER_LOOKALIKE))
+def test_collapse_runs_round_trips_in_js(name):
+    """Reversibility must hold in the port, not only in Python."""
+    text = CORPUS[name]
+    collapsed = _node("collapseRuns", text)
+    assert _node("expandRuns", collapsed) == text, f"JS collapse/expand lost bytes on {name!r}"
+
+
+def test_runs_of_marker_lookalikes_are_never_collapsed():
+    """The real safety property, in both implementations.
+
+    Collapsing a run of lines that already look like markers would make the
+    generated marker indistinguishable from original content. Both sides must
+    leave such input byte-exact rather than produce something unrecoverable.
+    """
+    text = CORPUS["run_marker_lookalike"]
+    assert collapse_runs(text) == text, "python collapsed a marker lookalike"
+    assert _node("collapseRuns", text) == text, "js collapsed a marker lookalike"
+
+
+@pytest.mark.parametrize("name", sorted(MUST_DECLINE_JSON))
+def test_js_declines_json_it_cannot_reproduce(name):
+    """Declining is the contract; emitting different bytes is the bug."""
+    text = MUST_DECLINE_JSON[name]
+    assert _node("minifyJson", text) is None, (
+        f"JS minified {name!r} instead of declining — output would be uncertified"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(MUST_DECLINE_JSON))
+def test_declining_still_returns_the_input_unharmed(name):
+    """A decline must fall through to byte-exact text, not to empty output."""
+    text = MUST_DECLINE_JSON[name]
+    out = _node("applyTier0", text)
+    assert out == text, f"declined input was altered: {out!r}"
+
+
+def test_js_actually_minifies_the_safe_cases():
+    """Guard against 'conformance' achieved by declining everything."""
+    assert _node("minifyJson", '{"b": 1, "a": 2}') == '{"b":1,"a":2}'
+    assert _node("minifyJson", "[1, 2, 3]") == "[1,2,3]"
+    assert _node("minifyJson", '{"b": 1, "a": 2}') == minify_json('{"b": 1, "a": 2}')
+
+
+def test_corpus_actually_exercises_compression():
+    """A corpus where nothing compresses would make every assertion vacuous."""
+    changed = [n for n, t in CORPUS.items() if _apply_tier0(t) != t]
+    assert len(changed) >= 6, f"only {len(changed)} corpus entries compress at all"


### PR DESCRIPTION
Closes the gaps from an end-to-end adoption/competitive audit, plus a **P1 outage class found on real traffic today**.

## P1 — settings.json precedence trap

A base URL in `~/.claude/settings.json` **outranks** the environment `distil wrap` exports. With the always-on service not running, every session on the machine failed with `API Error: Unable to connect (ConnectionRefused)` — an error naming the *provider*, not distil. Observed three times in one day.

`distil wrap` now refuses to start into that configuration and names the fix; a live-but-different pin warns instead. The end-of-session warning no longer guesses `agent update?` when it can verify the real cause.

**Release impact:** per `RELEASING.md` a P1 means **rc2 and a restarted soak clock** — 1.41.2 final cannot be cut on the original 2026-08-10 date.

## What else is here

| | |
|---|---|
| **T1.1** | `from distil import compress_messages, expand_handle` — distil could not previously be embedded as a dependency at all |
| **T0.1** | Sub-1% savings render `<1% smaller`, not a broken-looking `0%`, across all four surfaces |
| **T0.2** | `doctor` no longer reports a routing proxy as bypassed when it merely saved nothing |
| **T0.3** | README leads with capability; proof moved below the fold |
| **T1.3/1.4** | `opencode` + `qwen` presets; Agno + Strands integrations; IDE-agent doc |
| **T2.1/2.6** | Helm chart, alert rules, Grafana dashboard, `distil_requests_rejected_total` |
| **T2.3** | OIDC + RBAC on the gateway |
| **T2.4** | `SECURITY.md` (was missing) + security whitepaper + `docs/ENTERPRISE.md` |

## Naming note

The public API is `compress_messages`/`expand_handle`, not `compress`/`expand`: `distil.compress` and `distil.expand` are **modules**. A top-level export sharing those names resolves to the function in a fresh interpreter and to the module in any program that touched the submodule. A test now enumerates submodules and fails on any future collision.

## Verification

- **3007 tests passing** (was 2924), ruff + format clean at the pinned CI version
- `distil bench` — **GATE: PASS**, every trajectory certified non-inferior
- New e2e suite drives real sockets and files (compression → billing → receipt-chain verification → cross-process handle recovery → wrap refusal), because unit tests stayed green through all three outages
- OIDC tested adversarially: `alg:none`, tampered payload, wrong secret, alg-confusion, expired, issuer/audience mismatch — plus live-gateway tests proving a viewer role actually gets 403

## Not in this PR

Native TypeScript library (T1.2) is not started. Discord, the external beta, upstream integration PRs, SOC 2, and any SLA are human/company actions, not code.