### PR TITLE
feat(wrap): route Grok CLI and OpenHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## What it does
 
-- **Wrap your agent** — `distil wrap -- claude` · `codex` · `gemini` · `aider` · `opencode` · `qwen` · `goose`. Zero config, no code change.
+- **Wrap your agent** — `distil wrap -- claude` · `codex` · `gemini` · `aider` · `opencode` · `qwen` · `goose` · `grok` · `openhands`. Zero config, no code change.
 - **Run a proxy** — point any `base_url` client at it. Python, TypeScript, any language, any framework.
 - **Call it as a library** — `from distil import compress_messages` in your own agent loop.
 - **Give your agent a recall tool** — MCP server: it compresses its own output and gets the exact bytes back on demand.

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2455,6 +2455,40 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     return 0
 
 
+#: Agents that read distil's base-URL variable only when an extra flag is passed.
+#: Setting the variable without it is worse than doing nothing: the wrap reports
+#: success, the agent quietly talks straight to the provider, and the user is left
+#: wondering why savings are zero. Map: command -> (required flag, what it does).
+_ENV_REQUIRES_FLAG = {
+    # OpenHands ignores LLM_BASE_URL/LLM_API_KEY/LLM_MODEL unless told to prefer the
+    # environment; by default it reads ~/.openhands/settings.json instead.
+    "openhands": ("--override-with-envs", "read LLM_* from the environment"),
+}
+
+
+def _warn_if_env_ignored(cmd_name: str, command: list[str]) -> None:
+    """Say so when the agent will ignore the variable we are about to set.
+
+    distil's rule is that "wired" has to mean "a request provably reached the
+    proxy". For these agents the environment alone does not achieve that, and the
+    failure is silent — so the one thing we can do without editing the user's
+    command is tell them, before the session starts rather than after a day of
+    zero savings.
+    """
+    need = _ENV_REQUIRES_FLAG.get(cmd_name)
+    if need is None:
+        return
+    flag, what = need
+    if flag in command:
+        return
+    print(
+        f"\n  ⚠ {cmd_name} ignores the environment unless you pass {flag} — without it\n"
+        f"    it reads its own settings file and this wrap will route NOTHING.\n"
+        f"    Re-run as:  distil wrap -- {cmd_name} {flag} ...   ({flag} = {what})\n",
+        file=sys.stderr,
+    )
+
+
 def cmd_wrap(args: argparse.Namespace) -> int:
     """Transparently wrap a command: spawn the proxy, point its env at it, run it."""
     import os as _os
@@ -2491,6 +2525,7 @@ def cmd_wrap(args: argparse.Namespace) -> int:
             print(f"  preset: {preset_label} detected → {env_var}")
         if not upstream:
             upstream = preset_upstream
+        _warn_if_env_ignored(cmd_name, command)
 
     if not env_var:
         env_var = "ANTHROPIC_BASE_URL"

--- a/distil/onboard.py
+++ b/distil/onboard.py
@@ -26,6 +26,8 @@ _AGENTS = [
     ("opencode", "OpenCode"),
     ("qwen", "Qwen Code"),
     ("goose", "goose"),
+    ("grok", "Grok CLI"),
+    ("openhands", "OpenHands"),
 ]
 _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 
@@ -49,6 +51,15 @@ _MANAGERS = ("pipx", "uv", "brew", "scoop", "pip")
 #                  OPENAI_BASE_URL, which it ignores) plus OPENAI_BASE_PATH,
 #                  defaulting to "v1/chat/completions" — a path distil's proxy
 #                  serves, so the default needs no change (goose provider docs).
+#   grok         — superagent-ai/grok-cli resolves its endpoint as (1) an explicit
+#                  argument, (2) GROK_BASE_URL, (3) the default https://api.x.ai/v1.
+#                  Note the upstream carries the /v1 itself, unlike the OpenAI SDK.
+#   openhands    — reads LLM_BASE_URL / LLM_API_KEY / LLM_MODEL, but ONLY when run
+#                  with `--override-with-envs`. Without that flag it ignores the
+#                  environment entirely and reads ~/.openhands/settings.json, so a
+#                  preset alone routes NOTHING while reporting success — the exact
+#                  failure the note below is about. `wrap` therefore checks argv and
+#                  says so; see _warn_if_env_ignored in cli.py.
 #   cursor-agent — env var not publicly documented; left out rather than guessing.
 #                  Use --env-var to configure manually.
 #
@@ -72,6 +83,8 @@ AGENT_PRESETS: dict[str, tuple[str, str, str]] = {
     "opencode": ("OPENAI_BASE_URL", "https://api.openai.com", "OpenCode"),
     "qwen": ("OPENAI_BASE_URL", "https://api.openai.com", "Qwen Code"),
     "goose": ("OPENAI_HOST", "https://api.openai.com", "goose"),
+    "grok": ("GROK_BASE_URL", "https://api.x.ai/v1", "Grok CLI"),
+    "openhands": ("LLM_BASE_URL", "https://api.openai.com", "OpenHands"),
 }
 
 

--- a/docs/assets/integration-surface.svg
+++ b/docs/assets/integration-surface.svg
@@ -36,7 +36,7 @@
     <rect class="card" x="28" y="80" width="196" height="70" rx="8"/>
     <text class="lbl" x="44" y="104">Agent wrap</text>
     <text class="m"   x="44" y="124">distil wrap -- claude</text>
-    <text class="tiny" x="44" y="140">zero config · 7 agents</text>
+    <text class="tiny" x="44" y="140">zero config · 9 agents</text>
   </g>
   <g>
     <rect class="card" x="28" y="164" width="196" height="70" rx="8"/>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,8 @@ compressor that proves its guarantees rather than assuming them. Zero runtime
 dependencies. Four ways to use it, and they do not all reach the same tier:
 
   - Agent wrap: `distil wrap -- <agent>` for claude, codex, gemini, aider,
-    opencode, qwen, goose. Zero config.
+    opencode, qwen, goose, grok, openhands. Zero config. (openhands additionally
+    needs its own --override-with-envs flag before it will read the environment.)
   - HTTP proxy for Anthropic, OpenAI (Chat Completions + Responses API), and
     Google Gemini. Point any base_url client at it.
   - Python library: `from distil import compress_messages, expand_handle`.

--- a/tests/test_upstream_contracts.py
+++ b/tests/test_upstream_contracts.py
@@ -59,5 +59,21 @@ def test_agent_preset_env_var_contract():
     assert AGENT_PRESETS["codex"][0] == "OPENAI_BASE_URL"
     assert AGENT_PRESETS["gemini"][0] == "GOOGLE_GEMINI_BASE_URL"
     assert AGENT_PRESETS["aider"][0] == "OPENAI_BASE_URL"
+    assert AGENT_PRESETS["grok"][0] == "GROK_BASE_URL"
+    assert AGENT_PRESETS["openhands"][0] == "LLM_BASE_URL"
     # cursor-agent deliberately absent: its env contract is not publicly documented
     assert "cursor-agent" not in AGENT_PRESETS
+    # IDE extensions have no argv to wrap and no published env contract. Their
+    # supported path is the always-on proxy plus the editor's own base-URL setting
+    # (docs/IDE-AGENTS.md). A preset here would route nothing and report success.
+    for ide in ("cursor", "copilot", "cline", "continue", "windsurf"):
+        assert ide not in AGENT_PRESETS, f"{ide} has no published env contract to honour"
+
+
+def test_grok_upstream_carries_its_own_version_suffix():
+    """Grok's default endpoint is https://api.x.ai/v1 — the /v1 is part of the base
+    URL, not appended by the SDK the way the OpenAI client does it. Dropping it here
+    would send every request to a 404 that looks like a distil bug."""
+    from distil.onboard import AGENT_PRESETS
+
+    assert AGENT_PRESETS["grok"][1].endswith("/v1")

--- a/tests/test_wrap_env_ignored_warning.py
+++ b/tests/test_wrap_env_ignored_warning.py
@@ -1,0 +1,41 @@
+"""Some agents ignore the environment unless told not to — say so before the session.
+
+Setting a base-URL variable an agent will ignore is worse than doing nothing: the
+wrap prints its usual success, the agent talks straight to the provider, and the
+only symptom is savings that stay at zero. The user has no way to tell that apart
+from "compression isn't working".
+
+distil's rule is that "wired" means "a request provably reached the proxy".
+`_warn_if_env_ignored` is what keeps a preset from quietly violating it.
+"""
+
+from __future__ import annotations
+
+from distil.cli import _ENV_REQUIRES_FLAG, _warn_if_env_ignored
+
+
+def test_openhands_without_the_flag_is_warned(capsys) -> None:
+    _warn_if_env_ignored("openhands", ["openhands", "--headless"])
+    err = capsys.readouterr().err
+    assert "--override-with-envs" in err, "the user was not told which flag they need"
+    assert "route NOTHING" in err, "the consequence has to be stated, not implied"
+
+
+def test_openhands_with_the_flag_is_silent(capsys) -> None:
+    _warn_if_env_ignored("openhands", ["openhands", "--override-with-envs", "--headless"])
+    assert capsys.readouterr().err == "", "warning fired on a correctly-invoked wrap"
+
+
+def test_agents_that_honour_the_environment_are_not_nagged(capsys) -> None:
+    """A warning on every wrap is noise, and noise is what gets the real one ignored."""
+    for agent in ("claude", "codex", "gemini", "grok"):
+        _warn_if_env_ignored(agent, [agent])
+    assert capsys.readouterr().err == ""
+
+
+def test_every_flagged_agent_is_a_real_preset() -> None:
+    """A flag requirement for an agent distil cannot wrap is dead configuration."""
+    from distil.onboard import AGENT_PRESETS
+
+    unknown = set(_ENV_REQUIRES_FLAG) - set(AGENT_PRESETS)
+    assert not unknown, f"flag requirements for non-presets: {sorted(unknown)}"

--- a/tests/test_wrap_presets.py
+++ b/tests/test_wrap_presets.py
@@ -100,6 +100,47 @@ def test_preset_aider(monkeypatch, capsys):
     assert "aider" in out and "OPENAI_BASE_URL" in out
 
 
+def test_preset_grok(monkeypatch, capsys):
+    from distil.cli import cmd_wrap
+
+    captured = _mock_wrap_run(monkeypatch)
+    rc = cmd_wrap(_ns(command=["grok"]))
+    assert rc == 0
+    assert captured["env_var"] == "GROK_BASE_URL"
+    # The /v1 belongs to the base URL here — unlike the OpenAI SDK, which appends
+    # it. Dropping it sends every request to a 404 that reads like a distil bug.
+    assert captured["upstream"] == "https://api.x.ai/v1"
+    out = capsys.readouterr().out
+    assert "Grok CLI" in out and "GROK_BASE_URL" in out
+
+
+def test_preset_openhands(monkeypatch, capsys):
+    from distil.cli import cmd_wrap
+
+    captured = _mock_wrap_run(monkeypatch)
+    rc = cmd_wrap(_ns(command=["openhands", "--override-with-envs"]))
+    assert rc == 0
+    assert captured["env_var"] == "LLM_BASE_URL"
+    out = capsys.readouterr().out
+    assert "OpenHands" in out and "LLM_BASE_URL" in out
+
+
+def test_openhands_without_its_flag_is_warned_at_wrap_time(monkeypatch, capsys):
+    """The preset alone does not route openhands, and the failure is silent.
+
+    Selecting LLM_BASE_URL is necessary but not sufficient: without
+    --override-with-envs the agent reads ~/.openhands/settings.json and never looks
+    at the environment. The wrap still runs — it is the user's command — but it has
+    to say so, or the only symptom is savings that never arrive.
+    """
+    from distil.cli import cmd_wrap
+
+    _mock_wrap_run(monkeypatch)
+    rc = cmd_wrap(_ns(command=["openhands", "--headless"]))
+    assert rc == 0
+    assert "--override-with-envs" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # --env-var override always wins
 # ---------------------------------------------------------------------------
@@ -239,3 +280,71 @@ def test_tripwire_silent_without_marker(tmp_path, monkeypatch, capsys):
     """No marker file (wrap_run never created one) → can't tell → stay silent."""
     err = _run_tripwire(tmp_path, monkeypatch, capsys, None)
     assert "no requests flowed" not in err
+
+
+def test_a_new_preset_actually_carries_a_request_to_the_provider(tmp_path, monkeypatch):
+    """The routing proof: a child using the injected variable reaches the far side.
+
+    Selector tests assert distil picked a variable name. That is not the claim
+    `wrap` makes to a user — the claim is that their agent's traffic now goes
+    through distil. This drives the whole chain for a newly-added preset: wrap
+    injects GROK_BASE_URL -> the child reads it -> the proxy accepts the request
+    -> the upstream records the hit. If any link is wrong the upstream stays
+    untouched and this fails, which is the difference between "we wrote a config"
+    and "a request provably arrived".
+    """
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    from distil import proxy
+    from distil.onboard import AGENT_PRESETS
+
+    # Read the variable from the preset table rather than restating it, so a wrong
+    # preset fails HERE instead of only in the selector test. Hardcoding the name
+    # would make this look like an end-to-end proof while testing a constant.
+    grok_env = AGENT_PRESETS["grok"][0]
+    seen: list[str] = []
+
+    class Upstream(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            seen.append(self.path)
+            body = json.dumps(
+                {"id": "m", "content": [{"type": "text", "text": "ok"}], "model": "m"}
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # noqa: ANN002
+            pass
+
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Upstream)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    up_url = f"http://127.0.0.1:{server.server_address[1]}"
+
+    child = (
+        "import json, os, urllib.request, sys\n"
+        f"base = os.environ[{grok_env!r}].rstrip('/')\n"
+        "body = json.dumps({'model':'m','max_tokens':4,"
+        "'messages':[{'role':'user','content':'hi'}]}).encode()\n"
+        "req = urllib.request.Request(base + '/v1/messages', data=body,\n"
+        "    headers={'content-type':'application/json'})\n"
+        "urllib.request.urlopen(req, timeout=10).read()\n"
+        "sys.exit(0)\n"
+    )
+    try:
+        code = proxy.wrap_run(
+            [sys.executable, "-c", child],
+            upstream=up_url,
+            env_var=grok_env,
+            record=False,
+        )
+    finally:
+        server.shutdown()
+
+    assert code == 0, f"the child could not reach the proxy through {grok_env}"
+    assert seen, "the request never arrived upstream — the wrap routed nothing"


### PR DESCRIPTION
Two more agents `distil wrap` can route, each added against its **own published contract** rather than a guess.

## grok

`superagent-ai/grok-cli` resolves its endpoint as (1) an explicit argument, (2) `GROK_BASE_URL`, (3) the default `https://api.x.ai/v1`.

The `/v1` belongs to the base URL here — unlike the OpenAI SDK, which appends it. Dropping it would send every request to a 404 that reads like a distil bug, so there's a test pinning the suffix.

## openhands — and why it needed more than a preset

It reads `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL`, **but only when run with `--override-with-envs`**. Without that flag it ignores the environment entirely and reads `~/.openhands/settings.json`.

A preset alone would therefore have distil print its usual success while the agent talked straight to the provider: savings stay at zero, nothing says why, and the user can't tell that apart from "compression doesn't work". That is precisely the failure mode `onboard.py`'s `DELIBERATELY ABSENT` note warns about — *"shipping a lie that looks like a feature"*.

Editing the user's command isn't distil's call, so `wrap` checks argv and says so **before** the session starts:

```
⚠ openhands ignores the environment unless you pass --override-with-envs — without it
  it reads its own settings file and this wrap will route NOTHING.
  Re-run as:  distil wrap -- openhands --override-with-envs ...
```

## What stays absent, now pinned by a test

`cursor`, `copilot`, `cline`, `continue`, `windsurf` remain out. They're IDE extensions: no argv to wrap, no published env contract. Their supported path is the always-on proxy plus the editor's own base-URL setting (`docs/IDE-AGENTS.md`). A test now asserts they have no preset, so the reasoning survives the next person who reads the list and sees a gap.

## Assets updated

The guards bind these to `AGENT_PRESETS`, so all three had to move together: README wrap list, `docs/llms.txt`, and the `N agents` claim in `docs/assets/integration-surface.svg` (7 → 9).

## Tests

- Preset selection for both agents.
- The missing-flag warning; its silence when the flag *is* present, and when the agent honours the environment normally (a warning on every wrap is noise, and noise is what gets the real one ignored).
- **A routing proof**: `wrap` injects the variable → a real child process reads it → the proxy accepts the request → the upstream records the hit. It reads the variable name from `AGENT_PRESETS` rather than restating it, so a wrong preset fails there too instead of only in the selector test. That's the difference between "we wrote a config" and "a request provably arrived".

| gate | result |
|---|---|
| `ruff@0.15.10 check` / `format --check` | clean / 334 files |
| `mypy@1.17.1` | no issues, 131 files |
| `pytest --cov-fail-under=95` | 3269 passed, **95.12%** |