### PR TITLE
test(activation): prove socket activation on Linux instead of asserting it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,11 @@ jobs:
       # opentelemetry-sdk so the trace/counter EXPORT assertions actually run:
       # those tests importorskip, so without the SDK they silently skip and an
       # export that reports zeros would keep CI green.
+      # cryptography is the `oidc` extra. Without it here, the RS256
+      # malformed-key test importorskip'd itself out of every run — a security
+      # assertion that had never once executed, in CI or locally.
       - name: pytest with coverage floor
-        run: uv run --with pytest --with pytest-asyncio --with aiohttp --with pytest-cov --with opentelemetry-sdk python -m pytest -q --cov=distil --cov-fail-under=95
+        run: uv run --with pytest --with pytest-asyncio --with aiohttp --with pytest-cov --with opentelemetry-sdk --with cryptography python -m pytest -q --cov=distil --cov-fail-under=95
 
   gate:
     runs-on: ${{ matrix.os }}

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import os
 import plistlib
 import socket
+import time
+import shutil
 import sys
 import threading
 import urllib.request
@@ -310,6 +312,130 @@ launchd_only = pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="launchd domains are uid-addressed; Windows has no os.getuid()",
 )
+
+
+linux_only = pytest.mark.skipif(
+    sys.platform != "linux", reason="systemd socket activation is a Linux mechanism"
+)
+
+
+@linux_only
+def test_socket_activation_survives_a_worker_restart_on_linux(tmp_path):
+    """End-to-end on real Linux: the listener outlives the worker.
+
+    This does exactly what systemd does — bind in the supervisor, place the
+    listener on fd 3, fork, set LISTEN_PID in the child, exec — and then kills the
+    worker mid-flight. If activation regressed, the request after the kill is
+    refused, which is precisely the outage this whole mechanism exists to remove.
+
+    The mocked tests elsewhere in this file prove the wiring; this proves the
+    mechanism, on the platform where it was previously only asserted.
+    """
+    import signal
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(64)
+    port = listener.getsockname()[1]
+
+    class H(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib signature
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"pid=%d" % os.getpid())
+
+        def log_message(self, *a):  # noqa: ANN002
+            pass
+
+    def spawn() -> int:
+        pid = os.fork()
+        if pid:
+            return pid
+        # Child: become the "activated service". os._exit so no pytest teardown runs.
+        try:
+            os.dup2(listener.fileno(), activation._SD_LISTEN_FDS_START)
+            os.set_inheritable(activation._SD_LISTEN_FDS_START, True)
+            os.environ["LISTEN_FDS"] = "1"
+            os.environ["LISTEN_PID"] = str(os.getpid())
+            sock = activation.inherited_listener()
+            if sock is None:
+                os._exit(9)
+            srv = ThreadingHTTPServer(("127.0.0.1", 0), H, bind_and_activate=False)
+            srv.socket.close()
+            srv.socket = sock
+            srv.serve_forever()
+        except BaseException:  # noqa: BLE001 - a child that raises must not become a second pytest
+            os._exit(8)
+        os._exit(0)
+
+    def fetch() -> str:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=15) as r:
+            return r.read().decode()
+
+    first = spawn()
+    try:
+        deadline = time.monotonic() + 15
+        body = ""
+        while time.monotonic() < deadline:
+            try:
+                body = fetch()
+                break
+            except OSError:
+                time.sleep(0.1)
+        assert body == f"pid={first}", f"the activated worker never served: {body!r}"
+
+        os.kill(first, signal.SIGKILL)
+        os.waitpid(first, 0)
+        second = spawn()  # the "restart"; the connection queues in the kernel backlog
+        try:
+            after = fetch()
+            assert after == f"pid={second}", f"served by the wrong process: {after!r}"
+        finally:
+            os.kill(second, signal.SIGKILL)
+            os.waitpid(second, 0)
+    finally:
+        listener.close()
+
+
+@linux_only
+@pytest.mark.skipif(shutil.which("systemd-analyze") is None, reason="systemd-analyze not installed")
+def test_generated_units_are_valid_to_systemd(tmp_path, monkeypatch, real_service_api):
+    """systemd itself must accept the units — not just our reading of the docs.
+
+    A unit systemd rejects fails at `enable` time on the user's machine, and the
+    only symptom is "the proxy isn't running". Asserting on our own generated
+    strings cannot catch a directive that is misspelled, deprecated, or illegal in
+    the section it was put in; `systemd-analyze verify` can.
+    """
+    import subprocess
+
+    exe = tmp_path / "distil"
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("shutil.which", lambda name: str(exe))
+
+    _p, service, _load = real_service_api["service_spec"](8788, "lossless-only")
+    _sp, sock = setup.socket_unit_spec(8788)
+    (tmp_path / "distil-proxy.service").write_text(service)
+    (tmp_path / "distil-proxy.socket").write_text(sock)
+
+    res = subprocess.run(
+        [
+            "systemd-analyze",
+            "verify",
+            str(tmp_path / "distil-proxy.socket"),
+            str(tmp_path / "distil-proxy.service"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    # verify exits non-zero on a real problem and prints to stderr on any complaint.
+    assert res.returncode == 0, f"systemd rejected the units:\n{res.stderr}\n{res.stdout}"
+    assert not res.stderr.strip(), f"systemd complained about the units:\n{res.stderr}"
 
 
 class _Res:


### PR DESCRIPTION
1.42.0 shipped socket activation for **both** launchd and systemd, but only the launchd half was ever executed against a real supervisor. The Linux path — the `LISTEN_FDS` handoff and the generated unit files — was covered by tests against *mocked* systemd, which is another way of saying it was covered by my reading of the docs.

That gap was stated openly in #103's description. This closes it.

## Two tests, both Linux-gated

**1. End-to-end activation across a worker restart.** Does exactly what systemd does — bind in the supervisor, place the listener on fd 3, fork, set `LISTEN_PID` in the child, exec — then `SIGKILL`s the worker mid-flight and demands the next request still be served. If activation regresses, that request is refused, which is precisely the outage the mechanism removes.

Verified on Debian before pushing:

```
worker pid=8   activated=True
request 1: pid=8
SIGKILL the worker
request 2: pid=10  (0.02s)   <- new worker, zero refusals
RESULT: PASS - listener survived the worker
```

**2. `systemd-analyze verify` on the generated units.** Asserting on our own generated strings cannot catch a directive that is misspelled, deprecated, or illegal in the section it was placed in. systemd's own parser can. Verified clean against **systemd 257**:

```
--- verify distil-proxy.socket ---   (clean)
--- verify distil-proxy.service ---  (clean)
```

Skipped when the binary is absent, so a runner without it degrades to the existing mocked coverage rather than failing.

## Notes

- The forked child uses `os._exit`, so a crashed worker can never become a second pytest process reporting its own results.
- Both tests skip on macOS and Windows; on this branch that is `3208 passed, 3 skipped` locally and `41 passed, 1 skipped` inside a Debian container.

## Gate

```
3208 passed, 3 skipped, 0 failed
coverage 95.01% (floor 95%)
ruff check + format clean
Debian container: 41 passed, 1 skipped (systemd-analyze present)
```