### PR TITLE
release(1.43.0rc1): the safe default could not say what it cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.43.0] — the safe default could not say what it cost, and the reload could strand you
+
+**`distil default --always-on` could take macOS down.** The reload boots the job out,
+replaces the plist, and then demanded a free port before bootstrapping. Since 1.42.0 the
+plist declares `Sockets`, so launchd owns the listener and the SIGTERMed child that
+inherited the descriptor can still be holding the port at exactly that moment — a held
+port there is the design, not a foreign process. The check fired on that ordinary case,
+and it fired *after* the bootout: the job was already unregistered, so the machine was
+left with no proxy and nothing to restart it, while the command printed "your existing
+setup is untouched". It was reproduced by nothing more exotic than switching modes.
+Linux got this fix for the upgrade path in 1.42.1; macOS never got the equivalent. The
+port settle is now a wait, not a verdict — if the port really is stolen, the bootstrap
+still runs and the failure is reported with the job **registered**, so `KeepAlive` keeps
+retrying instead of stranding the machine. And a failed reload no longer claims nothing
+changed; it says the previous service is stopped and gives the command back.
+
+**The status line called a fully-routed session a bypass.** With an always-on install,
+the settings-file `ANTHROPIC_BASE_URL` pin outranks the env var `distil wrap` injects, so
+the agent talks to the always-on proxy — which stamps ledger rows with its own session id
+and cannot know the agent's. The wrap session's traffic marker therefore never flipped,
+and after the grace period the line read `⚠ wrapped, agent bypassing proxy` for the life
+of a session whose traffic was flowing through distil the entire time, with nothing the
+user could do to clear it. The marker only ever proved "this wrap's own proxy saw
+nothing"; the warning claimed "no distil proxy is seeing this traffic". The evidence now
+matches the claim.
+
+**A subscription default that could not say what it costs.** A flat-rate session runs
+lossless-only so no digest is left unrecoverable and nothing is injected — deliberate,
+and unchanged. But on the machine that prompted this it meant 8,319 runs at 0.27% while
+that same ledger held 2,353 digest runs at 52.27%, and all distil ever said was that
+near-zero "usually means lossless-only". No figure, no sample size. That line printed on
+every one of those runs and was read past every time. It now quotes the rate you earned
+on your own traffic, and states both halves of the trade — the safe default does not
+touch the request, and `--expand` does — because you cannot weigh a choice shown only
+one side of.
+
+**You could opt into tool injection with no notice.** The disclosure was gated on the
+`--lossless-only --expand` spelling only. The route the docs actually hand a subscription
+user, `distil default --mode expand`, leaves that flag False, so the notice never fired —
+and injection into a first-party session is precisely what the safe default promises not
+to do. It is now keyed on real billing and fires on every route into it.
+
+`policy.may_inject_tools()` is gone. It stated that injection is PAYG-only, a rule distil
+does not implement, and **nothing ever called it** while a passing test asserted it — so
+the drift between what distil said and what distil did was invisible in CI. An unenforced
+policy with a green test is worse than no policy. [ADR 0006](docs/adr/0006-the-subscription-boundary.md)
+records what the boundary actually is: consent, not recoverability. distil does not modify
+a first-party session unasked. Recoverability is still why a digest is *safe* once opted
+into; it is not why the default exists.
+
 ## [1.42.1] — the upgrade could not claim the port it had just been given
 
 **`distil default --always-on` was broken on Linux in 1.42.0**, in both directions,

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.42.1"
+appVersion: "1.43.0rc1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.42.1",
+  "version": "1.43.0-rc.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.42.1",
+  "version": "1.43.0rc1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.42.1"
+version = "1.43.0rc1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.42.1",
+  "version": "1.43.0rc1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.42.1",
+      "version": "1.43.0rc1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.42.1"
+version = "1.43.0rc1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Release candidate for **1.43.0**, covering #109, #110, #111, #112.

`RELEASING.md:20` requires an rc soak for any release that changes runtime behavior, and all four changes do — the launchd reload, the status line, the stats notice, and the injection disclosure. The CHANGELOG entry is written under the final `## [1.43.0]`; the rc soaks for it.

## What ships

- **`distil default --always-on` could strand macOS.** The reload aborted on a held port *after* booting the job out, leaving no proxy and nothing to restart it — while printing "your existing setup is untouched". Under socket activation a held port is the design. (#109)
- **The status line called a fully-routed session a bypass**, permanently and unclearably, whenever `wrap` and an always-on install were both in play. (#110)
- **The safe default now says what it costs**, quoting the rate you earned on your own traffic instead of "usually means lossless-only". (#111)
- **Tool injection could be opted into with no notice** via `distil default --mode expand` — the route the docs hand subscription users. (#112)
- **`policy.may_inject_tools()` deleted**; [ADR 0006](docs/adr/0006-the-subscription-boundary.md) records that the boundary is consent, not recoverability.

## Version locations — six of seven

Each in its own dialect, which is the part that has broken releases before:

| file | value |
|---|---|
| `pyproject.toml`, `server.json` ×2, `plugin.json` | `1.43.0rc1` |
| `packaging/npm/package.json` | `1.43.0-rc.1` — npm rejects the PEP 440 spelling |
| `packaging/helm/.../Chart.yaml` `appVersion` | `1.43.0rc1` — the default image tag a `helm install` deploys; it sat stale through all of 1.42.0 |
| `CITATION.cff` | **deliberately not bumped** — it cites the GA artifact, and its guard only binds on a final |

## Gates

| gate | result |
|---|---|
| `ruff@0.15.10 check` / `format --check` | clean / 333 files |
| packaging smoke | 16 passed |
| `pytest --cov-fail-under=95` | 3260 passed, 2 skipped, **95.12%** |

After merge: tag `v1.43.0rc1` → CI builds, attaches artifacts, and publishes to PyPI (rc tags are marked prerelease; Homebrew and the Docker image are skipped). Then the 3-day soak before a final.