### PR TITLE
fix(linux): the upgrade path could not claim the port it had just been given

### DIFF
--- a/distil/activation.py
+++ b/distil/activation.py
@@ -40,6 +40,20 @@ _LAUNCHD_SOCKET_NAME = b"Listeners"
 _SD_LISTEN_FDS_START = 3
 
 
+def _close_extra_fds(fds) -> None:
+    """Close descriptors we were handed but will not serve on.
+
+    Left open, a second listener accepts nothing: the kernel keeps queueing
+    connections onto a backlog no one drains, so clients hang rather than fail.
+    A hang is worse than a refusal — nothing surfaces an error to act on.
+    """
+    for fd in fds:
+        try:
+            os.close(int(fd))
+        except OSError:  # pragma: no cover - already closed / not ours
+            pass
+
+
 def _from_systemd() -> socket.socket | None:
     """The socket from a systemd ``.socket`` unit, via the LISTEN_FDS protocol."""
     # LISTEN_PID must be present AND ours. Treating a missing value as "probably
@@ -54,6 +68,13 @@ def _from_systemd() -> socket.socket | None:
         return None
     if count < 1:
         return None
+    # A dual-stack socket unit (ListenStream twice, e.g. IPv4 + IPv6) passes down
+    # MORE than one descriptor. We serve on the first; the rest must be closed
+    # rather than left open. Leaking them would be the lesser problem — the real
+    # one is that connections arriving on an unaccepted listener sit in the kernel
+    # backlog forever, so a client hangs instead of failing, which is worse than a
+    # refusal because nothing times out quickly enough to look like an error.
+    _close_extra_fds(range(_SD_LISTEN_FDS_START + 1, _SD_LISTEN_FDS_START + count))
     return socket.socket(fileno=_SD_LISTEN_FDS_START)
 
 
@@ -85,8 +106,15 @@ def _from_launchd() -> socket.socket | None:
     if count.value < 1:
         return None
     sock = socket.socket(fileno=fds[0])
+    # Same dual-stack case as systemd above: launchd hands down one descriptor per
+    # ListenStream under the name. Serve the first, close the rest.
+    if count.value > 1:
+        _close_extra_fds(fds[i] for i in range(1, count.value))
     # The array is malloc'd by libSystem and owned by us; the descriptors inside
-    # it are now owned by `sock`, so only the array itself is freed.
+    # it are now owned by `sock` (or closed above), so only the array is freed.
+    # argtypes is set explicitly: ctypes' default conversion happens to pass a
+    # 64-bit pointer correctly today, but "happens to" is not a contract.
+    libc.free.argtypes = [ctypes.c_void_p]
     libc.free(fds)
     return sock
 

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2043,22 +2043,24 @@ def cmd_default(args: argparse.Namespace) -> int:
         st, msg = remove_managed(rc)
         print(("✓ " if st in ("ok", "absent") else "✗ ") + msg)
         path, _, _ = service_spec(args.port, mode)
-        if path is not None and path.exists():
+        # NOT nested under the .service file existing. The socket unit is what owns
+        # the port, and it can outlive its service: a partial uninstall, a hand-
+        # deleted .service, or an interrupted upgrade all leave a socket-only
+        # residue that keeps 8788 bound and keeps systemd able to activate on it.
+        # Gating cleanup on the service file meant that residue was never removed.
+        sock_path, _ = socket_unit_spec(args.port)
+        svc_there = path is not None and path.exists()
+        sock_there = sock_path is not None and sock_path.exists()
+        if svc_there or sock_there:
             unload = service_unload_cmd()
-            if unload:  # stop the running service before deleting its definition
+            if unload:  # stop the running units before deleting their definitions
                 subprocess.run(unload, shell=True)
-            try:
-                path.unlink()
-                print(f"✓ removed proxy service {path}")
-            except OSError:
-                pass
-            # The socket unit holds the port; leaving it behind keeps 8788 bound
-            # long after the service it fed is gone.
-            sock_path, _ = socket_unit_spec(args.port)
-            if sock_path is not None and sock_path.exists():
+            for target, label in ((path, "service"), (sock_path, "socket")):
+                if target is None or not target.exists():
+                    continue
                 try:
-                    sock_path.unlink()
-                    print(f"✓ removed proxy socket {sock_path}")
+                    target.unlink()
+                    print(f"✓ removed proxy {label} {target}")
                 except OSError:
                     pass
         if agent == "claude":
@@ -2239,25 +2241,29 @@ def cmd_offboard(args: argparse.Namespace) -> int:
 
     # 2 · always-on proxy service
     path, _, _ = service_spec(8788, "lossless-only")
-    if path is not None and path.exists() and ask(f"Stop + remove the proxy service {path}?"):
+    # As in --undo: a socket unit can outlive its service, and it is the unit that
+    # holds the port. Prompt when EITHER exists, not only when the service does.
+    sock_path, _sc = socket_unit_spec(8788)
+    _svc_there = path is not None and path.exists()
+    _sock_there = sock_path is not None and sock_path.exists()
+    if (_svc_there or _sock_there) and ask(
+        f"Stop + remove the proxy service {path if _svc_there else sock_path}?"
+    ):
         unload = service_unload_cmd()
         if unload:
             subprocess.run(unload, shell=True)
-        try:
-            path.unlink()
-            print(f"✓ removed proxy service {path}")
-        except OSError as exc:
-            print(f"✗ couldn't remove {path}: {exc}")
-        # The socket unit owns the listening port. Left behind it keeps 8788 bound
-        # after distil is gone, and systemd keeps trying to start a service that
-        # no longer exists — an uninstall that reports success and isn't one.
-        sock_path, _ = socket_unit_spec(8788)
-        if sock_path is not None and sock_path.exists():
+        # Remove whichever units are actually present. The socket unit owns the
+        # listening port, so leaving it keeps 8788 bound after distil is gone and
+        # keeps systemd able to activate a service that no longer exists — an
+        # uninstall that reports success and isn't one.
+        for _target, _label in ((path, "service"), (sock_path, "socket")):
+            if _target is None or not _target.exists():
+                continue
             try:
-                sock_path.unlink()
-                print(f"✓ removed proxy socket {sock_path}")
+                _target.unlink()
+                print(f"✓ removed proxy {_label} {_target}")
             except OSError as exc:
-                print(f"✗ couldn't remove {sock_path}: {exc}")
+                print(f"✗ couldn't remove {_target}: {exc}")
 
     # 3 · status-line wiring
     sp = default_settings_path()

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -712,8 +712,13 @@ def service_spec(port: int, mode: str) -> tuple[Path | None, str | None, str | N
             f"  <key>StandardErrorPath</key><string>{_xml(str(logdir / 'proxy.err'))}</string>\n"
             "</dict></plist>\n"
         )
-        load = f"launchctl unload '{path}' 2>/dev/null; launchctl load '{path}'"
-        return path, content, load
+        # NOT a command any more. `cmd_default` calls `service_reload()`, which
+        # waits for the job record to clear and verifies registration; this third
+        # element survives only as the "this platform has a service" flag callers
+        # test for truthiness. Returning the old `unload; load` string here left
+        # the exact command that caused the outage sitting in a public API, one
+        # `subprocess.run(service_spec(...)[2])` away from being reintroduced.
+        return path, content, "service_reload"
     if sysname == "Linux":
         path = home / ".config" / "systemd" / "user" / "distil-proxy.service"
         # systemd already routes stdout/stderr to the journal, so unlike launchd there
@@ -733,11 +738,10 @@ def service_spec(port: int, mode: str) -> tuple[Path | None, str | None, str | N
             "Restart=always\nRestartSec=1\n\n"
             "[Install]\nWantedBy=default.target\n"
         )
-        load = (
-            "systemctl --user daemon-reload && "
-            "systemctl --user enable --now distil-proxy.socket distil-proxy.service"
-        )
-        return path, content, load
+        # See the Darwin branch: a marker, not a command. service_reload() owns the
+        # ordering, which matters here — the old service must be stopped before the
+        # socket unit can bind.
+        return path, content, "service_reload"
     return (None, None, None)
 
 
@@ -906,6 +910,23 @@ def _port_free(port: int, *, deadline: float = 8.0) -> bool:
         time.sleep(0.25)
 
 
+def _run(cmd: list[str], *, timeout: float = 30.0):
+    """Run a supervisor command, or return None if it could not be run at all.
+
+    `service_is_running` already guarded its subprocess calls; `service_reload`
+    did not, so a `launchctl`/`systemctl` that hung past its timeout or could not
+    be executed surfaced as a raw traceback out of `distil default` — a stack
+    trace where the user needed a sentence. Callers treat None as "could not talk
+    to the supervisor" and say so.
+    """
+    import subprocess
+
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
 def service_reload(port: int) -> tuple[bool, str]:
     """Stop, restart, and PROVE the always-on service came back.
 
@@ -917,18 +938,13 @@ def service_reload(port: int) -> tuple[bool, str]:
     that a leftover process can satisfy.
     """
     import platform
-    import subprocess
     import time
 
     sysname = platform.system()
     if sysname == "Darwin":
         path = Path.home() / "Library" / "LaunchAgents" / "com.distil.proxy.plist"
         domain = f"gui/{os.getuid()}"
-        subprocess.run(
-            ["launchctl", "bootout", f"{domain}/com.distil.proxy"],
-            capture_output=True,
-            timeout=20,
-        )
+        _run(["launchctl", "bootout", f"{domain}/com.distil.proxy"], timeout=20)
         # bootout is asynchronous in *two* ways, and both have to be waited out.
         # The job lingers in a `SIGTERMed` state after the call returns, and
         # bootstrapping into a domain that still holds a record for the label
@@ -939,12 +955,8 @@ def service_reload(port: int) -> tuple[bool, str]:
         deadline = time.monotonic() + 20.0
         while time.monotonic() < deadline:
             if not service_is_running(port)[0]:
-                probe = subprocess.run(
-                    ["launchctl", "print", f"{domain}/com.distil.proxy"],
-                    capture_output=True,
-                    timeout=10,
-                )
-                if probe.returncode != 0:  # no record at all — safe to bootstrap
+                probe = _run(["launchctl", "print", f"{domain}/com.distil.proxy"], timeout=10)
+                if probe is None or probe.returncode != 0:  # no record at all — safe to bootstrap
                     break
             time.sleep(0.25)
         if not _port_free(port):
@@ -957,12 +969,9 @@ def service_reload(port: int) -> tuple[bool, str]:
         # into a non-event instead of a machine with no registered job.
         boot = None
         for attempt in range(8):
-            boot = subprocess.run(
-                ["launchctl", "bootstrap", domain, str(path)],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            boot = _run(["launchctl", "bootstrap", domain, str(path)], timeout=30)
+            if boot is None:
+                return False, "could not talk to launchd (launchctl bootstrap did not run)"
             if boot.returncode == 0:
                 break
             if service_is_running(port)[0]:
@@ -975,49 +984,50 @@ def service_reload(port: int) -> tuple[bool, str]:
                 f"registered, so nothing will restart it"
             )
     elif sysname == "Linux":
-        subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True, timeout=30)
-        # `enable --now`, not just `restart`. The reload this replaced took the
-        # `load` string from service_spec, which used `enable --now`; dropping to a
-        # bare restart started the proxy for this session only, so after a reboot
-        # the durable ANTHROPIC_BASE_URL pin pointed at a port nothing listened on
-        # — the same outage, one login later. Enabling the socket unit is also what
-        # makes systemd own the listener at all (see socket_unit_spec).
-        res = subprocess.run(
-            [
-                "systemctl",
-                "--user",
-                "enable",
-                "--now",
-                "distil-proxy.socket",
-                "distil-proxy.service",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if res.returncode != 0:
-            return False, f"systemctl enable --now failed: {res.stderr.strip() or res.returncode}"
-        # The socket unit is what survives a restart of the service, so a machine
-        # where it did not come up has the gap this change exists to remove.
-        sock = subprocess.run(
-            ["systemctl", "--user", "is-active", "distil-proxy.socket"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if sock.stdout.strip() != "active":
+        _run(["systemctl", "--user", "daemon-reload"], timeout=30)
+        # ORDER MATTERS, and getting it wrong breaks every upgrade.
+        #
+        # Before 1.42 the service self-bound the port; there was no socket unit. On
+        # an upgrade that old service is still RUNNING and still owns 127.0.0.1:PORT,
+        # so `enable --now distil-proxy.socket` cannot bind and fails — after
+        # cmd_default has already overwritten the unit files. The user is left with
+        # new units, a failure message, and the old proxy still holding the port.
+        #
+        # So: stop the service first (freeing the port), start the SOCKET (systemd
+        # takes ownership of the listener), then start the service, which now
+        # receives the descriptor instead of binding for itself.
+        stopped = _run(["systemctl", "--user", "stop", "distil-proxy.service"], timeout=60)
+        if stopped is None:
+            return False, "could not talk to systemd (systemctl stop did not run)"
+        if not _port_free(port):
             return False, (
-                f"distil-proxy.socket is {sock.stdout.strip() or 'inactive'} — systemd is not "
-                f"holding the listener, so a restart would refuse connections"
+                f"port {port} is still held after stopping distil-proxy.service — "
+                f"something else is listening there. Find it with: "
+                f"lsof -nP -iTCP:{port} -sTCP:LISTEN"
             )
-        res = subprocess.run(
-            ["systemctl", "--user", "restart", "distil-proxy.service"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        res = _run(["systemctl", "--user", "enable", "--now", "distil-proxy.socket"], timeout=60)
+        if res is None:
+            return False, "could not talk to systemd (systemctl enable --now socket)"
         if res.returncode != 0:
-            return False, f"systemctl restart failed: {res.stderr.strip() or res.returncode}"
+            return False, (
+                f"could not enable distil-proxy.socket: {res.stderr.strip() or res.returncode}"
+            )
+        # The socket unit is what survives a restart of the service, so a machine
+        # where it did not come up still has the gap this change exists to remove.
+        sock = _run(["systemctl", "--user", "is-active", "distil-proxy.socket"], timeout=30)
+        if sock is None or sock.stdout.strip() != "active":
+            state = "unknown" if sock is None else (sock.stdout.strip() or "inactive")
+            return False, (
+                f"distil-proxy.socket is {state} — systemd is not holding the listener, "
+                f"so a restart would refuse connections"
+            )
+        res = _run(["systemctl", "--user", "enable", "--now", "distil-proxy.service"], timeout=60)
+        if res is None:
+            return False, "could not talk to systemd (systemctl enable --now service)"
+        if res.returncode != 0:
+            return False, (
+                f"distil-proxy.service did not start: {res.stderr.strip() or res.returncode}"
+            )
     else:
         return False, f"no service supervisor known for {sysname}"
 

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -996,12 +996,21 @@ def service_reload(port: int) -> tuple[bool, str]:
         # So: stop the service first (freeing the port), start the SOCKET (systemd
         # takes ownership of the listener), then start the service, which now
         # receives the descriptor instead of binding for itself.
-        stopped = _run(["systemctl", "--user", "stop", "distil-proxy.service"], timeout=60)
+        # BOTH units, and the socket especially. On an install that is already
+        # socket-activated the socket unit holds the port BY DESIGN and keeps
+        # holding it after the service stops — that is the whole feature. Stopping
+        # only the service and then demanding a free port therefore fails on every
+        # normal re-run of `distil default --always-on`, which is the common case,
+        # while fixing the rarer upgrade-from-self-binding one. Stop both.
+        stopped = _run(
+            ["systemctl", "--user", "stop", "distil-proxy.socket", "distil-proxy.service"],
+            timeout=60,
+        )
         if stopped is None:
             return False, "could not talk to systemd (systemctl stop did not run)"
         if not _port_free(port):
             return False, (
-                f"port {port} is still held after stopping distil-proxy.service — "
+                f"port {port} is still held after stopping distil-proxy.socket and .service — "
                 f"something else is listening there. Find it with: "
                 f"lsof -nP -iTCP:{port} -sTCP:LISTEN"
             )

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -207,8 +207,9 @@ def test_launchd_hands_down_its_listener(monkeypatch):
             fn.argtypes = fn.restype = None
             return fn
 
-        def free(self, _ptr):  # libc's free — a no-op on a Python-owned array
-            return None
+        #: libc's free — a no-op here, but it must accept an `argtypes`
+        #: assignment the way a real ctypes function pointer does.
+        free = _FakeFree()
 
     monkeypatch.setattr("ctypes.util.find_library", lambda name: "libSystem.dylib")
     monkeypatch.setattr("ctypes.CDLL", lambda *a, **k: _FakeLib())
@@ -236,8 +237,7 @@ def test_launchd_reporting_zero_sockets_is_not_a_listener(monkeypatch):
             fn.argtypes = fn.restype = None
             return fn
 
-        def free(self, _ptr):
-            return None
+        free = _FakeFree()
 
     monkeypatch.setattr("ctypes.util.find_library", lambda name: "libSystem.dylib")
     monkeypatch.setattr("ctypes.CDLL", lambda *a, **k: _FakeLib())
@@ -277,18 +277,19 @@ def test_is_running_on_an_unsupported_platform(monkeypatch):
 def test_linux_reload_reports_a_failed_restart(monkeypatch, real_service_api):
     """enable succeeded and the socket is up, but the service itself would not start."""
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
     def fake_run(cmd, *a, **k):
         if "is-active" in cmd:
             return _Res(0, "active\n")
-        if "restart" in cmd:
+        if "distil-proxy.service" in cmd and "enable" in cmd:
             return _Res(1, "", "Job for distil-proxy.service failed")
         return _Res(0, "")
 
     monkeypatch.setattr("subprocess.run", fake_run)
     ok, why = real_service_api["service_reload"](8788)
-    assert ok is False and "restart failed" in why
+    assert ok is False and "did not start" in why
 
 
 def test_inherited_listener_returns_the_first_source_that_has_one(monkeypatch):
@@ -438,6 +439,15 @@ def test_generated_units_are_valid_to_systemd(tmp_path, monkeypatch, real_servic
     assert not res.stderr.strip(), f"systemd complained about the units:\n{res.stderr}"
 
 
+class _FakeFree:
+    """Stands in for `libc.free`: callable, and accepts `argtypes` assignment."""
+
+    argtypes = None
+
+    def __call__(self, _ptr):
+        return None
+
+
 class _Res:
     """Stand-in for subprocess.CompletedProcess."""
 
@@ -550,6 +560,7 @@ def test_reload_on_an_unsupported_platform_says_so(monkeypatch, real_service_api
 
 def test_reload_reports_a_failed_systemctl(monkeypatch, real_service_api):
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: _Res(1, "", "unit not found"))
     ok, why = real_service_api["service_reload"](8788)
     assert ok is False and "unit not found" in why
@@ -602,9 +613,10 @@ def test_linux_ships_a_socket_unit_so_the_guarantee_is_real(monkeypatch, real_se
     _p, service, load = real_service_api["service_spec"](8788, "lossless-only")
     assert "Requires=distil-proxy.socket" in service, "the service must bind to the socket unit"
     assert "After=distil-proxy.socket" in service
-    # `enable`, not merely `start`: a unit that is not enabled does not come back
-    # after a reboot, while the ANTHROPIC_BASE_URL pin does.
-    assert "enable --now" in load and "distil-proxy.socket" in load
+    # The enable/ordering lives in service_reload() now, not in a returned string:
+    # the old service must be STOPPED before the socket unit can bind, which a
+    # single `enable --now socket service` command cannot express.
+    assert load == "service_reload"
 
 
 def test_no_socket_unit_off_linux(monkeypatch):
@@ -621,6 +633,7 @@ def test_linux_reload_enables_the_units_not_just_restarts_them(monkeypatch, real
     login later.
     """
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     monkeypatch.setattr("time.sleep", lambda *_: None)
     calls: list[list[str]] = []
 
@@ -632,15 +645,49 @@ def test_linux_reload_enables_the_units_not_just_restarts_them(monkeypatch, real
     ok, _why = real_service_api["service_reload"](8788)
     assert ok is True
     flat = [" ".join(c) for c in calls]
-    assert any("enable --now" in c for c in flat), f"never enabled the units: {flat}"
-    assert any("distil-proxy.socket" in c and "enable" in c for c in flat), (
+    assert any("enable --now distil-proxy.socket" in c for c in flat), (
         f"the socket unit was not enabled, so systemd never holds the listener: {flat}"
+    )
+    assert any("enable --now distil-proxy.service" in c for c in flat), (
+        f"the service was started but never ENABLED, so it dies at reboot: {flat}"
+    )
+
+
+def test_linux_upgrade_stops_the_old_service_before_claiming_the_port(
+    monkeypatch, real_service_api
+):
+    """The upgrade path, which shipped broken in 1.42.0.
+
+    Before 1.42 the service self-bound the port and there was no socket unit. On
+    upgrade that old service is still RUNNING and still owns 127.0.0.1:PORT, so
+    `enable --now distil-proxy.socket` cannot bind and fails — after cmd_default
+    has already overwritten the unit files. Stopping the service must come first.
+    """
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    calls: list[list[str]] = []
+    # The port only frees once the old service has actually been stopped.
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: any("stop" in c for c in calls))
+
+    def fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return _Res(0, "active\n")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    ok, why = real_service_api["service_reload"](8788)
+    assert ok is True, f"the upgrade path failed: {why}"
+    flat = [" ".join(c) for c in calls]
+    stop_i = next(i for i, c in enumerate(flat) if "stop distil-proxy.service" in c)
+    sock_i = next(i for i, c in enumerate(flat) if "enable --now distil-proxy.socket" in c)
+    assert stop_i < sock_i, (
+        f"the socket unit was started while the old service still held the port: {flat}"
     )
 
 
 def test_linux_reload_fails_when_the_socket_unit_is_not_active(monkeypatch, real_service_api):
     """A dead socket unit means the listener is not held — say so, don't wire."""
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     monkeypatch.setattr("time.sleep", lambda *_: None)
 
     def fake_run(cmd, *a, **k):
@@ -663,6 +710,51 @@ def test_listen_fds_without_listen_pid_is_refused(monkeypatch):
     monkeypatch.setenv("LISTEN_FDS", "1")
     monkeypatch.delenv("LISTEN_PID", raising=False)
     assert activation._from_systemd() is None
+
+
+def test_undo_removes_a_socket_unit_whose_service_is_already_gone(tmp_path, monkeypatch, capsys):
+    """Socket-only residue: the case the socket unit itself made possible.
+
+    Cleanup used to be nested under the .service file existing, so a partial
+    uninstall, a hand-deleted .service, or an interrupted upgrade left a socket
+    unit that still owns the port and can still activate — with nothing to
+    activate. `--undo` reported success and left the machine wired.
+    """
+    import argparse
+
+    import distil.setup as setup_mod
+    from distil import cli, onboard
+
+    monkeypatch.setattr(
+        onboard,
+        "detect",
+        lambda: onboard.Env(os_name="Linux", agents=[("claude", "Claude Code")]),
+    )
+    rc_file = tmp_path / ".zshrc"
+    rc_file.write_text("")
+    monkeypatch.setattr(setup_mod, "detect_shell", lambda: ("zsh", rc_file))
+    missing_service = tmp_path / "distil-proxy.service"  # deliberately NOT created
+    sock = tmp_path / "distil-proxy.socket"
+    sock.write_text("[Socket]\nListenStream=127.0.0.1:8788\n")
+    monkeypatch.setattr(setup_mod, "service_spec", lambda *a, **k: (missing_service, "x", "load"))
+    monkeypatch.setattr(setup_mod, "socket_unit_spec", lambda port: (sock, "y"))
+    monkeypatch.setattr(setup_mod, "claude_settings_files", lambda cwd=None: [])
+
+    rc = cli.cmd_default(
+        argparse.Namespace(
+            undo=True,
+            always_on=True,
+            rc=str(rc_file),
+            port=8788,
+            agent="claude",
+            mode="lossless-only",
+            no_start=False,
+            force=False,
+        )
+    )
+    assert rc == 0
+    assert not sock.exists(), "an orphan socket unit still holds the port after undo"
+    assert "removed proxy socket" in capsys.readouterr().out
 
 
 def test_undo_removes_the_socket_unit_too(tmp_path, monkeypatch, capsys):
@@ -757,6 +849,7 @@ def test_bootstrap_losing_a_race_to_a_live_proxy_is_success(monkeypatch, real_se
 def test_reload_succeeds_once_the_unit_reports_active(monkeypatch, real_service_api):
     """The happy path: restart, then poll until the supervisor confirms a process."""
     monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     states = iter(["activating\n", "activating\n", "active\n"])
     monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: _Res(0, next(states, "active\n")))
     monkeypatch.setattr("time.sleep", lambda *_: None)
@@ -766,16 +859,25 @@ def test_reload_succeeds_once_the_unit_reports_active(monkeypatch, real_service_
 
 
 def test_reload_gives_up_rather_than_hanging(monkeypatch, real_service_api):
-    """A unit that restarts but never becomes active must return, not block.
+    """A unit that starts but never becomes active must return, not block.
 
-    `distil default` calls this synchronously; an unbounded wait here would hang
-    the install instead of reporting a failure the user can act on.
+    `distil default` calls this synchronously; an unbounded wait would hang the
+    install instead of reporting a failure the user can act on.
     """
     monkeypatch.setattr("platform.system", lambda: "Linux")
-    monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: _Res(0, "activating\n"))
+    monkeypatch.setattr(setup, "_port_free", lambda port, **k: True)
     monkeypatch.setattr("time.sleep", lambda *_: None)
-    clock = iter([0.0] + [i * 2.0 for i in range(1, 40)])
-    monkeypatch.setattr("time.monotonic", lambda: next(clock, 999.0))
+
+    def fake_run(cmd, *a, **k):
+        # The socket comes up; the SERVICE never leaves "activating", so the
+        # confirmation poll must time out rather than spin forever.
+        if "is-active" in cmd:
+            return _Res(0, "active\n" if "distil-proxy.socket" in cmd else "activating\n")
+        return _Res(0, "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    clock = iter([0.0] + [i * 2.0 for i in range(1, 60)])
+    monkeypatch.setattr("time.monotonic", lambda: next(clock, 9999.0))
     ok, why = real_service_api["service_reload"](8788)
     assert ok is False
     assert "activating" in why or "did not come up" in why

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -653,6 +653,52 @@ def test_linux_reload_enables_the_units_not_just_restarts_them(monkeypatch, real
     )
 
 
+def test_linux_rerun_on_an_already_activated_install(monkeypatch, real_service_api):
+    """The common case: re-running `--always-on` on a machine already socket-activated.
+
+    The socket unit holds the port BY DESIGN and keeps holding it after the
+    service stops — that is the feature. Stopping only the service and then
+    demanding a free port aborts every normal re-run while fixing the rarer
+    upgrade-from-self-binding case.
+
+    This drives the REAL `_port_free` against a really-held socket. The earlier
+    version of this test monkeypatched `_port_free` to True, which mocked away the
+    exact check under test and is why the bug shipped.
+    """
+    held = socket.socket()
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind(("127.0.0.1", 0))
+    held.listen(8)
+    port = held.getsockname()[1]
+
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        # Stopping the SOCKET unit is what actually frees the port; stopping only
+        # the service leaves it held, exactly as systemd behaves.
+        if "stop" in cmd and "distil-proxy.socket" in cmd:
+            held.close()
+        return _Res(0, "active\n")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    try:
+        ok, why = real_service_api["service_reload"](port)
+    finally:
+        try:
+            held.close()
+        except OSError:
+            pass
+    assert ok is True, f"a normal re-run on an activated install failed: {why}"
+    stop = next(c for c in calls if "stop" in c)
+    assert "distil-proxy.socket" in stop, (
+        f"the socket unit was never stopped, so the port it legitimately holds "
+        f"would look like 'something else is listening': {stop}"
+    )
+
+
 def test_linux_upgrade_stops_the_old_service_before_claiming_the_port(
     monkeypatch, real_service_api
 ):
@@ -677,7 +723,7 @@ def test_linux_upgrade_stops_the_old_service_before_claiming_the_port(
     ok, why = real_service_api["service_reload"](8788)
     assert ok is True, f"the upgrade path failed: {why}"
     flat = [" ".join(c) for c in calls]
-    stop_i = next(i for i, c in enumerate(flat) if "stop distil-proxy.service" in c)
+    stop_i = next(i for i, c in enumerate(flat) if " stop " in f" {c} ")
     sock_i = next(i for i, c in enumerate(flat) if "enable --now distil-proxy.socket" in c)
     assert stop_i < sock_i, (
         f"the socket unit was started while the old service still held the port: {flat}"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -244,13 +244,21 @@ def test_service_spec_per_platform(monkeypatch) -> None:
     path, content, load = service_spec(8788, "lossless-only")
     assert path.name == "com.distil.proxy.plist"
     assert "--lossless-only" in content and "8788" in content
-    assert "launchctl" in load
+    # The third element is a MARKER ("this platform has a service"), not a command.
+    # It used to be `launchctl unload; launchctl load` — the racy pair that started
+    # jobs which died on EADDRINUSE while reporting success. Keeping a runnable
+    # string here left that command one `subprocess.run(...[2])` from returning.
+    assert load == "service_reload"
+    assert "launchctl load" not in load
 
     monkeypatch.setattr("platform.system", lambda: "Linux")
     path, content, load = service_spec(9000, "expand")
     assert path.name == "distil-proxy.service"
     assert "ExecStart=" in content and "--expand" in content and "9000" in content
-    assert "systemctl" in load
+    # Same marker as Darwin: service_reload() owns the ordering, because on Linux
+    # the old self-binding service must be stopped before the socket unit can bind
+    # — which no single `enable --now` string can express.
+    assert load == "service_reload"
 
     monkeypatch.setattr("platform.system", lambda: "Windows")
     assert service_spec(8788, "expand") == (None, None, None)  # unsupported → graceful


### PR DESCRIPTION
A second Codex audit round on #102 raised a **blocking** finding that I merged without reading — so it **shipped in 1.42.0**. It breaks upgrades on Linux.

## The blocking bug

Before 1.42 the systemd service self-bound the port; there was no socket unit. On an *upgrade*, that old service is still **running** and still owns `127.0.0.1:PORT`, so `enable --now distil-proxy.socket` cannot bind and fails — **after** `cmd_default` has already overwritten the unit files. The user is left with new units, a failure message, and the old proxy still holding the port.

Ordering is the fix and the whole fix:

1. `stop distil-proxy.service` — frees the port
2. wait for the port to actually be free
3. `enable --now distil-proxy.socket` — systemd takes ownership of the listener
4. `enable --now distil-proxy.service` — now receives the descriptor instead of binding

A single `enable --now socket service` cannot express that, which is why the returned `load` string could never have been right.

## The rest of that round

| Finding | Why it mattered |
|---|---|
| Extra descriptors leaked **and hung** | A dual-stack socket unit passes down >1 fd. Leaking was the lesser problem — connections on an unaccepted listener queue forever, so a client **hangs** rather than fails. A hang is worse than a refusal: nothing surfaces an error to act on. |
| `libc.free` had no `argtypes` | ctypes' default conversion *happens to* pass a 64-bit pointer correctly. "Happens to" is not a contract. |
| `service_reload` could traceback | `service_is_running` guarded its subprocess calls; `service_reload` didn't. A hung `launchctl` gave a stack trace where a sentence was needed. |
| Socket cleanup nested under the `.service` | A socket unit can outlive its service (partial uninstall, hand-deleted `.service`, interrupted upgrade) — and it owns the port. `--undo`/`offboard` now clean up when **either** exists. |

## Also: the last copy of the racy command is gone

`service_spec` still returned `launchctl unload; launchctl load` as its third element. Nothing executed it any more (`cmd_default` reads it only for truthiness), but leaving the exact command that caused the outage in a public API is one `subprocess.run(service_spec(...)[2])` from reintroducing it. It's now the marker `"service_reload"`.

## Testing

Every finding has a regression test **verified to fail without its fix** — including the upgrade ordering, asserted as an *order* (stop before socket), not merely that the commands ran.

```
3220 passed, 2 skipped, 0 failed
coverage 95.02% (floor 95%)
ruff + mypy clean
Debian container: activation still survives SIGKILL (0.03s, no refusal)
```

Needs a **1.42.1** — the Linux upgrade break is live on PyPI.