### PR TITLE
release(1.41.2rc2): bundle adoption + enterprise work into one soak

### DIFF
--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.41.2-rc.1",
+  "version": "1.41.2-rc.2",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.41.2rc1",
+  "version": "1.41.2rc2",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.41.2rc1"
+version = "1.41.2rc2"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.41.2rc1",
+  "version": "1.41.2rc2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.41.2rc1",
+      "version": "1.41.2rc2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version surfaces only — `pyproject.toml`, `plugin.json`, `server.json`, `packaging/npm/package.json`. `CITATION.cff` stays at 1.41.1 until the final, matching how rc1 was cut.

**Why rc2 rather than soaking rc1 to a final:** rc1 has a known P1 (the settings.json precedence outage, three occurrences on one machine in a day). Per `RELEASING.md` a P1 means a new rc and a restarted clock, so soaking rc1 could never produce a final. Rather than soak the fix and then soak the adoption + enterprise work separately, both go into one rc and soak once.

The `[1.41.2]` CHANGELOG entry — which the rc soaks for — was extended in #97.

Preflight already green locally: 3118 tests, and a clean wheel install of 1.41.2rc2 runs `distil bench`.