### PR TITLE
fix(shadow): report the running build's replay rate, not a lifetime average

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1280,14 +1280,33 @@ def cmd_shadow_stats(args: argparse.Namespace) -> int:
     if led.samples == 0:
         _attempted = _ctrs.get("replay_attempted", 0)
         if _attempted > 0:
-            _seen = _ctrs.get("requests_seen", 0)
-            _sampled = _ctrs.get("sampled", 0)
-            _failed = _ctrs.get("replay_failed", 0)
-            _reason = _ctrs.get("last_fail_reason", "")
-            _skipped = _ctrs.get("signature_none_skipped", 0)
-            _reason_str = f" (last: {_reason})" if _reason else ""
+            # Same lifetime-vs-running-build problem as the reporting path below:
+            # prefer THIS build's counters, because a fixed bug's failures live in
+            # the lifetime totals forever and make a working sampler look broken.
+            from .shadow import _counter_version
+
+            _bv = _ctrs.get("by_version")
+            _cur = _bv.get(_counter_version()) if isinstance(_bv, dict) else None
+            _src = _cur if isinstance(_cur, dict) and _cur.get("replay_attempted") else _ctrs
+            _scope = (
+                f" ({_counter_version()})"
+                if _src is not _ctrs
+                else " (lifetime — no replays yet on this build)"
+            )
+            _attempted = _src.get("replay_attempted", 0)
+            _seen = _src.get("requests_seen", 0)
+            _sampled = _src.get("sampled", 0)
+            _failed = _src.get("replay_failed", 0)
+            _skipped = _src.get("signature_none_skipped", 0)
+            _reasons = _src.get("fail_reasons")
+            if isinstance(_reasons, dict) and _reasons:
+                _top = sorted(_reasons.items(), key=lambda kv: -kv[1])[:3]
+                _reason_str = " (" + ", ".join(f"{k}×{v}" for k, v in _top) + ")"
+            else:
+                _reason = _src.get("last_fail_reason", "")
+                _reason_str = f" (last: {_reason})" if _reason else ""
             print(
-                f"Shadow counters: {_seen} seen, {_sampled} sampled, "
+                f"Shadow counters{_scope}: {_seen} seen, {_sampled} sampled, "
                 f"{_attempted} replay{'s' if _attempted != 1 else ''} attempted, "
                 f"{_failed} failed{_reason_str}"
             )
@@ -1345,17 +1364,53 @@ def cmd_shadow_stats(args: argparse.Namespace) -> int:
         "equivalence\n  means the agent chose the same next action. Numbers only, never content."
     )
     if _ctrs:
-        _seen = _ctrs.get("requests_seen", 0)
-        _sampled = _ctrs.get("sampled", 0)
-        _attempted = _ctrs.get("replay_attempted", 0)
-        _failed = _ctrs.get("replay_failed", 0)
-        _reason = _ctrs.get("last_fail_reason", "")
-        _recorded = _ctrs.get("recorded", 0)
-        _reason_str = f" (last: {_reason})" if _reason and _failed else ""
-        print(
-            f"\n  Sampling: {_seen} seen, {_sampled} sampled, "
-            f"{_attempted} attempted, {_failed} failed{_reason_str}, {_recorded} recorded"
-        )
+        # The RUNNING build's rate is the health signal; lifetime is context.
+        #
+        # These counters accumulate for the life of the install, so failures from a
+        # fixed bug stay in the displayed rate forever. Concretely: the temperature-0
+        # replay bug (fixed in 8c744df) left 295/323 failures behind, which pinned the
+        # lifetime rate at 42% while the rate since the fix was 5.3%. That does two
+        # things, and the second is the one that matters — a fixed bug makes the
+        # sampler look broken, and the next REAL regression has to clear a 42% noise
+        # floor before anyone notices it.
+        from .shadow import _counter_version
+
+        _by_version = _ctrs.get("by_version")
+        _cur = _by_version.get(_counter_version()) if isinstance(_by_version, dict) else None
+
+        def _line(src: dict, label: str) -> str:
+            seen, sampled = src.get("requests_seen", 0), src.get("sampled", 0)
+            attempted, failed = src.get("replay_attempted", 0), src.get("replay_failed", 0)
+            recorded = src.get("recorded", 0)
+            # A histogram, so a run mixing 400s, 429s and exceptions says so —
+            # `last_fail_reason` kept only the most recent, which made diagnosing
+            # the above archaeology rather than a read.
+            reasons = src.get("fail_reasons")
+            if isinstance(reasons, dict) and reasons:
+                top = sorted(reasons.items(), key=lambda kv: -kv[1])[:3]
+                why = " (" + ", ".join(f"{k}×{v}" for k, v in top) + ")"
+            else:
+                last = src.get("last_fail_reason", "")
+                why = f" (last: {last})" if last and failed else ""
+            rate = f" — {failed / attempted * 100:.1f}% of replays" if attempted and failed else ""
+            return (
+                f"  {label}: {seen} seen, {sampled} sampled, {attempted} attempted, "
+                f"{failed} failed{why}, {recorded} recorded{rate}"
+            )
+
+        print()
+        if isinstance(_cur, dict) and _cur:
+            print(_line(_cur, f"Sampling ({_counter_version()})"))
+            if _ctrs.get("replay_attempted", 0) > _cur.get("replay_attempted", 0):
+                print(_line(_ctrs, "  lifetime"))
+                print(
+                    "  (lifetime spans every build ever installed, including ones whose "
+                    "bugs are fixed —\n   judge the running build by its own line.)"
+                )
+        else:
+            # No per-version bucket yet: an install that has not shadowed anything
+            # since upgrading. Lifetime is all there is, and saying so is the point.
+            print(_line(_ctrs, "Sampling (lifetime — no samples yet on this build)"))
     return 0
 
 

--- a/distil/shadow.py
+++ b/distil/shadow.py
@@ -583,6 +583,10 @@ class ShadowCounters:
 
     _FILENAME = "shadow_counters.json"
 
+    #: Resolved once per process: `_current_version()` imports hotswap lazily, and
+    #: this runs on every flush from the background shadow thread.
+    _VERSION_CACHE: str | None = None
+
     def __init__(self, path: Path | None = None) -> None:
         self._path = path or (_state_dir() / self._FILENAME)
         self._lock = threading.Lock()
@@ -646,6 +650,40 @@ class ShadowCounters:
                         data = {}
                     for k, v in deltas.items():
                         data[k] = data.get(k, 0) + v
+                    # Per-version buckets, mirroring what ShadowLedger already does
+                    # for its rows. Without them these counters accumulate for the
+                    # life of the install, so failures from an ALREADY-FIXED bug stay
+                    # in the displayed rate forever: the temperature-0 replay bug
+                    # (fixed in 8c744df) left 295/323 failures behind, which held the
+                    # lifetime rate at 42% while the real rate since the fix was 5.3%.
+                    #
+                    # Two costs, and the second is the one that matters: a fixed bug
+                    # makes the sampler look broken, and the next REAL regression has
+                    # to clear that stale noise floor before anyone can see it.
+                    #
+                    # Deliberately NOT resetting on a version change — that would lose
+                    # the trend and make the opposite mistake, hiding a rate that
+                    # degrades across releases. Lifetime totals stay for continuity.
+                    by_version = data.get("by_version")
+                    if not isinstance(by_version, dict):
+                        by_version = {}
+                    bucket = by_version.get(_counter_version())
+                    if not isinstance(bucket, dict):
+                        bucket = {}
+                    for k, v in deltas.items():
+                        bucket[k] = int(bucket.get(k, 0)) + v
+                    if fail_reason:
+                        # A histogram, not a single value. `last_fail_reason` keeps
+                        # only the most recent, so a run mixing 400s, 429s and
+                        # exceptions reported whichever landed last — which turned
+                        # diagnosing the above into archaeology.
+                        reasons = bucket.get("fail_reasons")
+                        if not isinstance(reasons, dict):
+                            reasons = {}
+                        reasons[fail_reason] = int(reasons.get(fail_reason, 0)) + 1
+                        bucket["fail_reasons"] = reasons
+                    by_version[_counter_version()] = bucket
+                    data["by_version"] = by_version
                     if fail_reason:
                         data["last_fail_reason"] = fail_reason
                     f.seek(0)
@@ -676,6 +714,13 @@ class ShadowCounters:
                         fcntl.flock(f.fileno(), fcntl.LOCK_UN)
         except OSError:
             return {}
+
+
+def _counter_version() -> str:
+    """The version bucket key for the shadow counters (memoised)."""
+    if ShadowCounters._VERSION_CACHE is None:
+        ShadowCounters._VERSION_CACHE = _current_version()
+    return ShadowCounters._VERSION_CACHE
 
 
 def compare_decisions(compressed_resp: Any, original_resp: Any) -> bool:

--- a/tests/test_shadow_counters.py
+++ b/tests/test_shadow_counters.py
@@ -179,3 +179,232 @@ def test_renderer_shows_counter_line_when_samples_exist() -> None:
     assert "5 sampled" in out
     assert "5 recorded" in out
     assert "0 failed" in out
+
+
+# ---------------------------------------------------------------------------
+# Per-version buckets — a fixed bug must not depress the rate forever (#96)
+# ---------------------------------------------------------------------------
+
+
+def test_counters_are_bucketed_by_version(tmp_path: Path, monkeypatch) -> None:
+    """Lifetime totals accumulate for the life of the install, so failures from an
+    ALREADY-FIXED bug stay in the displayed rate forever.
+
+    Concretely, the case that prompted this: the temperature-0 replay bug (fixed in
+    8c744df) left 295/323 failures behind, which pinned the lifetime rate at 42%
+    while the real rate since the fix was 5.3%. Two consequences, and the second is
+    the one that matters — a fixed bug makes the sampler look broken, and the next
+    REAL regression has to clear that stale noise floor before anyone can see it.
+    """
+    import distil.shadow as sh
+
+    p = tmp_path / "ctr.json"
+    monkeypatch.setattr(sh.ShadowCounters, "_VERSION_CACHE", "1.0.0")
+    c = ShadowCounters(path=p)
+    c.note_seen()
+    c.flush_with(replay_attempted=True, replay_failed=True, fail_reason="400")
+
+    # ... a fix ships, and the next build behaves.
+    monkeypatch.setattr(sh.ShadowCounters, "_VERSION_CACHE", "1.1.0")
+    c2 = ShadowCounters(path=p)
+    c2.note_seen()
+    c2.flush_with(replay_attempted=True, recorded=True)
+
+    data = ShadowCounters.load(p)
+    assert data["replay_failed"] == 1, "lifetime totals stay, for continuity"
+    assert data["replay_attempted"] == 2
+    by_v = data["by_version"]
+    assert by_v["1.0.0"]["replay_failed"] == 1
+    assert by_v["1.1.0"].get("replay_failed", 0) == 0, (
+        "the fixed build must not inherit the broken build's failures"
+    )
+    assert by_v["1.1.0"]["recorded"] == 1
+
+
+def test_a_version_change_does_not_reset_the_lifetime_totals(tmp_path: Path, monkeypatch) -> None:
+    """Deliberately NOT resetting: that loses the trend and makes the opposite
+    mistake — a rate degrading across releases would become invisible."""
+    import distil.shadow as sh
+
+    p = tmp_path / "ctr.json"
+    for ver in ("1.0.0", "1.1.0", "1.2.0"):
+        monkeypatch.setattr(sh.ShadowCounters, "_VERSION_CACHE", ver)
+        ShadowCounters(path=p).flush_with(replay_attempted=True)
+    data = ShadowCounters.load(p)
+    assert data["replay_attempted"] == 3, "history must survive an upgrade"
+    assert set(data["by_version"]) == {"1.0.0", "1.1.0", "1.2.0"}
+
+
+def test_fail_reasons_are_a_histogram_not_the_last_one(tmp_path: Path, monkeypatch) -> None:
+    """`last_fail_reason` keeps only the most recent value, so a run mixing 400s,
+    429s and exceptions reported whichever landed last — which turned diagnosing a
+    real failure into archaeology rather than a read."""
+    import distil.shadow as sh
+
+    p = tmp_path / "ctr.json"
+    monkeypatch.setattr(sh.ShadowCounters, "_VERSION_CACHE", "1.0.0")
+    c = ShadowCounters(path=p)
+    for reason in ("400", "400", "429", "exception"):
+        c.flush_with(replay_attempted=True, replay_failed=True, fail_reason=reason)
+
+    bucket = ShadowCounters.load(p)["by_version"]["1.0.0"]
+    assert bucket["fail_reasons"] == {"400": 2, "429": 1, "exception": 1}
+    assert ShadowCounters.load(p)["last_fail_reason"] == "exception", "kept for continuity"
+
+
+def test_a_counter_file_written_before_buckets_existed_still_loads(tmp_path: Path) -> None:
+    """Every existing install has a bucket-less file; upgrading must not lose it."""
+    p = tmp_path / "ctr.json"
+    p.write_text(json.dumps({"requests_seen": 7, "replay_failed": 2}))
+    ShadowCounters(path=p).flush_with(replay_attempted=True)
+    data = ShadowCounters.load(p)
+    assert data["requests_seen"] == 7 and data["replay_failed"] == 2
+    assert data["replay_attempted"] == 1
+    assert "by_version" in data
+
+
+def test_a_corrupt_by_version_value_is_replaced_not_crashed(tmp_path: Path) -> None:
+    """Counters are diagnostics: a mangled file must never break the request path."""
+    p = tmp_path / "ctr.json"
+    p.write_text(json.dumps({"by_version": "not-a-dict"}))
+    ShadowCounters(path=p).flush_with(replay_attempted=True)
+    assert isinstance(ShadowCounters.load(p)["by_version"], dict)
+
+
+# ---------------------------------------------------------------------------
+# What `distil shadow-stats` actually prints (#96)
+# ---------------------------------------------------------------------------
+
+
+def _stats(home: Path, counters: dict, monkeypatch, capsys) -> str:
+    """Run `shadow-stats` IN-PROCESS.
+
+    A subprocess would be more end-to-end but invisible to coverage, so the
+    reporting branches these tests exist to pin would read as untested — and an
+    untested branch is the next one to rot.
+    """
+    import argparse
+
+    from distil import cli
+
+    (home / "shadow_counters.json").write_text(json.dumps(counters))
+    monkeypatch.setenv("DISTIL_HOME", str(home))
+    cli.cmd_shadow_stats(argparse.Namespace(record=False, max_change_rate=None))
+    return capsys.readouterr().out
+
+
+#: The real shape from the field: a lifetime dominated by an already-fixed bug.
+_FIELD = {
+    "requests_seen": 34315,
+    "sampled": 757,
+    "replay_attempted": 757,
+    "replay_failed": 318,
+    "recorded": 438,
+    "last_fail_reason": "exception",
+}
+
+
+def test_stats_leads_with_the_running_build_not_the_lifetime(tmp_path, monkeypatch, capsys) -> None:
+    """The headline number must describe the build the user is running.
+
+    Reading `318 failed` off a 42% lifetime rate says the sampler is broken. It
+    isn't — nearly all of those are 400s from a bug fixed months earlier.
+    """
+    import distil.shadow as sh
+
+    ctrs = dict(_FIELD)
+    ctrs["by_version"] = {
+        sh._counter_version(): {
+            "requests_seen": 900,
+            "sampled": 12,
+            "replay_attempted": 12,
+            "replay_failed": 1,
+            "recorded": 11,
+            "fail_reasons": {"429": 1},
+        }
+    }
+    out = _stats(tmp_path, ctrs, monkeypatch, capsys)
+    assert sh._counter_version() in out, "the running version must be named"
+    assert "12 replays attempted, 1 failed" in out or "12 attempted, 1 failed" in out
+    assert "318 failed" not in out.split("lifetime")[0], (
+        "the stale lifetime failure count must not be the headline"
+    )
+    assert "429×1" in out, "fail reasons are a histogram now"
+
+
+def test_stats_says_so_when_this_build_has_no_samples_yet(tmp_path, monkeypatch, capsys) -> None:
+    """Falling back to lifetime is fine — presenting it as current is not."""
+    out = _stats(tmp_path, dict(_FIELD), monkeypatch, capsys)
+    assert "lifetime" in out.lower()
+    assert "757" in out, "with nothing else to show, lifetime is what there is"
+
+
+def test_stats_with_samples_reports_this_build_and_labels_lifetime(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """The main reporting path — the one a user with real traffic actually sees.
+
+    The lifetime line must still be shown (dropping it would hide a rate degrading
+    across releases) but must be LABELLED, so nobody reads a fixed bug's failures
+    as the current state of the sampler.
+    """
+    import argparse
+
+    import distil.shadow as sh
+    from distil import cli
+    from distil.shadow import ShadowLedger
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    led = ShadowLedger()
+    for i in range(60):
+        led.record(i % 20 != 0, path=tmp_path / "shadow.jsonl")
+    for _ in range(40):
+        led.record(True, kind="aa", path=tmp_path / "shadow.jsonl")
+
+    ctrs = dict(_FIELD)
+    ctrs["by_version"] = {
+        sh._counter_version(): {
+            "requests_seen": 900,
+            "sampled": 12,
+            "replay_attempted": 12,
+            "replay_failed": 1,
+            "recorded": 11,
+            "fail_reasons": {"429": 1},
+        }
+    }
+    (tmp_path / "shadow_counters.json").write_text(json.dumps(ctrs))
+
+    cli.cmd_shadow_stats(argparse.Namespace(record=False, max_change_rate=None))
+    out = capsys.readouterr().out
+
+    assert f"Sampling ({sh._counter_version()})" in out, "the running build leads"
+    assert "429×1" in out, "fail reasons are a histogram"
+    assert "lifetime" in out, "history is kept as context, not dropped"
+    head = out.split("lifetime")[0]
+    assert "318 failed" not in head, "the stale failure count must not be the headline"
+    assert "8.3%" in out or "% of replays" in out, "the rate is stated, not left to arithmetic"
+
+
+def test_stats_falls_back_to_lifetime_but_says_so(tmp_path, monkeypatch, capsys) -> None:
+    """Just-upgraded install: samples exist, but none yet on this build.
+
+    Falling back to lifetime is correct — it is all there is. Presenting it as the
+    running build's rate is what this whole change exists to stop, so the label
+    carries the honesty.
+    """
+    import argparse
+
+    from distil import cli
+    from distil.shadow import ShadowLedger
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    led = ShadowLedger()
+    for i in range(60):
+        led.record(i % 20 != 0, path=tmp_path / "shadow.jsonl")
+
+    (tmp_path / "shadow_counters.json").write_text(json.dumps(dict(_FIELD)))  # no by_version
+    cli.cmd_shadow_stats(argparse.Namespace(record=False, max_change_rate=None))
+    out = capsys.readouterr().out
+
+    assert "no samples yet on this build" in out, "the fallback must announce itself"
+    assert "757" in out, "and still show what history there is"


### PR DESCRIPTION
Closes #96.

## The problem

`ShadowCounters` accumulates for the life of the install — `data[k] = data.get(k, 0) + v`, no reset, no version dimension — so failures from an **already-fixed** bug stay in the displayed rate forever:

| Window | Failed / attempted | Rate |
|---|---|---|
| Lifetime (what `shadow-stats` printed) | 318 / 757 | **42.0%** |
| Before the fix — the bug | 295 / 323 | 91.3% |
| Since the fix | 23 / 434 | **5.3%** |

The bug is the one `force_deterministic`'s own docstring records: pinning `temperature: 0` on every replay 400'd against extended thinking and against Opus 4.7+. Fixed in `8c744df`.

Two consequences, and the second is the one that matters:

1. A fixed bug makes the sampler look permanently broken.
2. **The next real regression is invisible** — it must clear a 42% noise floor before anyone notices.

## The fix

`ShadowLedger` already stamps rows with `_current_version()` (`shadow.py:509`); the counters never got the same treatment. Now they do — a `by_version` bucket alongside the lifetime totals:

```json
{
  "requests_seen": 34315,
  "replay_failed": 318,
  "by_version": {
    "1.42.0": {"replay_attempted": 12, "replay_failed": 1, "recorded": 11,
               "fail_reasons": {"429": 1}}
  }
}
```

`shadow-stats` leads with the running build and keeps lifetime as **labelled** context:

```
  Sampling (1.42.0): 900 seen, 12 sampled, 12 attempted, 1 failed (429×1), 11 recorded — 8.3% of replays
    lifetime: 34315 seen, 757 attempted, 318 failed ...
    (lifetime spans every build ever installed, including ones whose bugs are fixed —
     judge the running build by its own line.)
```

**Not** resetting on a version change, as the issue argues: that loses the trend and makes the opposite mistake — a rate degrading across releases would become invisible.

## Also from the issue

`last_fail_reason` kept only the most recent value, so a run mixing 400s, 429s and exceptions reported whichever landed last — which turned diagnosing this into archaeology rather than a read. Replaced with a `fail_reasons` histogram per version.

## Beyond the issue

- **Both display paths were wrong**, not just the one reported. The no-samples-yet branch (`cli.py:1280`) printed the same misleading lifetime line; it now leads with the running build too.
- A **bucket-less counter file** — which every existing install has — still loads and keeps its history.
- A **corrupt `by_version`** value is replaced rather than raised. These are diagnostics; they must never reach the request path.

## Testing

Each behaviour has a test verified to fail without its fix — 5 catch the missing buckets, 1 catches the display reading lifetime.

The display tests run `cmd_shadow_stats` **in-process** rather than as a subprocess. A subprocess is more end-to-end but invisible to coverage, so the reporting branches would have read as untested — and an untested branch is the next one to rot.

## Gate

```
3218 passed, 0 failed, 0 skipped
coverage 95.05% (floor 95%)
ruff check + format clean, mypy clean
```