### PR TITLE
release(1.42.0): the outage was the test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,78 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.42.0] — the outage was the test suite
+
+**distil's own test suite tore down the developer's live proxy, and that is what took
+a machine's API traffic out roughly fifteen times in one evening.** `cmd_offboard` and
+`distil default --undo` call `service_spec(8788, ...)`, which returns the *real*
+`~/Library/LaunchAgents/com.distil.proxy.plist` — then `launchctl unload` it and
+`unlink()` it. Five tests never patched `service_spec`. Every full-suite run silently
+uninstalled the always-on service while `ANTHROPIC_BASE_URL` stayed pinned at the
+now-dead port, so every session afterwards failed with `ConnectionRefused`, an error
+that names the *provider*.
+
+It was hard to see because the job came back **unregistered** rather than crashed:
+`proxy.err` was empty, there was no crash report, and `KeepAlive` cannot restart a job
+that is no longer loaded. Remembering to patch per-test fails open, and it failed open
+five times — so `conftest` now redirects the plist into a tmp dir and makes the
+destructive commands inert *by construction*.
+
+**`launchctl unload; launchctl load` was a coin flip.** `unload` is asynchronous, so the
+replacement job often died on `EADDRINUSE` and launchd discarded it — while the legacy
+`load` still exited 0 and the orphaned old process kept answering just long enough for
+the routing probe to pass. `distil default` printed ✓ and wired the pin onto a machine
+with *no registered job*; nothing restarted it when the orphan exited. `service_reload()`
+uses the modern bootout/bootstrap API, waits for the job *record* to clear (the port
+frees the instant the process dies, while the record lingers in `SIGTERMed` — and
+bootstrapping into that returns `Bootstrap failed: 5: Input/output error`), retries
+transient EIO, and verifies a running pid. A failed start now wires nothing.
+
+**A restart is no longer a refusal.** launchd and systemd own the listening socket
+(`Sockets` in the plist; a real `distil-proxy.socket` unit on Linux), so connections
+queue in the kernel backlog while the proxy restarts instead of being refused. Verified
+on hardware: `kill -9` against the running proxy four times returned HTTP 401 every
+time, `connect=0.26ms`, zero refusals — where the same machine had previously logged a
+37-second window of `ECONNREFUSED`.
+
+Nine more faults in the machine-wiring path, each with a regression test verified to
+fail without its fix:
+
+- A pre-existing `alias claude=...` made the rc file **unparseable**. bash and zsh
+  alias-expand the word before `()` while *reading* a function definition, so the
+  managed block was a syntax error that abandoned the rest of the user's rc — PATH
+  included. An earlier distil installed exactly such an alias.
+- `os.replace` **destroyed a symlinked rc**, detaching dotfile repos (stow, chezmoi)
+  from the file they manage.
+- A hyphenated agent name (`claude-code`) is a syntax error in dash, which is `/bin/sh`
+  on Debian and reads `~/.profile`. A subshell capability probe now gates the
+  definition. `eval … || true` does *not* work: `eval` is a POSIX special builtin, and
+  a syntax error in one exits the shell before the `||` is reached.
+- The plist spliced paths and mode into XML **unescaped**; a `&` in `$HOME` produced a
+  plist launchd silently refuses to load.
+- The escape hatch matched loopback by **substring**, so a corporate gateway at
+  `…/pools/127.0.0.1` would have been deleted and `http://127.1:8788` kept.
+- The escape hatch scanned only hardcoded `$HOME` rc paths, missing `$ZDOTDIR` and any
+  `--rc` path — the machines least served by the defaults.
+- `remove_managed` returned `ok` when the end marker was missing, so undo and offboard
+  printed ✓ while the wiring stayed live.
+- `_port_free` probed by **connecting**, which fills the listener backlog: against a
+  hung proxy it reported a held port as free, causing the exact `EADDRINUSE` it exists
+  to prevent. It now probes by binding, which is what the supervisor does.
+- Nothing removed the systemd **socket unit** on uninstall. An orphaned enabled
+  `.socket` keeps the port bound after distil is gone and keeps systemd starting a
+  service that no longer exists.
+
+Also: the subscription notice drops from seven lines to two (it prints on every bare
+wrap, and a wall of text is skipped exactly by the readers it exists for), and
+`CITATION.cff` gains the drift guard it never had — it was the one version location no
+test pinned, and it had already fallen behind to 1.41.1.
+
+**Confidence is uneven and worth stating plainly.** macOS is proven on real hardware.
+The Linux paths — the socket unit, `enable --now`, the `LISTEN_FDS` handoff — are
+correct by construction and covered by tests against mocked systemd, but have not been
+executed on a real Linux system.
+
 ## [1.41.2] — the escape hatch that wasn't, and a price nobody was charged
 
 **`distil default --always-on` took `launchctl load` returning 0 as proof the proxy

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.41.1
-date-released: 2026-08-05
+version: 1.42.0
+date-released: 2026-08-08
 keywords:
   - llm
   - context-compression

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.41.2-rc.3",
+  "version": "1.42.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.41.2rc3",
+  "version": "1.42.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.41.2rc3"
+version = "1.42.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.41.2rc3",
+  "version": "1.42.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.41.2rc3",
+      "version": "1.42.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -226,6 +226,36 @@ def _npm_version(pep440: str) -> str:
     return f"{match.group(1)}-{match.group(2)}.{match.group(3)}"
 
 
+def test_citation_tracks_the_released_version() -> None:
+    """CITATION.cff had no guard, and drifted — 1.41.1 while everything else was 1.41.2rc3.
+
+    A version bump touches SIX places across five files. server.json and
+    packaging/npm/package.json are pinned to pyproject by the tests above;
+    CITATION.cff was not, so it was the one that silently fell behind. That class of
+    drift already broke a release once (1.35.0 failed its own packaging gate).
+
+    The convention here is that CITATION tracks the CITED artifact — a GA release —
+    not every rc on the way to it, so this only binds on a final version. Demanding
+    byte-equality unconditionally would fail every rc and get deleted.
+    """
+    version = _pyproject()["project"]["version"]
+    cited = None
+    for line in (ROOT / "CITATION.cff").read_text().splitlines():
+        if line.startswith("version:"):
+            cited = line.split(":", 1)[1].strip()
+            break
+    assert cited, "CITATION.cff has no version: line"
+    if re.fullmatch(r"\d+\.\d+\.\d+", version):  # a final release
+        assert cited == version, (
+            f"CITATION.cff says {cited} but this is release {version} — "
+            f"the citation would credit the wrong version"
+        )
+    else:  # a prerelease: CITATION legitimately still names the last GA
+        assert re.fullmatch(r"\d+\.\d+\.\d+", cited), (
+            f"CITATION.cff should name a final release, not {cited!r}"
+        )
+
+
 def test_npm_version_translation() -> None:
     assert _npm_version("1.38.0") == "1.38.0"
     assert _npm_version("1.38.0rc1") == "1.38.0-rc.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.41.2rc3"
+version = "1.42.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts **1.42.0 GA**, closing the `1.41.2` rc train.

Minor rather than patch: socket activation is a new capability, not a bug fix, and the always-on wiring path changed shape on both platforms.

## What ships

The whole of #102 — thirteen faults in the machine-wiring path, each with a regression test verified to fail without its fix. The three that mattered:

1. **distil's own test suite tore down the developer's live proxy.** `cmd_offboard` and `distil default --undo` call `service_spec(8788, ...)`, which returns the *real* `~/Library/LaunchAgents` plist, then `launchctl unload` it and `unlink()` it. Five tests never patched `service_spec`. This is what took a machine's API traffic out ~15 times in one evening.
2. **`launchctl unload; launchctl load` was a coin flip** that left the machine with no registered job while printing ✓.
3. **A restart was a hard `ConnectionRefused`** — the supervisor now owns the listening socket on both platforms.

Full detail in the CHANGELOG entry.

## Version locations

All six, across five files, plus the lock:

| File | |
|---|---|
| `pyproject.toml` | `1.41.2rc3` → `1.42.0` |
| `server.json` | ×2 occurrences |
| `packaging/npm/package.json` | `1.41.2-rc.3` → `1.42.0` |
| `plugins/distil/.claude-plugin/plugin.json` | bumped |
| `CITATION.cff` | `1.41.1` → `1.42.0`, + `date-released` |
| `uv.lock` | resynced |

## New: the CITATION drift guard

`CITATION.cff` was the one version location **no test pinned**, and it had already drifted — sitting at `1.41.1` while everything else was `1.41.2rc3`. That class of drift broke a release before (`1.35.0` failed its own packaging gate).

The guard binds **only on a final version**, because the convention here is that CITATION names the *cited artifact* — a GA — not every rc on the way to it. Demanding byte-equality unconditionally would fail every rc release and get deleted. Verified both directions: fails on a lagging CITATION at a final, passes when pyproject is a prerelease.

## Also caught

`uv.lock` had drifted to `1.43.0rc1`. `uv run` resyncs the lock whenever pyproject changes, so a temporary version bump during testing leaves it behind — and nothing pins the lock's version, so this would have shipped a release whose lockfile named a version that never existed.

## Confidence

Stated plainly, because it is uneven:

- **macOS always-on** — proven on real hardware: `kill -9` ×4 → HTTP 401 every time, `connect=0.26ms`, zero refusals; `distil default --always-on` 5/5 deterministic where it was ~50/50; ~2 hours with zero refusals across many full test-suite runs that previously destroyed the service every time.
- **Linux always-on** — the socket unit, `enable --now`, and the `LISTEN_FDS` handoff are correct by construction and covered by tests against mocked systemd, but **have never run on a real Linux system**.
- **Windows** — the wiring paths do not apply; verified only that nothing crashes.

That unevenness is the argument for cutting a minor and letting it soak rather than treating this as a routine patch.

## Gate

```
3208 passed, 1 skipped, 0 failed
coverage 95.01% (floor 95%)
ruff check + format clean, mypy clean
packaging smoke: 15 passed
```