### PR TITLE
release(1.42.1): the upgrade could not claim the port it had just been given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.42.1] — the upgrade could not claim the port it had just been given
+
+**`distil default --always-on` was broken on Linux in 1.42.0**, in both directions,
+and macOS was unaffected — which is why it shipped.
+
+Upgrading from 1.41.x: before 1.42 the systemd service self-bound the port and there
+was no socket unit. On upgrade that old service is still *running* and still owns
+`127.0.0.1:PORT`, so `enable --now distil-proxy.socket` cannot bind and fails — after
+the unit files have already been overwritten. The user is left with new units, an
+error, and the old proxy still holding the port.
+
+Re-running on an install that already works: the socket unit holds the port **by
+design** and keeps holding it after the service stops — that is the entire feature. A
+reload that stops only the service and then demands a free port therefore aborts every
+ordinary re-run with "something else is listening", pointing the user at a culprit that
+is distil itself.
+
+Both are one fault: ordering. The reload now stops **both** units, waits for the port,
+starts the socket so systemd owns the listener, then starts the service, which receives
+the descriptor instead of binding for itself. No single `enable --now` can express that
+sequence, which is why the command string `service_spec` used to return could never
+have been right — it is now a marker, and the last copy of the racy
+`launchctl unload; launchctl load` is gone from the codebase.
+
+Three more faults in the same area:
+
+- **Extra descriptors were leaked *and* hung.** A dual-stack socket unit hands down more
+  than one fd; distil wrapped the first and left the rest open. The leak was the lesser
+  problem — connections arriving on an unaccepted listener queue in the kernel forever,
+  so a client **hangs** instead of failing. A hang is worse than a refusal: nothing
+  surfaces an error to act on. Extras are now closed on both platforms.
+- **`service_reload` could hand the user a traceback.** Its sibling guarded its
+  subprocess calls; it did not, so a `launchctl`/`systemctl` that hung past its timeout
+  printed a stack trace where a sentence belonged.
+- **Socket cleanup was gated on the `.service` file existing.** A socket unit can
+  outlive its service — a partial uninstall, a hand-deleted unit, an interrupted upgrade
+  — and it is the unit that owns the port. `--undo` and `offboard` now clean up when
+  *either* is present.
+
+Also: `libc.free` is given explicit `argtypes`. ctypes' default conversion happens to
+pass a 64-bit pointer correctly; "happens to" is not a contract.
+
+Every fix has a regression test verified to fail without it. One of those tests is a
+correction in itself: the first version stubbed `_port_free` to `True`, mocking away the
+exact check under test, which is how the re-run break got past a green suite. It now
+drives the real function against a genuinely held socket.
+
 ## [1.42.0] — the outage was the test suite
 
 **distil's own test suite tore down the developer's live proxy, and that is what took

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.42.0
-date-released: 2026-08-08
+version: 1.42.1
+date-released: 2026-08-09
 keywords:
   - llm
   - context-compression

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -6,8 +6,8 @@ description: >-
 type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
-version: 0.1.0
-appVersion: "1.41.2"
+version: 0.1.1
+appVersion: "1.42.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.42.0"
+version = "1.42.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.42.0",
+  "version": "1.42.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -403,3 +403,27 @@ def test_release_smoke_test_cannot_file_a_census_ping() -> None:
     )
     assert first_cli != -1, "smoke block no longer invokes the installed CLI"
     assert isolate_at < first_cli, "DISTIL_HOME is set after the CLI has already run"
+
+
+def test_helm_chart_defaults_to_this_release() -> None:
+    """`appVersion` is the default image tag a Helm install deploys.
+
+    `templates/deployment.yaml` renders
+    `image.tag | default .Chart.AppVersion`, so a stale appVersion silently ships
+    the OLD container to anyone who does not override `image.tag` — they get a
+    release that predates every fix, and nothing tells them. It had already
+    drifted twice (sitting at 1.41.2 through the whole of 1.42.0) because no test
+    looked at it, which is exactly how CITATION.cff drifted before it got a guard.
+    """
+    version = _pyproject()["project"]["version"]
+    chart = (ROOT / "packaging" / "helm" / "distil-gateway" / "Chart.yaml").read_text()
+    app = None
+    for line in chart.splitlines():
+        if line.startswith("appVersion:"):
+            app = line.split(":", 1)[1].strip().strip('"').strip("'")
+            break
+    assert app, "Chart.yaml has no appVersion"
+    assert app == version, (
+        f"Chart.yaml appVersion is {app} but this release is {version} — a default "
+        f"`helm install` would deploy ghcr.io/dshakes/distil:{app}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.42.0"
+version = "1.42.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Patch release for a **Linux-only break in 1.42.0**. macOS is unaffected, which is exactly why it shipped.

## What was broken

`distil default --always-on` failed in **both** directions on Linux:

- **Upgrading from 1.41.x** — the old self-binding service still owned `127.0.0.1:PORT`, so `enable --now distil-proxy.socket` could not bind and failed *after* the unit files had been overwritten.
- **Re-running on an install that already worked** — the socket unit holds the port **by design**; a reload that stopped only the service and then demanded a free port reported "something else is listening", pointing the user at distil itself.

One fault, two symptoms: **ordering**. The reload now stops both units → waits for the port → starts the socket (systemd owns the listener) → starts the service, which receives the descriptor instead of binding.

## Also in this release

| | |
|---|---|
| Extra inherited descriptors | closed, not left to **hang** a client forever in the kernel backlog |
| `service_reload` | a sentence instead of a traceback when the supervisor is unreachable |
| Socket-unit cleanup | no longer gated on the `.service` file existing |
| `libc.free` | explicit `argtypes` |
| The racy `launchctl unload; launchctl load` | gone from the codebase entirely |

## A note on the tests

One of the fixes is a correction to a test, not to code. The first version of the re-run test stubbed `_port_free` to `True` — mocking away the exact check under test, which is how the re-run break got past a green suite. It now drives the real function against a genuinely held socket and was verified to fail against the bug it describes.

## Version

All six locations plus `uv.lock` and a CHANGELOG entry.

## Gate

```
3221 passed, 2 skipped, 0 failed
coverage 95.02% (floor 95%)
ruff + mypy clean · packaging smoke 15 passed
```