### PR TITLE
release(1.41.2rc3): keep the soaking artifact identical to main

### DIFF
--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.41.2-rc.2",
+  "version": "1.41.2-rc.3",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.41.2rc2",
+  "version": "1.41.2rc3",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.41.2rc2"
+version = "1.41.2rc3"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.41.2rc2",
+  "version": "1.41.2rc3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.41.2rc2",
+      "version": "1.41.2rc3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version surfaces only.

**Why rc3 an hour after rc2:** #99 added the `goose` wrap preset — runtime code `distil wrap` executes. `RELEASING.md` requires the final to be byte-identical to the last rc plus the version bump, so that delta had to be in a soaked artifact.

rc2 had ~50 minutes of real use, so this costs about an hour of soak instead of three days. Waiting would have cost the whole window.

Everything else in #99 — AI SDK middleware (npm-only), claims-audit tests, community docs — is soak-exempt.