### PR TITLE
fix(policy): make the subscription boundary say what it is, on every route

### DIFF
--- a/distil/policy.py
+++ b/distil/policy.py
@@ -53,9 +53,18 @@ def may_compress_lossy(mode: AuthMode) -> bool:
     return mode is AuthMode.PAYG
 
 
-def may_inject_tools(mode: AuthMode) -> bool:
-    """Injecting a retrieval/expand tool into the request is only safe on PAYG."""
-    return mode is AuthMode.PAYG
+# There was a `may_inject_tools(mode)` here returning `mode is AuthMode.PAYG`,
+# with tests asserting it. Nothing ever called it. The rule it stated — tool
+# injection is PAYG-only — is not the rule distil actually implements: a
+# subscription session that passes `--expand` DOES get distil_expand injected,
+# deliberately and with a notice (see proxy.py), because an injected recovery
+# tool is what makes a Tier-1 digest reversible.
+#
+# An unenforced policy with a passing test is worse than no policy: the test
+# makes it look covered, so the drift between what distil says and what distil
+# does is invisible in CI. The real rule is "injection on a flat-rate session
+# requires an explicit opt-in", it lives at the one place that can enforce it,
+# and ADR 0006 records why. Do not reintroduce this without a call site.
 
 
 def guard(mode: AuthMode, strategy: str) -> None:

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -398,16 +398,30 @@ def build_handler(
     if _lossy_ok and not verbatim:
         expand = True
     verbatim = verbatim or not (_lossy_ok or expand)
-    if lossless_only and expand:
-        import sys as _sys
+    # Disclose injection on EVERY route into it on a flat-rate session, not just
+    # one. This used to be gated on `lossless_only and expand`, which is only the
+    # `--lossless-only --expand` spelling. The other way in — `distil default
+    # --mode expand`, which is what the docs tell a subscription user to run —
+    # leaves lossless_only False, so the notice never fired and the user opted
+    # into tool injection with no notice at all. Injecting into a first-party
+    # session is precisely what onboard.py promises the safe default does not do,
+    # so whoever leaves that path is owed a sentence saying so.
+    #
+    # Keyed on real billing, not on the flag: the flag says which spelling was
+    # used, `subscription_mode()` says whether this is a flat-rate session.
+    if expand:
+        from .doctor import subscription_mode as _sub_mode
 
-        print(
-            "distil: --expand enabled on a lossless-only/subscription session — the "
-            "recoverable digest is ON (you opted in explicitly). distil_expand is "
-            "injected so nothing is irreversibly lost; note this alters requests more "
-            "than pure lossless mode. Drop --expand for lossless-only.",
-            file=_sys.stderr,
-        )
+        if lossless_only or _sub_mode():  # startup-only; not on the request path
+            import sys as _sys
+
+            print(
+                "distil: recoverable digest ON for a flat-rate session (you opted in "
+                "with --expand). distil_expand is injected, so nothing is irreversibly "
+                "lost — but the request IS modified, which the subscription-safe "
+                "default never does. Drop --expand to go back to lossless-only.",
+                file=_sys.stderr,
+            )
 
     # Learning flywheel state (loaded once when expand is on): the learned
     # keep-byte-exact policy + the accumulating expand stats. See distil.learn.

--- a/docs/adr/0006-the-subscription-boundary.md
+++ b/docs/adr/0006-the-subscription-boundary.md
@@ -1,0 +1,58 @@
+# 0006 — The subscription boundary: what distil does to a flat-rate session
+
+- **Status:** accepted
+- **Date:** 2026-08-10
+- **Supersedes:** nothing. Records a boundary that existed in code but was never written down, and which two parts of the codebase described differently.
+
+## Context
+
+A flat-rate (Claude Pro/Max OAuth) session defaults to `lossless-only`. Two places in the tree explained that default, and they did not agree.
+
+`distil/onboard.py` told the user the subscription path is:
+
+> flat-rate plan: real lossless token savings … **ToS-safe (no lossy digest, no tool injection)**
+
+`distil/proxy.py` justified the same default on recoverability:
+
+> lossless-only is a hard safety boundary: with no injected expand tool the agent can never recover a Tier-1 digest stub, so a stub there is irreversibly lossy.
+
+These lead to opposite conclusions the moment `--expand` enters the picture. Under the recoverability reading, `--expand` injects `distil_expand`, every stub becomes recoverable, the stated harm disappears, and the default should simply flip — the same reasoning already applied to PAYG, which defaults to recoverable-digest for exactly this reason. Under the ToS reading, injection is the thing being avoided, and `--expand` is precisely what you must not do by default.
+
+A third artifact voted for the ToS reading and enforced nothing: `policy.may_inject_tools(mode)` returned `mode is AuthMode.PAYG`, was asserted by `test_policy_fidelity_holdout.py`, and **was never called by any production code**. A subscription session passing `--expand` got injection with nothing consulting that function.
+
+The stakes are not small. Measured on a maintainer's machine over its own ledger:
+
+| mode | runs | smaller | tokens saved |
+|---|---|---|---|
+| digest | 2,353 | 52.27% | 644,922,653 |
+| lossless-only | 8,319 | 0.27% | 9,601,508 |
+
+~190×, at 100% decision-equivalence over 847 shadowed requests. The safe default is not conservative at the margin; it is most of the product, off.
+
+## Decision
+
+**The boundary is consent, not recoverability.** Stated positively:
+
+1. **The default for a flat-rate session injects nothing and loses nothing.** `lossless-only` stays the default. Tier-0 transforms only.
+2. **`--expand` is an explicit opt-in that DOES modify the request.** It is permitted on a flat-rate session — an injected `distil_expand` is what makes a Tier-1 digest reversible — and it is the user's call to make, not distil's.
+3. **Every route into injection must say so, once, on stderr.** Both spellings (`--lossless-only --expand` and `distil default --mode expand`) cross the same line and both must disclose it.
+4. **Output shaping stays PAYG-only.** It rewrites the *response*, which `--expand` does not make recoverable. This is the one thing an opt-in does not buy.
+
+Recoverability remains true and remains the reason a digest is *safe* once opted into. It is not the reason for the default. The reason for the default is that distil does not modify a first-party session unasked.
+
+## Consequences
+
+- `onboard.py`'s "no tool injection" claim stays accurate, because it describes the default path, which still injects nothing.
+- The disclosure gap is closed. Previously the notice fired only on `lossless_only and expand`, so the documented route (`distil default --mode expand`) opted the user into injection **silently**. It is now keyed on `expand and (lossless_only or subscription_mode())`.
+- `may_inject_tools()` and its assertions are **deleted**. It stated a rule distil does not implement, and its passing test made the drift invisible in CI. An unenforced policy with a green test is worse than no policy. Do not reintroduce it without a call site.
+- Flipping the default to `expand` remains a live proposal, and this ADR is what it has to argue against: not "is it recoverable" (it is) but "may distil modify a flat-rate session without being asked". That is a product decision, and it is unresolved.
+
+## If the default is ever flipped, one trap
+
+`proxy.py` derives `_auth_mode` from the `lossless_only` **flag**, not from real billing:
+
+```python
+_auth_mode = AuthMode.SUBSCRIPTION if lossless_only else AuthMode.PAYG
+```
+
+Simply defaulting `lossless_only=False` on a subscription would therefore make the session look like PAYG, and `--shape-output` would take effect on a flat-rate session — violating decision 4 above as a side effect of an unrelated change. Derive `_auth_mode` from `subscription_mode()` first.

--- a/tests/test_policy_fidelity_holdout.py
+++ b/tests/test_policy_fidelity_holdout.py
@@ -12,19 +12,17 @@ from distil.fidelity import (
     numeric_precision_preserved,
     verify_reversible,
 )
-from distil.policy import AuthMode, PolicyError, allowed_strategies, guard, may_inject_tools
+from distil.policy import AuthMode, PolicyError, allowed_strategies, guard
 from distil.trajectory import Block, Kind, Stability
 
 
 # ---- Phase 4: auth-mode gating ---------------------------------------------
 def test_payg_allows_everything():
     assert allowed_strategies(AuthMode.PAYG) == {"none", "distil", "naive", "aggressive"}
-    assert may_inject_tools(AuthMode.PAYG)
 
 
 def test_subscription_is_lossless_only():
     assert allowed_strategies(AuthMode.SUBSCRIPTION) == {"none", "distil"}
-    assert not may_inject_tools(AuthMode.SUBSCRIPTION)
     guard(AuthMode.SUBSCRIPTION, "distil")  # allowed
     with pytest.raises(PolicyError):
         guard(AuthMode.SUBSCRIPTION, "aggressive")

--- a/tests/test_subscription_disclosure.py
+++ b/tests/test_subscription_disclosure.py
@@ -1,0 +1,68 @@
+"""Both routes into tool injection on a flat-rate session must disclose it.
+
+`onboard.py` promises flat-rate users the safe default does "no tool injection".
+Leaving that path is the user's call and it is allowed — but it must never be
+silent, because the promise is what they are deciding against.
+
+The notice used to be gated on `lossless_only and expand`, which is only the
+`--lossless-only --expand` spelling. The route the docs actually hand a
+subscription user, `distil default --mode expand`, leaves `lossless_only` False
+— so the one path most people take was the one that said nothing. See ADR 0006.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from distil import proxy
+
+
+@pytest.fixture
+def _sub(monkeypatch):
+    """A flat-rate machine, whatever the caller's real ~/.claude.json says."""
+    monkeypatch.setattr("distil.doctor.subscription_mode", lambda: True)
+
+
+def _make(**kw) -> str:
+    """Build the app and return whatever it wrote to stderr at startup."""
+    import io
+    import sys
+
+    err = io.StringIO()
+    real = sys.stderr
+    sys.stderr = err
+    try:
+        proxy.build_handler("https://api.anthropic.com", **kw)
+    finally:
+        sys.stderr = real
+    return err.getvalue()
+
+
+def test_the_documented_route_discloses_injection(_sub) -> None:
+    """`distil default --mode expand` runs `distil proxy --expand`: lossless_only
+    is False. This is the path that was silent."""
+    out = _make(expand=True, lossless_only=False)
+    assert "distil_expand is injected" in out or "injected" in out, (
+        f"opted the user into tool injection with no notice:\n{out!r}"
+    )
+    assert "--expand" in out, "the notice must name the flag that caused it"
+
+
+def test_the_explicit_spelling_still_discloses(_sub) -> None:
+    out = _make(expand=True, lossless_only=True)
+    assert "injected" in out
+
+
+def test_the_safe_default_says_nothing_about_injection(_sub) -> None:
+    """No opt-in, no injection, so no notice — a warning on the safe path is
+    noise, and noise is what gets the real one tuned out."""
+    out = _make(expand=False, lossless_only=True)
+    assert "injected" not in out
+
+
+def test_a_metered_session_is_not_told_about_a_flat_rate_boundary(monkeypatch) -> None:
+    """PAYG turns expand on by default and has no such promise to weigh, so the
+    notice would be pure noise there."""
+    monkeypatch.setattr("distil.doctor.subscription_mode", lambda: False)
+    out = _make(expand=True, lossless_only=False)
+    assert "injected" not in out


### PR DESCRIPTION
Closes the first two of the three things flagged on #111. The default and the ToS position are **unchanged**.

## Three artifacts, three different stories

| where | what it said |
|---|---|
| `onboard.py:213` | the subscription path is *"ToS-safe (no lossy digest, **no tool injection**)"* |
| `proxy.py:372` | the default exists because *"with no injected expand tool the agent can never recover a Tier-1 digest stub"* — i.e. **recoverability** |
| `policy.may_inject_tools()` | injection is PAYG-only — **and nothing ever called it** |

These diverge the moment `--expand` appears. Under the recoverability reading, `--expand` injects `distil_expand`, every stub becomes recoverable, the stated harm is gone, and the default should simply flip. Under the ToS reading, injection is the thing being avoided and `--expand` is exactly what you must not default to.

The stakes aren't marginal — measured on a maintainer's own ledger, digest returns **52.27%** over 2,353 runs against **0.27%** over 8,319. The safe default isn't conservative at the margin; it's most of the product, off. So which rationale is true decides a lot.

## ADR 0006 settles it: the boundary is consent, not recoverability

distil does not modify a first-party session unasked. Recoverability is still true, and still why a digest is *safe* once opted into — it is not why the default exists. That keeps `onboard.py`'s claim accurate (it describes the default path, which still injects nothing) and makes `--expand` what it always was: the user's call.

## The defect this exposed

The injection notice was gated on `lossless_only and expand` — only the `--lossless-only --expand` spelling. The route the docs actually hand a subscription user, **`distil default --mode expand`**, leaves `lossless_only` False, so the notice never fired. Users have been opting into tool injection on flat-rate sessions **with no notice at all** — against the one promise they'd want to weigh.

Now keyed on real billing: `expand and (lossless_only or subscription_mode())`. Startup-only, not on the request path.

## `may_inject_tools()` deleted

It stated a rule distil does not implement, and `test_policy_fidelity_holdout.py` asserted it — so CI showed the policy as covered while nothing applied it. An unenforced policy with a green test is worse than no policy: it makes the drift invisible. A comment records why, so it can't come back without a call site.

(Correcting #111's description, which called it "defined, never called" — it *was* referenced, by tests. Asserted but unenforced, which is the worse shape.)

## A trap recorded for whoever flips the default later

`proxy.py` derives `_auth_mode` from the `lossless_only` **flag**, not from billing. Defaulting `lossless_only=False` on a subscription would make it look like PAYG and let `--shape-output` take effect there — and shaping rewrites the *response*, which `--expand` does **not** make recoverable. ADR 0006 spells this out.

## Verification

Regression test confirmed **red on the parent commit** — the documented route produced an empty stderr, which is the silence itself.

| gate | result |
|---|---|
| `ruff@0.15.10 check` | clean |
| `ruff@0.15.10 format --check` | 331 files clean |
| `mypy@1.17.1` | no issues, 131 files |
| `pytest --cov-fail-under=95` | 3230 passed, **95.01%** |

Coverage reads 95.01% because this branch predates #111's coverage work; rebased on current `main` (95.12%) it is higher. The third flagged item — coverage headroom — was fixed in #111 itself, since the merge of #109+#110 dropped main to 94.99% and would have gone red.