### PR TITLE
fix(statusline): stop crying "bypassing proxy" at a fully-routed session

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -1471,13 +1471,34 @@ def cmd_statusline(args: argparse.Namespace) -> int:
 
         mp = ledger.session_marker_path()
         try:
-            return (
+            if not (
                 mp is not None
                 and mp.read_text(encoding="utf-8").strip() == "0"
                 and _t.time() - mp.stat().st_mtime > 180
-            )
+            ):
+                return False
+            started = mp.stat().st_mtime
         except OSError:
             return False
+        # An unflipped marker only proves THIS wrap's own proxy saw nothing, and
+        # that is routinely true of a fully-routed session: when an always-on
+        # install has pinned ANTHROPIC_BASE_URL in a settings file, the pin
+        # outranks the env var wrap injects, so the agent talks to the always-on
+        # proxy. That proxy stamps rows with its OWN session id and cannot know
+        # the agent's, so the marker stays "0" for the life of the session and
+        # the warning could never clear no matter how much traffic flowed.
+        #
+        # Widen the evidence to match the claim: "bypassing" means no distil
+        # proxy is seeing this machine's traffic. A row recorded after this
+        # session started disproves that.
+        #
+        # ponytail: any row, not this session's, because an always-on proxy
+        # cannot attribute one. A second agent genuinely bypassing while another
+        # session keeps the ledger warm would go unwarned — the trade for never
+        # crying wolf at a session that is in fact routed. To make it exact the
+        # agent would have to forward its session id to the proxy (a header on
+        # the injected base URL), which is a protocol change, not a status line.
+        return ledger.latest_row_ts() <= started
 
     # "on" must mean THIS session's requests route through distil: wrap sets
     # DISTIL_SESSION in the agent's env; always-on setups point the base URL

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -264,6 +264,31 @@ def latest_mode(session: str = "", path: Path | None = None) -> str:
     return ""
 
 
+def latest_row_ts(path: Path | None = None) -> float:
+    """Unix timestamp of the most recent row, or 0.0 if there are none.
+
+    Answers "has ANY distil proxy served traffic recently", which is a different
+    question from the per-session marker: an always-on proxy records rows under
+    its own session id and can never flip a wrap session's marker. Reversed
+    single pass, same shape (and cost) as :func:`latest_mode`."""
+    path = path or default_path()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return 0.0
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            d = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue  # a corrupt/partial tail line must not crash the status line
+        ts = d.get("ts")
+        if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+            return float(ts)
+    return 0.0
+
+
 def summary(
     path: Path | None = None, *, since: float | None = None, session: str | None = None
 ) -> LedgerSummary:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -588,6 +588,50 @@ def test_bypass_warning_replaces_idle_on_with_lifetime_total(monkeypatch, capsys
     assert "✓ on" not in out
 
 
+def _write_row(ts: float) -> None:
+    """One ledger row stamped *ts*, as an always-on proxy would record it —
+    under its OWN session id, never the wrap session's."""
+    import json
+
+    p = ledger.default_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"ts": ts, "session": "s-always-on-1234", "mode": "digest"}) + "\n")
+
+
+def test_no_bypass_warning_when_an_always_on_proxy_is_serving(monkeypatch, capsys):
+    """The false positive: wrap + always-on together.
+
+    An always-on install pins ANTHROPIC_BASE_URL in a settings file, and that
+    pin outranks the env var `distil wrap` injects — so the agent talks to the
+    always-on proxy, which stamps rows with its own session id and cannot know
+    the wrap session's. The marker therefore stays "0" for the whole session and
+    the old check warned "agent bypassing proxy" at a session that was fully
+    routed, forever, with no way for the user to clear it.
+    """
+    monkeypatch.setenv("DISTIL_SESSION", "sTEST-alwayson")
+    mp = _mk_marker("0", age_s=600.0)
+    _write_row(mp.stat().st_mtime + 60)  # a request served after this wrap started
+    rc, out = _run(monkeypatch, capsys, ledger.LedgerSummary(0, 0.0, 0, {}))
+    assert rc == 0
+    assert "bypassing" not in out, f"warned at a routed session: {out}"
+    assert "✓ on" in out
+
+
+def test_bypass_warning_survives_a_ledger_that_went_quiet(monkeypatch, capsys):
+    """Rows from BEFORE this session started are not evidence about it.
+
+    Otherwise any machine with history would suppress the warning permanently
+    and the detection would be dead code.
+    """
+    monkeypatch.setenv("DISTIL_SESSION", "sTEST-quiet")
+    mp = _mk_marker("0", age_s=600.0)
+    _write_row(mp.stat().st_mtime - 60)  # last traffic predates this wrap
+    rc, out = _run(monkeypatch, capsys, ledger.LedgerSummary(0, 0.0, 0, {}))
+    assert rc == 0
+    assert "bypassing" in out
+
+
 def test_bypass_warning_minimal_mode(monkeypatch, capsys):
     monkeypatch.setenv("DISTIL_STATUSLINE", "minimal")
     monkeypatch.setenv("DISTIL_SESSION", "sTEST-min")


### PR DESCRIPTION
## The false positive

Reported from a live session showing:

```
distil · ⬢ digest · ⚠ wrapped, agent bypassing proxy
```

...while the ledger was recording `mode=digest` rows *at that moment*. The traffic was flowing through distil the whole time.

**Cause.** With an always-on install, `distil wrap` and the always-on proxy are both in play:

1. `wrap` mints `DISTIL_SESSION` and writes a marker containing `"0"`.
2. The marker is flipped to `"1"` by `_mark_session_traffic()`, which resolves the path from **the proxy process's own** `DISTIL_SESSION`.
3. But the settings-file `ANTHROPIC_BASE_URL` pin outranks the env var wrap injects, so the agent talks to the **always-on** proxy — a long-running launchd job that has no idea what the agent's session id is. It stamps its rows with its own (`s<ts>-<its pid>`).

So the marker stays `"0"` for the life of the session, and after the 180s grace period the warning fires and can never clear. Confirmed on the reporting machine: marker `sessions/s1786386249-69523` = `"0"`, 27 minutes old, while rows were landing under `s1786386525-74866` — the PID of the always-on proxy.

## The fix

The marker only ever proved *"THIS wrap's own proxy saw nothing"*. The warning claims *"no distil proxy is seeing this machine's traffic"*. Those are different statements, and the gap is the bug.

Widen the evidence to match the claim: a ledger row recorded **after this session started** disproves bypass.

- `ledger.latest_row_ts()` — newest row timestamp; reversed single pass, same shape and cost as the adjacent `latest_mode()` the status line already calls.

## Known ceiling (marked in-code with a `ponytail:` comment)

A second agent genuinely bypassing, while another session keeps the ledger warm, now goes unwarned. That is the deliberate trade for never crying wolf at a session that *is* routed — a permanent false alarm is worse than a rare missed one, because it teaches the user to distrust every number on the line. Making it exact requires the agent to forward its session id to the proxy: a protocol change, not a status line change.

## Verification

The regression test was confirmed **red on the parent commit**, and its failure output is the reported string verbatim:

```
E         'bypassing' is contained here:
E           distil · ⬢ digest · ⚠ wrapped, agent bypassing proxy
```

A second test pins that history alone must **not** suppress the warning (rows predating the session), so the detection cannot quietly rot into dead code on any machine with a ledger.

| gate | result |
|---|---|
| `ruff@0.15.10 check` | clean |
| `ruff@0.15.10 format --check` | 330 files clean |
| `mypy@1.17.1` | no issues, 131 files |
| `pytest --cov-fail-under=95` | 3224 passed, 2 skipped, **95.01%** |

Independent of #109; both touch `cli.py` but in different functions.