### PR TITLE
fix(macos): the reload aborted onto a held port and left no proxy behind

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2133,7 +2133,14 @@ def cmd_default(args: argparse.Namespace) -> int:
             started, why = service_reload(args.port)
             if not started:
                 print(f"\n✗ the proxy service did not start — {why}")
-                print("  Nothing was wired. Your existing setup is untouched.")
+                # NOT "your existing setup is untouched" — that was a lie in the
+                # only case it printed. Reaching here means the old service was
+                # already stopped and this service file replaced it, so the
+                # machine has no working proxy while ANTHROPIC_BASE_URL may still
+                # point at the port. Say that, and give the way back.
+                print("  The base URL was NOT wired, but the previous service is stopped —")
+                print("  until this starts, traffic to that port has nowhere to go.")
+                print(f"  Recover now:  distil default --always-on --port {args.port}")
                 print(f"  See the error yourself:  distil proxy --{mode} --port {args.port}")
                 print(f"  Logs: {log_dir() / 'proxy.err'}")
                 return 1

--- a/distil/setup.py
+++ b/distil/setup.py
@@ -959,11 +959,23 @@ def service_reload(port: int) -> tuple[bool, str]:
                 if probe is None or probe.returncode != 0:  # no record at all — safe to bootstrap
                     break
             time.sleep(0.25)
-        if not _port_free(port):
-            return False, (
-                f"port {port} is still held after stopping the service — something "
-                f"else is listening there. Find it with: lsof -nP -iTCP:{port} -sTCP:LISTEN"
-            )
+        # Let the port settle, but do NOT abort on it. Since 1.42.0 the plist
+        # declares Sockets, so launchd owns the listener and the SIGTERMed child
+        # that inherited the descriptor can still hold it right here — a held
+        # port is the design, not evidence of a foreign process. The Linux branch
+        # below documents the same trap for the socket unit.
+        #
+        # The old fatal check fired on that ordinary case, and — this is the part
+        # that made it an outage rather than an error — it fired AFTER bootout.
+        # The job was already unregistered, so returning here left the machine
+        # with no proxy and nothing to restart it, while cmd_default printed
+        # "your existing setup is untouched". Observed on a maintainer's machine
+        # switching modes with `distil default --always-on`.
+        #
+        # If the port really is stolen, bootstrap still runs and the
+        # service_is_running() poll at the end reports it — with the job
+        # REGISTERED, so KeepAlive keeps retrying instead of stranding the box.
+        _port_free(port)
         # Even after the record clears, launchd can transiently refuse. Retrying a
         # bootstrap is safe (it is not partially applied) and turns a spurious EIO
         # into a non-event instead of a machine with no registered job.
@@ -1048,6 +1060,15 @@ def service_reload(port: int) -> tuple[bool, str]:
         if ok:
             return True, detail
         time.sleep(0.25)
+    # Both branches have registered/enabled the job by the time we get here, so
+    # the supervisor keeps retrying it. A foreign process owning the port is the
+    # likeliest reason it cannot come up — this is where that diagnosis belongs,
+    # not in a precondition that aborts before anything has been started.
+    if not _port_free(port, deadline=0.5):
+        detail += (
+            f" — and port {port} is held by another process. "
+            f"Find it with: lsof -nP -iTCP:{port} -sTCP:LISTEN"
+        )
     return False, detail
 
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -515,20 +515,95 @@ def test_reload_fails_loudly_when_bootstrap_fails(monkeypatch, real_service_api)
 
 
 @launchd_only
-def test_reload_refuses_to_bootstrap_onto_a_held_port(monkeypatch, real_service_api):
-    """Bootstrapping while the old proxy still holds the port is the race itself.
+def test_darwin_reload_bootstraps_even_when_the_port_is_still_held(monkeypatch, real_service_api):
+    """A still-held port must NOT abort the reload. It is the design, not a fault.
 
-    `launchctl unload` is asynchronous. Starting the replacement before the port
-    is released is what made it die on EADDRINUSE and get discarded by launchd.
+    Since 1.42.0 the plist declares Sockets: launchd owns the listener, and the
+    SIGTERMed child that inherited the descriptor can still be holding the port
+    at exactly this moment. The previous version of this test asserted the
+    opposite ("must not bootstrap onto a held port") and so locked in the bug.
+
+    What made it an outage rather than an error is the ordering: the abort fired
+    AFTER `launchctl bootout`, so the job was already unregistered. The machine
+    was left with no proxy, nothing to restart it, and `cmd_default` printing
+    "your existing setup is untouched". Hit on a maintainer's machine simply
+    switching modes with `distil default --always-on`.
+
+    Drives the REAL `_port_free` against a really-held socket — patching it out
+    would mock away the exact check under test. Virtual time keeps it instant.
     """
     monkeypatch.setattr("platform.system", lambda: "Darwin")
-    monkeypatch.setattr(setup, "_port_free", lambda port, **k: False)
-    called = []
-    monkeypatch.setattr("subprocess.run", lambda cmd, *a, **k: (called.append(cmd), _Res(0))[1])
-    ok, why = real_service_api["service_reload"](8788)
+    held = socket.socket()
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind(("127.0.0.1", 0))
+    held.listen(8)
+    port = held.getsockname()[1]
+
+    # Virtual clock: real bind probes, real loop, no wall-clock wait.
+    now = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: now[0])
+    monkeypatch.setattr("time.sleep", lambda d: now.__setitem__(0, now[0] + d))
+
+    calls: list[str] = []
+    # First `print` answers the teardown poll: the record is gone. Every later
+    # one answers service_is_running() after the bootstrap: a live pid.
+    prints = iter([_Res(1, "")])
+
+    def fake_run(cmd, *a, **k):
+        calls.append(cmd[1])
+        if cmd[1] == "print":
+            return next(prints, _Res(0, "\tpid = 4242\n"))
+        return _Res(0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    try:
+        ok, why = real_service_api["service_reload"](port)
+    finally:
+        held.close()
+
+    assert ok is True, f"a held port aborted the reload and stranded the job: {why}"
+    assert "bootstrap" in calls, (
+        "the job was never re-registered — this is the state that leaves the "
+        f"machine with no proxy and nothing to restart it: {calls}"
+    )
+    assert calls.index("bootout") < calls.index("bootstrap")
+
+
+@launchd_only
+def test_darwin_reload_names_the_port_holder_when_the_service_cannot_come_up(
+    monkeypatch, real_service_api
+):
+    """The "something else is listening" diagnosis belongs AFTER the bootstrap.
+
+    Moved, not deleted: it is still the likeliest reason a job that is registered
+    cannot come up. The difference is that we now say it with the job registered
+    (so KeepAlive keeps retrying) instead of as a precondition that aborts with
+    the machine stranded.
+    """
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    held = socket.socket()
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind(("127.0.0.1", 0))
+    held.listen(8)
+    port = held.getsockname()[1]
+
+    now = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: now[0])
+    monkeypatch.setattr("time.sleep", lambda d: now.__setitem__(0, now[0] + d))
+
+    def fake_run(cmd, *a, **k):
+        if cmd[1] == "print":
+            return _Res(1, "")  # no record: never comes up, and none reported
+        return _Res(0, "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    try:
+        ok, why = real_service_api["service_reload"](port)
+    finally:
+        held.close()
+
     assert ok is False
-    assert "still held" in why
-    assert not any("bootstrap" in c for c in called), "must not bootstrap onto a held port"
+    assert "lsof" in why and str(port) in why, f"no actionable diagnosis: {why}"
 
 
 def test_systemd_unit_state_decides_running(monkeypatch):
@@ -1007,7 +1082,12 @@ def test_always_on_does_not_wire_the_pin_when_the_service_did_not_start(
     assert not settings.exists(), "settings.json must be untouched when the service is down"
     out = capsys.readouterr().out
     assert "did not start" in out
-    assert "Nothing was wired" in out
+    assert "NOT wired" in out
+    # ...but it must not go on to claim the machine is unchanged. By this point
+    # the old job has been booted out and its definition replaced, so "your
+    # existing setup is untouched" was false exactly when it printed. See
+    # test_cmd_default_failed_reload_does_not_claim_nothing_changed.
+    assert "untouched" not in out
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="launchd plist is macOS-only")

--- a/tests/test_cli_onboard.py
+++ b/tests/test_cli_onboard.py
@@ -1674,6 +1674,62 @@ def test_cmd_default_always_on_service_start(tmp_path, monkeypatch, capsys) -> N
     assert "proxy service started" in capsys.readouterr().out
 
 
+def test_cmd_default_failed_reload_does_not_claim_nothing_changed(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """A failed reload must not print "your existing setup is untouched".
+
+    By the time `service_reload` returns False the old job has been booted out
+    and its definition replaced, so the machine has NO working proxy — while
+    ANTHROPIC_BASE_URL may still point at that port from a previous install.
+    Telling the user nothing changed sent them looking at the provider instead
+    of at the dead service, which is how one mode switch became a long outage.
+    """
+
+    import distil.setup as setup_mod
+    from distil import onboard
+
+    env = onboard.Env(
+        os_name="Darwin",
+        agents=[("claude", "Claude Code")],
+        installed_version="1.0.0",
+        method="pipx",
+        managers=["pipx"],
+    )
+    monkeypatch.setattr(onboard, "detect", lambda: env)
+    rc_file = tmp_path / ".zshrc"
+    rc_file.write_text("")
+    monkeypatch.setattr(setup_mod, "detect_shell", lambda: ("zsh", rc_file))
+    monkeypatch.setattr(
+        setup_mod, "service_spec", lambda *a, **k: (tmp_path / "service.plist", "content", "load")
+    )
+    monkeypatch.setattr(setup_mod, "write_managed", lambda *a, **k: ("ok", "wrote env block"))
+    monkeypatch.setattr(setup_mod, "env_body", lambda *a, **k: "export ANTHROPIC_BASE_URL=...")
+    monkeypatch.setattr(setup_mod, "default_settings_path", lambda: tmp_path / "settings.json")
+    # No subprocess patch: cmd_default must bail at the failed reload, before it
+    # runs anything else. A stray patch here would hide it if that ever changed.
+    monkeypatch.setattr(setup_mod, "service_reload", lambda port: (False, "bootstrap failed"))
+
+    rc = cli.cmd_default(
+        argparse.Namespace(
+            always_on=True,
+            rc=str(rc_file),
+            port=34120,
+            agent="claude",
+            mode="expand",
+            no_start=False,
+            undo=False,
+            yes=True,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "untouched" not in out, (
+        f"claimed the setup was untouched while the service it just replaced is stopped:\n{out}"
+    )
+    assert "distil default --always-on" in out, f"no way back was offered:\n{out}"
+
+
 # --------------------------------------------------------------------------- #
 # cmd_offboard — service unlink OSError (1053-1054)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The outage

`distil default --always-on` on macOS boots out the running job, replaces the plist, then calls `service_reload()`. That function demanded a free port before bootstrapping and returned an error if it did not get one.

Since 1.42.0 the plist declares `Sockets`, so **launchd owns the listener** and the SIGTERMed child that inherited the descriptor can still be holding the port at exactly that moment. A held port there is the design, not a foreign process. The Linux branch already documents this same trap for the socket unit (`setup.py`, "the socket unit holds the port BY DESIGN") and got its fix for the upgrade path in 1.42.1 — Darwin never got the equivalent.

What made it an outage rather than an error is the **ordering**: the abort fired *after* the bootout, so the job was already unregistered. The machine was left with no proxy and nothing to restart it, while `cmd_default` printed "your existing setup is untouched" — sending the user to look at the provider instead of at the dead service.

Reproduced by simply switching a machine from `--lossless-only` to `--expand`.

## Changes

- **`setup.py`** — the port settle is now a wait, not a verdict. If the port really is stolen, bootstrap still runs and the closing `service_is_running()` poll reports it *with the job REGISTERED*, so `KeepAlive` keeps retrying instead of stranding the box. The `lsof` diagnosis moves to that poll, where it is actionable.
- **`cli.py`** — a failed reload no longer claims nothing changed. It states the previous service is stopped and gives the command back.
- **tests** — `test_reload_refuses_to_bootstrap_onto_a_held_port` asserted the *buggy* behaviour and is replaced by one driving the REAL `_port_free` against a really-held socket on a virtual clock (patching `_port_free` out would mock away the check under test — the same mistake called out in the Linux test). Plus a test that the caller never prints "untouched" over a stopped service.

## Verification

Regression test confirmed **red on the parent commit**, green here.

| gate | result |
|---|---|
| `ruff@0.15.10 check` | clean |
| `ruff@0.15.10 format --check` | 330 files clean |
| `mypy@1.17.1` | no issues, 131 files |
| `pytest --cov-fail-under=95` | 3224 passed, 2 skipped, **95.02%** |

## Known asymmetry, deliberately not changed

The Linux branch keeps its `_port_free` precondition. There it is *correct* — both units are stopped first, so the port genuinely should be free — and it only fires when a foreign process really owns the port, a state where no proxy can run anyway. Widening this PR to restructure that path would mean touching freshly-shipped 1.42.1 code without a reproducer. Flagging rather than folding it in.