### PR TITLE
Adoption round 2: goose, AI SDK middleware, executable claims audit, community surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something distil did that it should not have, or did not do that it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **If the agent could not reach the API at all**, run `distil doctor` first
+        and paste its output — a base URL pinned in your agent's settings file
+        outranks the one `distil wrap` sets, and that is the most common cause.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you ran, what you expected, what you got. Exact commands beat description.
+      placeholder: |
+        $ distil wrap -- claude
+        expected: … 
+        got: …
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`distil doctor` output"
+      description: Redact anything you consider sensitive; it prints no content by design.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "`distil --version`"
+      placeholder: "1.41.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is it installed
+      options: [pipx, uv / uvx, pip in a venv, Homebrew, Docker, npm / npx, from source]
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options: [macOS, Linux, Windows]
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent
+      options: [Claude Code, Codex, Gemini CLI, aider, OpenCode, Qwen Code, goose, SDK / library, gateway, other]
+  - type: checkboxes
+    id: confirms
+    attributes:
+      label: Before submitting
+      options:
+        - label: I am on the latest version (`pipx upgrade distil-llm`), or I have said which version above and why
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/dshakes/distil/security/advisories/new
+    about: Report privately. Please do not open a public issue for a suspected vulnerability.
+  - name: Question or idea
+    url: https://github.com/dshakes/distil/issues/new
+    about: Every question is a docs gap we have not closed yet — ask it as a normal issue.

--- a/.github/ISSUE_TEMPLATE/quality_report.yml
+++ b/.github/ISSUE_TEMPLATE/quality_report.yml
@@ -1,0 +1,40 @@
+name: Compression quality report
+description: A digest lost something it should have kept, or an agent behaved differently under compression
+labels: ["quality", "certificate"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **This is the most valuable kind of report this project receives.** The
+        whole claim is decision-equivalence, so a case where it does not hold is
+        evidence — including one that contradicts our own published numbers.
+
+        Please do **not** file it as a security issue; it is a normal bug with a
+        higher priority.
+  - type: textarea
+    id: what_was_lost
+    attributes:
+      label: What was lost or changed
+      description: The fact, line, or value the agent needed and did not have.
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Compression mode
+      options: [expand, digest (default), lossless-only / safe, verbatim, "not sure"]
+    validations:
+      required: true
+  - type: textarea
+    id: shadow
+    attributes:
+      label: "`distil shadow-stats` output, if you have it"
+      description: |
+        Live decision-equivalence on YOUR traffic outranks anything in this
+        repository — including a result that makes us look bad.
+      render: shell
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: A trajectory, a tool output, or a `distil dissect` report. Content-free is fine.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Code of Conduct
+
+## The short version
+
+Be decent. Argue about code, not people. Assume the person you are replying to is
+competent and acting in good faith until they prove otherwise.
+
+## Why this file is short
+
+Distil's contribution bar is unusually mechanical: **a new compression strategy
+must pass `make gate`** — non-inferior on every domain, byte-reversible — and no
+green gate means no merge. That removes most of what community conflict is
+usually about, because "is this good?" is answered by evidence rather than by
+whoever argues longest.
+
+What is left is ordinary human conduct, and the rules are the ones you would
+expect.
+
+## Expected behaviour
+
+- Critique the work, and be specific. "This breaks reversibility on inputs with
+  a `<<xN>>` lookalike" is useful. "This is bad" is not.
+- Accept that a maintainer may decline a change that passes the gate. Scope is a
+  judgment call, and "it works" is not the same as "it belongs".
+- When you are wrong, say so plainly and move on. Nobody needs the ceremony.
+- Report what actually happened. A benchmark you did not run, a test you did not
+  see pass, a claim you have not checked — say which, and label it.
+
+## Unacceptable behaviour
+
+- Personal attacks, harassment, or discriminatory language of any kind.
+- Publishing someone's private information.
+- Sustained disruption of discussions or reviews.
+- Sockpuppeting, or manufacturing consensus.
+- Deliberately misrepresenting benchmark results or the certificate's scope. This
+  project's value is that its numbers can be trusted; faking one is not a
+  technical disagreement, it is a breach of the thing being built.
+
+## Scope
+
+Applies in the issue tracker, pull requests, discussions, and any space where you
+are representing the project.
+
+## Enforcement
+
+Report to the maintainer through [private vulnerability
+reporting](https://github.com/dshakes/distil/security/advisories/new) (it works
+for conduct reports too and keeps the thread private) or by opening an issue if
+the matter is not sensitive.
+
+Reports are read by the maintainer. Responses range from a private word to a
+permanent ban, proportional to the behaviour and its history. There is no formal
+appeals process — this is a small project, not an institution, and pretending
+otherwise would be theatre.
+
+## Attribution
+
+Adapted in spirit from the [Contributor Covenant](https://www.contributor-covenant.org),
+rewritten to say what this project actually does rather than to fill a template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,25 @@ Publishing (no token anywhere). `./scripts/release.sh` drives it end to end.
 Landed a PR? Add yourself to [`CONTRIBUTORS.md`](CONTRIBUTORS.md) in the same PR —
 one line, newest last. Every merged contribution earns a spot.
 
+## Good first issues
+
+Issues labelled [`good first issue`](https://github.com/dshakes/distil/labels/good%20first%20issue)
+are scoped so the gate can tell you whether you got it right. If none are open,
+these are always welcome and always in scope:
+
+| | Why it is a good first change |
+|---|---|
+| **A new `wrap` preset** | One line in `distil/onboard.py:AGENT_PRESETS` plus the doc comment. The bar is a **published** env-var contract — a guessed variable ships a wrap that reports success and routes nothing, which is worse than no preset. Cursor/Copilot/Cline are excluded for exactly this reason; see `docs/IDE-AGENTS.md`. |
+| **A framework integration** | Copy `distil/integrations/agno.py`. The rule: duck-typed, never import the framework, so distil stays zero-dependency and a framework release cannot break us. |
+| **A corpus domain** | `distil bench` grades per domain. A new one with real (content-free) traffic makes every certificate broader. |
+| **A failing case for `distil validate`** | An input that breaks reversibility, inflates output, or leaks into telemetry. A reproduction is a contribution even without a fix. |
+| **Docs that were wrong** | Especially a claim that is no longer true. `tests/test_packaging_assets.py` pins the checkable ones; the rest need a human who noticed. |
+
+Not sure if something is in scope? Open the issue first and ask — that is cheaper
+than a PR neither of us wants to reject.
+
 ## Conduct
 
-Be kind, be rigorous, report results faithfully (if a check failed, say so with
-the output). That's it.
+See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). The short version: be kind, be
+rigorous, and report results faithfully — if a check failed, say so with the
+output.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## What it does
 
-- **Wrap your agent** — `distil wrap -- claude` · `codex` · `gemini` · `aider` · `opencode` · `qwen`. Zero config, no code change.
+- **Wrap your agent** — `distil wrap -- claude` · `codex` · `gemini` · `aider` · `opencode` · `qwen` · `goose`. Zero config, no code change.
 - **Run a proxy** — point any `base_url` client at it. Python, TypeScript, any language, any framework.
 - **Call it as a library** — `from distil import compress_messages` in your own agent loop.
 - **Give your agent a recall tool** — MCP server: it compresses its own output and gets the exact bytes back on demand.
@@ -137,7 +137,7 @@ distil wrap -- python my_agent_sdk_script.py
 
 > **Using Cursor, Cline, Continue, or Windsurf?** They are IDE extensions — no argv to wrap and no documented env var, so `distil wrap` cannot reach them. Run a proxy and point the editor's base-URL setting at it: [docs/IDE-AGENTS.md](docs/IDE-AGENTS.md). (GitHub Copilot is not redirectable at all, and that page says so rather than wasting your afternoon.)
 
-Each recognized agent (`claude` / `codex` / `gemini` / `aider` / `opencode` / `qwen`) auto-selects the right env var and upstream — no `--env-var` or `--upstream` flag needed. Prints `preset: <agent> detected → <VAR>` on start. Explicit flags always win.
+Each recognized agent (`claude` / `codex` / `gemini` / `aider` / `opencode` / `qwen` / `goose`) auto-selects the right env var and upstream — no `--env-var` or `--upstream` flag needed. Prints `preset: <agent> detected → <VAR>` on start. Explicit flags always win.
 
 <details>
 <summary><b>Make it the default</b> — never type <code>distil wrap</code> again</summary>
@@ -308,7 +308,7 @@ const client = new Anthropic({ baseURL: distilBaseURL() });
 | Anthropic SDK (Py/TS) | `base_url="http://127.0.0.1:8788"` | [`examples/python_anthropic.py`](examples/python_anthropic.py) · [`examples/js_anthropic.ts`](examples/js_anthropic.ts) |
 | Claude Agent SDK / `claude -p` (headless) | `distil wrap -- <cmd>` or `ANTHROPIC_BASE_URL` | [`examples/python_claude_agent_sdk.py`](examples/python_claude_agent_sdk.py) |
 | OpenAI SDK (Chat + Responses) | `base_url="http://127.0.0.1:8788/v1"` | [`examples/python_openai.py`](examples/python_openai.py) |
-| Vercel AI SDK | `createAnthropic({ baseURL: '…:8788' })` | [`examples/js_vercel_ai_sdk.ts`](examples/js_vercel_ai_sdk.ts) |
+| Vercel AI SDK | `createAnthropic({ baseURL: '…:8788' })` — or in-process: `wrapLanguageModel({ model, middleware: distilMiddleware() })` | [`examples/js_vercel_ai_sdk.ts`](examples/js_vercel_ai_sdk.ts) |
 | LangChain (py/js) · LangGraph | `anthropicApiUrl` / base URL · `pre_model_hook` | [`examples/js_langchain.ts`](examples/js_langchain.ts) |
 | LiteLLM | `api_base="http://127.0.0.1:8788"` | [`examples/python_litellm.py`](examples/python_litellm.py) |
 | Google Gemini | `--upstream https://generativelanguage.googleapis.com` | [`examples/python_gemini.py`](examples/python_gemini.py) |

--- a/distil/onboard.py
+++ b/distil/onboard.py
@@ -25,6 +25,7 @@ _AGENTS = [
     ("gemini", "Gemini CLI"),
     ("opencode", "OpenCode"),
     ("qwen", "Qwen Code"),
+    ("goose", "goose"),
 ]
 _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 
@@ -44,6 +45,10 @@ _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 #   qwen         — Qwen Code calls LLMs through the OpenAI SDK and documents
 #                  OPENAI_API_KEY / OPENAI_BASE_URL / OPENAI_MODEL explicitly
 #                  (Qwen Code README).
+#   goose        — Block's goose reads OPENAI_HOST for the endpoint (NOT
+#                  OPENAI_BASE_URL, which it ignores) plus OPENAI_BASE_PATH,
+#                  defaulting to "v1/chat/completions" — a path distil's proxy
+#                  serves, so the default needs no change (goose provider docs).
 #   cursor-agent — env var not publicly documented; left out rather than guessing.
 #                  Use --env-var to configure manually.
 #
@@ -66,6 +71,7 @@ AGENT_PRESETS: dict[str, tuple[str, str, str]] = {
     "aider": ("OPENAI_BASE_URL", "https://api.openai.com", "aider"),
     "opencode": ("OPENAI_BASE_URL", "https://api.openai.com", "OpenCode"),
     "qwen": ("OPENAI_BASE_URL", "https://api.openai.com", "Qwen Code"),
+    "goose": ("OPENAI_HOST", "https://api.openai.com", "goose"),
 }
 
 

--- a/docs/IDE-AGENTS.md
+++ b/docs/IDE-AGENTS.md
@@ -93,4 +93,5 @@ distil wrap -- gemini      # Gemini CLI
 distil wrap -- aider       # aider
 distil wrap -- opencode    # OpenCode
 distil wrap -- qwen        # Qwen Code
+distil wrap -- goose       # goose
 ```

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -101,3 +101,25 @@ const client = new Anthropic({ baseURL: distilBaseURL() });
 ```bash
 npx distil-llm proxy        # or: distil default --always-on
 ```
+
+## Vercel AI SDK middleware
+
+```js
+import { wrapLanguageModel } from "ai";
+import { distilMiddleware } from "distil-llm";
+
+const model = wrapLanguageModel({
+  model: gateway("anthropic/claude-sonnet-5"),
+  middleware: distilMiddleware({
+    onSavings: (s) => console.log(`${s.savedPct.toFixed(1)}% smaller`),
+  }),
+});
+```
+
+Implements `transformParams` only — compression happens on the way **in**, and
+wrapping the response would mean rewriting the model's own output, which distil
+does not do. Tool results (both the v4 `result` and v5 `output.value` shapes),
+user text parts, and system strings are compressed; assistant messages, files,
+and tool calls are passed through untouched.
+
+Lossless tier, like `compress()`. Route through the proxy for the digest tier.

--- a/packaging/npm/index.d.ts
+++ b/packaging/npm/index.d.ts
@@ -63,3 +63,30 @@ export function expandRuns(text: string): string;
 export function minifyJson(text: string): string | null;
 /** Heuristic token count, matching the Python HeuristicTokenizer. */
 export function countTokens(text: string): number;
+
+export interface SavingsInfo {
+  tokensBefore: number;
+  tokensAfter: number;
+  tokensSaved: number;
+  savedPct: number;
+}
+
+export interface DistilMiddlewareOptions {
+  /** Called once per request with the measured delta. */
+  onSavings?: (info: SavingsInfo) => void;
+}
+
+/**
+ * Vercel AI SDK middleware that losslessly compresses the prompt in-process.
+ *
+ * Implements `transformParams` only — compression happens on the way IN, and
+ * wrapping the response would mean rewriting the model's own output, which
+ * distil does not do.
+ *
+ *   const model = wrapLanguageModel({ model: ..., middleware: distilMiddleware() });
+ *
+ * For the reversible digest tier, route through a distil proxy instead.
+ */
+export function distilMiddleware(
+  opts?: DistilMiddlewareOptions
+): { transformParams: (arg: { params: unknown }) => Promise<unknown> };

--- a/packaging/npm/index.js
+++ b/packaging/npm/index.js
@@ -24,11 +24,14 @@ const {
   DEFAULT_HOST,
 } = require("./lib/baseurl");
 const { compress } = require("./lib/compress");
+const { distilMiddleware } = require("./lib/aisdk");
 const { applyTier0, collapseRuns, expandRuns, minifyJson, countTokens } = require("./lib/tier0");
 
 module.exports = {
   // in-process lossless compression (byte-identical to the Python engine)
   compress,
+  // Vercel AI SDK middleware for wrapLanguageModel()
+  distilMiddleware,
   // proxy routing helpers
   distilBaseURL,
   distilOpenAIBaseURL,

--- a/packaging/npm/lib/aisdk.js
+++ b/packaging/npm/lib/aisdk.js
@@ -1,0 +1,132 @@
+// Vercel AI SDK middleware.
+//
+// The proxy route (`createAnthropic({ baseURL: distilBaseURL() })`) is still the
+// way to get the reversible digest tier. This is for the other case: you want
+// lossless savings in-process, with no daemon to keep alive — a serverless
+// function, an edge worker, a CI job that runs once.
+//
+//   import { wrapLanguageModel } from "ai";
+//   import { distilMiddleware } from "distil-llm";
+//
+//   const model = wrapLanguageModel({
+//     model: gateway("anthropic/claude-sonnet-5"),
+//     middleware: distilMiddleware(),
+//   });
+//
+// Implements `transformParams` only. `wrapGenerate`/`wrapStream` are not
+// implemented because compression happens on the way IN — wrapping the response
+// would let us rewrite the model's own output, which distil does not do.
+
+"use strict";
+
+const { applyTier0, countTokens } = require("./tier0");
+
+/**
+ * A `LanguageModelV4Prompt` message carries `content` that is a plain STRING for
+ * `system`, and an ARRAY OF PARTS for `user`, `assistant`, and `tool`. Both are
+ * handled; anything unrecognised is passed through untouched, because a
+ * compressor that mangles a shape it does not understand is worse than one that
+ * saves nothing.
+ */
+
+/** Compress a text-bearing part, preserving every sibling key. */
+function compressPart(part) {
+  if (!part || typeof part !== "object") return part;
+
+  // { type: "text", text: "..." } — user and tool text.
+  if (part.type === "text" && typeof part.text === "string") {
+    const next = applyTier0(part.text);
+    return next === part.text ? part : { ...part, text: next };
+  }
+
+  // Tool results carry the payload under different keys across SDK versions:
+  //   v5: { type: "tool-result", output: { type: "text", value: "..." } }
+  //   v4: { type: "tool-result", result: "..." }
+  // Both are handled rather than pinning one, so an SDK bump does not silently
+  // stop compressing the single largest thing in an agent's context.
+  if (part.type === "tool-result") {
+    if (part.output && typeof part.output.value === "string") {
+      const next = applyTier0(part.output.value);
+      return next === part.output.value
+        ? part
+        : { ...part, output: { ...part.output, value: next } };
+    }
+    if (typeof part.result === "string") {
+      const next = applyTier0(part.result);
+      return next === part.result ? part : { ...part, result: next };
+    }
+  }
+  return part; // file / image / tool-call parts are never rewritten
+}
+
+function compressMessage(message) {
+  if (!message || typeof message !== "object") return message;
+
+  // The model's own words are not distil's to edit.
+  if (message.role === "assistant") return message;
+
+  if (typeof message.content === "string") {
+    const next = applyTier0(message.content);
+    return next === message.content ? message : { ...message, content: next };
+  }
+  if (Array.isArray(message.content)) {
+    const parts = message.content.map(compressPart);
+    const changed = parts.some((p, i) => p !== message.content[i]);
+    return changed ? { ...message, content: parts } : message;
+  }
+  return message;
+}
+
+function textOf(message) {
+  if (typeof message?.content === "string") return message.content;
+  if (Array.isArray(message?.content)) {
+    return message.content
+      .map((p) =>
+        typeof p?.text === "string"
+          ? p.text
+          : typeof p?.output?.value === "string"
+            ? p.output.value
+            : typeof p?.result === "string"
+              ? p.result
+              : ""
+      )
+      .join("");
+  }
+  return "";
+}
+
+/**
+ * Build AI SDK middleware that losslessly compresses the prompt before it is sent.
+ *
+ * @param {{onSavings?: (info: {tokensBefore: number, tokensAfter: number,
+ *   tokensSaved: number, savedPct: number}) => void}} [opts]
+ *   `onSavings` is called once per request with the measured delta. Provided
+ *   because in-process compression has no proxy to report through, and savings
+ *   you cannot see are savings you will not trust.
+ * @returns {{transformParams: (arg: {params: object}) => Promise<object>}}
+ */
+function distilMiddleware(opts) {
+  const onSavings = opts && typeof opts.onSavings === "function" ? opts.onSavings : null;
+  return {
+    transformParams: async ({ params }) => {
+      if (!params || !Array.isArray(params.prompt)) return params;
+
+      const before = onSavings ? params.prompt.reduce((n, m) => n + countTokens(textOf(m)), 0) : 0;
+      const prompt = params.prompt.map(compressMessage);
+      const changed = prompt.some((m, i) => m !== params.prompt[i]);
+
+      if (onSavings) {
+        const after = prompt.reduce((n, m) => n + countTokens(textOf(m)), 0);
+        onSavings({
+          tokensBefore: before,
+          tokensAfter: after,
+          tokensSaved: before - after,
+          savedPct: before > 0 ? (100 * (before - after)) / before : 0,
+        });
+      }
+      return changed ? { ...params, prompt } : params;
+    },
+  };
+}
+
+module.exports = { distilMiddleware };

--- a/packaging/npm/test/aisdk.test.mjs
+++ b/packaging/npm/test/aisdk.test.mjs
@@ -1,0 +1,101 @@
+// Vercel AI SDK middleware. Exercised against the real LanguageModelV4Prompt
+// shapes — system content is a STRING, everything else is an array of parts —
+// because a middleware tested only on a shape we invented is untested.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { distilMiddleware } from "../index.js";
+
+const BIG = "ERROR failed to connect to worker pool\n".repeat(60);
+const mw = distilMiddleware();
+
+const run = (prompt) => mw.transformParams({ params: { prompt } });
+
+test("compresses tool-result parts (AI SDK v5 output.value shape)", async () => {
+  const out = await run([
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "c1",
+          toolName: "bash",
+          output: { type: "text", value: BIG },
+        },
+      ],
+    },
+  ]);
+  const part = out.prompt[0].content[0];
+  assert.ok(part.output.value.length < BIG.length);
+  assert.equal(part.toolCallId, "c1", "sibling keys preserved");
+  assert.equal(part.output.type, "text");
+});
+
+test("compresses tool-result parts (v4 result shape)", async () => {
+  const out = await run([
+    { role: "tool", content: [{ type: "tool-result", toolCallId: "c1", result: BIG }] },
+  ]);
+  assert.ok(out.prompt[0].content[0].result.length < BIG.length);
+});
+
+test("compresses user text parts", async () => {
+  const out = await run([{ role: "user", content: [{ type: "text", text: BIG }] }]);
+  assert.ok(out.prompt[0].content[0].text.length < BIG.length);
+});
+
+test("compresses a system message, whose content is a bare string", async () => {
+  const out = await run([{ role: "system", content: BIG }]);
+  assert.ok(out.prompt[0].content.length < BIG.length);
+});
+
+test("never rewrites assistant messages", async () => {
+  const prompt = [{ role: "assistant", content: [{ type: "text", text: BIG }] }];
+  const out = await run(prompt);
+  assert.equal(out.prompt[0], prompt[0], "assistant message must pass through by identity");
+});
+
+test("leaves file and tool-call parts alone", async () => {
+  const prompt = [
+    {
+      role: "user",
+      content: [
+        { type: "file", mediaType: "image/png", data: "..." },
+        { type: "tool-call", toolCallId: "x", toolName: "bash", input: {} },
+      ],
+    },
+  ];
+  const out = await run(prompt);
+  assert.equal(out.prompt[0], prompt[0]);
+});
+
+test("returns params untouched when there is nothing to compress", async () => {
+  const params = { prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }] };
+  const out = await mw.transformParams({ params });
+  assert.equal(out, params, "unchanged params should be the same object");
+});
+
+test("tolerates a missing or malformed prompt", async () => {
+  assert.deepEqual(await mw.transformParams({ params: {} }), {});
+  const weird = { prompt: "not an array" };
+  assert.equal(await mw.transformParams({ params: weird }), weird);
+  const nulls = { prompt: [null, 42, { role: "user" }] };
+  assert.deepEqual((await mw.transformParams({ params: nulls })).prompt, nulls.prompt);
+});
+
+test("preserves other params", async () => {
+  const out = await mw.transformParams({
+    params: { prompt: [{ role: "system", content: BIG }], temperature: 0.2, maxOutputTokens: 99 },
+  });
+  assert.equal(out.temperature, 0.2);
+  assert.equal(out.maxOutputTokens, 99);
+});
+
+test("onSavings reports a real measured delta", async () => {
+  const seen = [];
+  const m = distilMiddleware({ onSavings: (i) => seen.push(i) });
+  await m.transformParams({ params: { prompt: [{ role: "system", content: BIG }] } });
+  assert.equal(seen.length, 1);
+  assert.ok(seen[0].tokensSaved > 0);
+  assert.ok(seen[0].savedPct > 50);
+  assert.equal(seen[0].tokensBefore - seen[0].tokensAfter, seen[0].tokensSaved);
+});

--- a/tests/test_packaging_assets.py
+++ b/tests/test_packaging_assets.py
@@ -132,3 +132,80 @@ def test_readme_leads_with_capability_not_statistics():
     assert text.index("## What it does") < text.index("Why trust it"), (
         "the proof section must sit below the capability section"
     )
+
+
+# --- claims re-audit ----------------------------------------------------------
+# GA_READINESS lists "claims re-audit at launch commit" as a launch gate, and the
+# last full audit was 1.11.0. A one-time human read goes stale the moment code
+# moves, so the checkable claims are pinned here instead: the README cannot
+# advertise an agent, an integration, or an API that does not exist, and it
+# cannot omit one that does.
+
+
+def _readme_text() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_every_advertised_agent_has_a_real_preset():
+    from distil.onboard import AGENT_PRESETS
+
+    text = _readme_text()
+    line = next(ln for ln in text.splitlines() if ln.startswith("- **Wrap your agent**"))
+    advertised = set(re.findall(r"`(?:distil wrap -- )?([a-z][a-z0-9-]*)`", line))
+    unreal = advertised - set(AGENT_PRESETS)
+    assert not unreal, f"README advertises agents with no preset: {sorted(unreal)}"
+
+
+def test_every_real_preset_is_advertised():
+    """The reverse: shipping an agent nobody is told about wastes the work."""
+    from distil.onboard import AGENT_PRESETS
+
+    text = _readme_text()
+    missing = [a for a in AGENT_PRESETS if f"`{a}`" not in text]
+    assert not missing, f"presets exist but the README never mentions them: {missing}"
+
+
+def test_every_advertised_integration_module_exists():
+    import importlib
+
+    text = _readme_text()
+    line = next(ln for ln in text.splitlines() if ln.startswith("- **Framework hooks**"))
+    named = re.findall(r"\b(LangChain|LangGraph|LiteLLM|Agno|Strands)\b", line)
+    assert named, "the framework-hooks line names no framework"
+    for name in named:
+        mod = f"distil.integrations.{name.lower()}"
+        importlib.import_module(mod)  # raises if the claim is false
+
+
+def test_advertised_public_api_names_are_importable():
+    """The README's headline code sample must actually run."""
+    import distil
+
+    text = _readme_text()
+    for name in re.findall(r"from distil import ([a-z_, ]+)", text):
+        for symbol in (n.strip() for n in name.split(",")):
+            assert hasattr(distil, symbol), f"README imports `{symbol}`, which does not exist"
+
+
+def test_no_doc_promises_a_proxy_endpoint_that_does_not_exist():
+    """A documented endpoint nobody implemented is a support ticket in waiting."""
+    import distil.gateway as gw
+
+    served = set(re.findall(r'self\.path == "(/distil/[a-z]+)"', inspect_source(gw)))
+    served |= {"/v1/messages", "/v1/chat/completions", "/v1/responses"}
+    docs = [README] + sorted((ROOT / "docs").glob("*.md"))
+    claimed = set()
+    for d in docs:
+        text = d.read_text(encoding="utf-8")
+        # Only CODE SPANS count. A bare match also catches website paths like
+        # `dshakes.github.io/distil/architecture.html` and
+        # `github.com/dshakes/distil/actions`, which are pages, not endpoints.
+        claimed |= set(re.findall(r"`(/distil/[a-z]+)`", text))
+    unreal = claimed - served
+    assert not unreal, f"docs reference proxy endpoints that do not exist: {sorted(unreal)}"
+
+
+def inspect_source(mod) -> str:
+    import inspect as _inspect
+
+    return _inspect.getsource(mod)


### PR DESCRIPTION
Closes the four audit gaps that were closable in code.

## Claims re-audit — now executable

`GA_READINESS.md` lists "claims re-audit at launch commit" as a launch gate, last done at **1.11.0**. A one-time human read goes stale the moment code moves — and I had just rewritten the README headline and added claims about the library API and the TS port, so this was overdue *because of me*.

It is now a test. The README cannot advertise an agent, framework, or API that does not exist — **and cannot omit one that does**, so shipping an integration nobody is told about also fails. Docs cannot reference a `/distil/*` endpoint the gateway does not serve.

That last check caught my own near-miss: the first version matched URL fragments like `github.io/distil/architecture.html`. Narrowed to code spans.

## `goose` — my own miss

It was on my roadmap list and I neither added it nor explained why. It uses `OPENAI_HOST` (**not** `OPENAI_BASE_URL`) plus `OPENAI_BASE_PATH`, defaulting to `v1/chat/completions` — a path the proxy already serves, which I verified rather than assumed. **6 → 7 presets.**

Cursor/Copilot/Cline/Continue stay out: IDE extensions, no argv, no published env-var contract. A guessed variable ships a wrap that reports success and routes nothing.

## Vercel AI SDK middleware

`wrapLanguageModel({ model, middleware: distilMiddleware() })`, written against the real `LanguageModelV4Prompt` shapes rather than an invented one — system content is a bare **string** while user/tool content is an array of parts, and tool results carry their payload under `output.value` (v5) or `result` (v4). Both handled, so an SDK bump cannot silently stop compressing the largest thing in an agent's context.

`transformParams` only. `wrapGenerate`/`wrapStream` are deliberately absent: compression happens on the way **in**, and wrapping the response would mean rewriting the model's own output.

## Community surface

`CODE_OF_CONDUCT.md`, issue templates, and a good-first-issue table. The bug form asks for `distil doctor` output first, since the settings-precedence trap is the most common cause of "it can't reach the API". The quality-report template explicitly invites a result that contradicts our own published numbers.

## Verification

ruff · format · mypy (130 files) · **3127 Python tests** · coverage **95.02%** · **27 node tests** · `bench` **GATE: PASS**

## Still not done, and not closable here

External beta, Discord, upstream integration PRs, SOC 2, SLA, and the two open GA items (validation breadth, calibration data — both need live compute). These need a community, a company, or spend.