### PR TITLE
feat(proxy): trust a corporate CA bundle, and explain the failure when it is missing

### DIFF
--- a/distil/doctor.py
+++ b/distil/doctor.py
@@ -63,6 +63,44 @@ def _claude_oauth_present() -> bool:
         return False
 
 
+def _check_tls_trust() -> Check:
+    """Whether upstream TLS will verify, and against which CA bundle.
+
+    Behind an SSL-inspecting corporate proxy this is the difference between
+    distil working and distil looking broken, and it is invisible from the
+    outside: curl and the browser read the OS trust store, Python does not.
+    Doctor is where someone looks after the first failure, so the answer needs
+    to be here rather than only in a 502 body.
+    """
+    from .proxy import _which_ca_var, ca_bundle_path
+
+    bundle = ca_bundle_path()
+    if bundle is not None:
+        return Check(
+            "TLS trust",
+            OK,
+            f"using the CA bundle at {bundle}",
+            f"from {_which_ca_var()} — upstream TLS verifies against this, not the system store",
+        )
+    # No override is the normal, healthy case; only say something is wrong when a
+    # variable is exported but points nowhere, which is silently ignored.
+    stale = [
+        v
+        for v in ("DISTIL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "SSL_CERT_FILE")
+        if (os.environ.get(v) or "").strip() and not os.path.isfile(os.environ[v].strip())
+    ]
+    if stale:
+        return Check(
+            "TLS trust",
+            WARN,
+            f"{', '.join(stale)} names a file that does not exist — ignored",
+            "distil falls back to the system trust store; fix or unset it to avoid confusion",
+        )
+    return Check(
+        "TLS trust", OK, "system trust store", "set REQUESTS_CA_BUNDLE if behind SSL inspection"
+    )
+
+
 def _check_version() -> Check:
     import sys
 
@@ -598,6 +636,7 @@ def diagnose() -> list[Check]:
     checks: list[Check] = []
     for fn in (
         _check_version,
+        _check_tls_trust,
         _check_shadowed_install,
         _check_ledger,
         _check_session,

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 import re
 import socket
 import threading
@@ -180,7 +181,93 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-_OPENER = urllib.request.build_opener(_NoRedirect)
+#: CA-bundle variables, in the order the ecosystem already resolves them. distil
+#: honours the names a corporate environment has ALREADY set for curl/requests
+#: rather than inventing a distil-specific one nobody has exported.
+_CA_BUNDLE_VARS = ("DISTIL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "SSL_CERT_FILE")
+
+
+def ca_bundle_path() -> str | None:
+    """The CA bundle to trust for upstream TLS, or None for the system default.
+
+    Behind an SSL-inspecting corporate proxy (Zscaler, Netskope, a company MITM
+    box) every outbound TLS connection is re-signed by an internal CA. Python
+    does not read the macOS keychain or the Windows store for this, so distil's
+    upstream call fails certificate verification while curl and the browser —
+    which do read them, or have been pointed at the corporate bundle — work
+    fine. The user sees "upstream connection failed" and concludes distil is
+    broken, which from where they are sitting is indistinguishable from true.
+
+    Returns the first variable that names a file that actually exists. A path
+    that does not exist is ignored rather than passed to OpenSSL, which would
+    raise at context-construction time and take down the proxy at startup for a
+    stale export in someone's shell profile.
+    """
+    for var in _CA_BUNDLE_VARS:
+        val = (os.environ.get(var) or "").strip()
+        if val and os.path.isfile(val):
+            return val
+    return None
+
+
+def tls_failure_hint(reason: object) -> str | None:
+    """Turn a certificate-verification failure into the sentence that fixes it.
+
+    Raw, this arrives as ``[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify
+    failed: unable to get local issuer certificate``, which reads like distil is
+    broken. It usually means one thing: an SSL-inspecting corporate proxy is
+    re-signing traffic with a CA that Python does not trust. The user's browser
+    and curl work, so distil looks uniquely at fault.
+
+    Returns None for every other connection error — a hint about certificates on
+    a DNS failure or a refused connection is worse than silence, because it sends
+    the reader somewhere the problem is not.
+    """
+    text = str(reason)
+    if "CERTIFICATE_VERIFY_FAILED" not in text and "SSLCertVerificationError" not in text:
+        return None
+    current = ca_bundle_path()
+    if current is not None:
+        return (
+            f"TLS verification failed against the CA bundle at {current} "
+            f"(from {_which_ca_var()}). That file exists but does not contain the "
+            "issuer your network re-signs with — check it is the full corporate "
+            "root chain, not a single leaf certificate."
+        )
+    return (
+        "This is what an SSL-inspecting corporate proxy looks like: traffic is "
+        "re-signed by an internal CA that Python does not trust, so curl and your "
+        "browser work while distil does not. Point distil at your organisation's "
+        "CA bundle, e.g. export REQUESTS_CA_BUNDLE=/path/to/corp-ca.pem (or "
+        "SSL_CERT_FILE / CURL_CA_BUNDLE / DISTIL_CA_BUNDLE), then restart the proxy."
+    )
+
+
+def _which_ca_var() -> str:
+    """Which variable supplied the active bundle — named so the user edits the
+    right one when several are exported and only the first takes effect."""
+    for var in _CA_BUNDLE_VARS:
+        val = (os.environ.get(var) or "").strip()
+        if val and os.path.isfile(val):
+            return var
+    return "(none)"
+
+
+def _build_opener() -> urllib.request.OpenerDirector:
+    """The upstream opener, with a corporate CA bundle applied when present.
+
+    Verification is never disabled. There is no distil flag to turn it off, and
+    that is deliberate: "it works with verification off" is how a proxy holding
+    every prompt on the machine ends up trusting anything on the wire.
+    """
+    bundle = ca_bundle_path()
+    if bundle is None:
+        return urllib.request.build_opener(_NoRedirect)
+    ctx = ssl.create_default_context(cafile=bundle)
+    return urllib.request.build_opener(_NoRedirect, urllib.request.HTTPSHandler(context=ctx))
+
+
+_OPENER = _build_opener()
 
 
 class _ErrStream:
@@ -644,9 +731,14 @@ def build_handler(
                 return exc.code, rhdrs, rbody
             except urllib.error.URLError as exc:
                 status = 504 if _is_timeout(exc) else 502
-                rbody = json.dumps(
-                    {"error": "upstream connection failed", "detail": str(exc.reason)[:200]}
-                ).encode()
+                payload: dict[str, Any] = {
+                    "error": "upstream connection failed",
+                    "detail": str(exc.reason)[:200],
+                }
+                hint = tls_failure_hint(exc.reason)
+                if hint:
+                    payload["hint"] = hint
+                rbody = json.dumps(payload).encode()
                 return status, {"Content-Type": "application/json"}, rbody
             except TimeoutError:
                 rbody = b'{"error":"upstream timed out"}'

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -84,6 +84,36 @@ with large stable prefixes and small tool outputs genuinely has little to fold.
 It is alertable because it is indistinguishable from a misconfigured mode, and
 that distinction needs a human.
 
+## 3b. Networks that inspect TLS
+
+If your network re-signs outbound TLS with an internal CA — Zscaler, Netskope, a
+corporate MITM appliance — point distil at the CA bundle:
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/corp-ca.pem   # or SSL_CERT_FILE, CURL_CA_BUNDLE,
+                                                 # or DISTIL_CA_BUNDLE (checked first)
+distil doctor            # "TLS trust" names the bundle actually in effect
+```
+
+distil honours the variables your environment has almost certainly already
+exported for `curl` and `requests`, so on most managed machines this is already
+configured and nothing needs doing.
+
+**Why it is needed at all, and why it looks like a distil bug.** `curl` and your
+browser read the OS trust store; Python does not. So the corporate root that makes
+everything else on the machine work is invisible to distil, and the *only* symptom
+is distil failing to reach the provider while every other tool succeeds. The 502 it
+returns now carries the explanation and the fix rather than a raw OpenSSL string.
+
+A bundle path that does not exist is **ignored**, not fatal — a stale export in
+someone's shell profile must not stop the proxy from starting — and `distil doctor`
+warns when it finds one, because silently ignored is the worst outcome for a user
+who believes they configured it.
+
+There is no option to disable certificate verification, deliberately. distil sees
+every prompt on the machine; "it works with verification off" is how that becomes
+trusting anything on the wire.
+
 ## 4. Commercial status — read this before planning around distil
 
 | | Status |

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -872,24 +872,20 @@ def test_diagnose_swallows_check_exceptions(monkeypatch):
     def _explode():
         raise RuntimeError("simulated check failure")
 
-    # Replace every check with an exploding one so the aggregator exception path fires
-    monkeypatch.setattr(doctor, "_check_version", _explode)
-    monkeypatch.setattr(doctor, "_check_shadowed_install", _explode)
-    monkeypatch.setattr(doctor, "_check_ledger", _explode)
-    monkeypatch.setattr(doctor, "_check_session", _explode)
-    monkeypatch.setattr(doctor, "_check_live_routing", _explode)
-    monkeypatch.setattr(doctor, "_check_shadow", _explode)
-    monkeypatch.setattr(doctor, "_check_proxy_selftest", _explode)
-    monkeypatch.setattr(doctor, "_check_anthropic_extra", _explode)
-    monkeypatch.setattr(doctor, "_check_api_key", _explode)
-    monkeypatch.setattr(doctor, "_check_pricing_catalog", _explode)
-    monkeypatch.setattr(doctor, "_check_tokenizer_grade", _explode)
-    monkeypatch.setattr(doctor, "_check_mode", _explode)
-    monkeypatch.setattr(doctor, "_check_claude_code", _explode)
+    # Explode EVERY check, discovered by name rather than listed. The list version
+    # of this silently stopped covering each newly-added check until one of them
+    # returned a non-FAIL status and broke the `all(...)` assertion — the test
+    # failing for the right reason, but only by luck and one check too late.
+    names = [n for n in dir(doctor) if n.startswith("_check_") and callable(getattr(doctor, n))]
+    assert len(names) >= 13, f"check discovery found too few: {names}"
+    for name in names:
+        monkeypatch.setattr(doctor, name, _explode)
 
     checks = doctor.diagnose()
     # Every failed check should appear as FAIL (not raise)
-    assert all(c.status == doctor.FAIL for c in checks)
+    assert all(c.status == doctor.FAIL for c in checks), (
+        f"a check survived as non-FAIL: {[(c.name, c.status) for c in checks if c.status != doctor.FAIL]}"
+    )
     assert len(checks) >= 12
 
 

--- a/tests/test_ssl_inspection.py
+++ b/tests/test_ssl_inspection.py
@@ -1,0 +1,160 @@
+"""Corporate SSL inspection: the failure that looks like distil being broken.
+
+Behind an inspecting proxy (Zscaler, Netskope, a company MITM box) every outbound
+TLS connection is re-signed by an internal CA. curl and the browser read the OS
+trust store; Python does not. So distil's upstream call fails certificate
+verification while everything else on the machine works, and the user reasonably
+concludes distil is at fault.
+
+distil honours the variables such an environment has ALREADY exported for curl and
+requests, rather than inventing a distil-only name nobody has set.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from distil import proxy
+
+VARS = ("DISTIL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "SSL_CERT_FILE")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for v in VARS:
+        monkeypatch.delenv(v, raising=False)
+
+
+def _bundle(tmp_path):
+    p = tmp_path / "corp-ca.pem"
+    p.write_text("-----BEGIN CERTIFICATE-----\nnot a real cert\n-----END CERTIFICATE-----\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Which bundle wins
+# ---------------------------------------------------------------------------
+
+
+def test_no_variables_means_the_system_store(monkeypatch):
+    assert proxy.ca_bundle_path() is None
+
+
+@pytest.mark.parametrize("var", VARS)
+def test_each_supported_variable_is_honoured(var, monkeypatch, tmp_path):
+    monkeypatch.setenv(var, str(_bundle(tmp_path)))
+    assert proxy.ca_bundle_path() == str(_bundle(tmp_path))
+
+
+def test_precedence_is_most_specific_first(monkeypatch, tmp_path):
+    """A machine can have several of these exported; only one takes effect, and
+    doctor names which — otherwise the user edits the wrong one and nothing
+    changes."""
+    specific = tmp_path / "distil.pem"
+    specific.write_text("x")
+    monkeypatch.setenv("DISTIL_CA_BUNDLE", str(specific))
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(_bundle(tmp_path)))
+    assert proxy.ca_bundle_path() == str(specific)
+    assert proxy._which_ca_var() == "DISTIL_CA_BUNDLE"
+
+
+def test_a_path_that_does_not_exist_is_ignored(monkeypatch, tmp_path):
+    """A stale export in a shell profile must not take the proxy down at startup.
+
+    Passing a missing file to OpenSSL raises while building the context, which
+    would turn someone else's leftover environment variable into "distil will not
+    start" — a worse failure than the one this feature exists to fix.
+    """
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path / "gone.pem"))
+    assert proxy.ca_bundle_path() is None
+    proxy._build_opener()  # must not raise
+
+
+def test_a_real_bundle_produces_a_verifying_context(monkeypatch, tmp_path):
+    """The bundle is actually installed on the opener, and it still VERIFIES.
+
+    There is no distil switch to disable verification, deliberately: "it works
+    with verification off" is how a proxy holding every prompt on the machine
+    ends up trusting anything on the wire.
+    """
+    import urllib.request
+    from pathlib import Path
+
+    default = ssl.get_default_verify_paths().cafile
+    if not default:
+        pytest.skip("no system CA file to copy on this platform")
+    real = tmp_path / "real.pem"
+    real.write_bytes(Path(default).read_bytes())  # a guaranteed-valid PEM
+
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(real))
+    handlers = [
+        h for h in proxy._build_opener().handlers if isinstance(h, urllib.request.HTTPSHandler)
+    ]
+    assert handlers, "no HTTPS handler installed, so the bundle would be silently ignored"
+    ctx = handlers[0]._context
+    assert ctx.verify_mode == ssl.CERT_REQUIRED, "verification was weakened"
+    assert ctx.check_hostname is True
+
+
+# ---------------------------------------------------------------------------
+# The message, which is the actual deliverable
+# ---------------------------------------------------------------------------
+
+
+def test_a_verification_failure_explains_itself():
+    hint = proxy.tls_failure_hint(
+        "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+        "unable to get local issuer certificate"
+    )
+    assert hint is not None
+    assert "REQUESTS_CA_BUNDLE" in hint, "the fix must be named, not implied"
+    assert "corporate" in hint.lower() or "inspect" in hint.lower(), "the cause must be named"
+
+
+def test_a_failure_with_a_bundle_already_set_says_the_bundle_is_wrong(monkeypatch, tmp_path):
+    """Different problem, different sentence: the bundle exists but lacks the issuer.
+    Repeating "set REQUESTS_CA_BUNDLE" at someone who already did is useless."""
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(_bundle(tmp_path)))
+    hint = proxy.tls_failure_hint("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+    assert hint is not None and "corp-ca.pem" in hint
+    assert "full corporate root chain" in hint
+
+
+def test_other_connection_errors_get_no_certificate_hint():
+    """A certificate hint on a DNS or refused-connection failure sends the reader
+    somewhere the problem is not, which is worse than saying nothing."""
+    assert proxy.tls_failure_hint("[Errno 61] Connection refused") is None
+    assert proxy.tls_failure_hint("[Errno 8] nodename nor servname provided") is None
+    assert proxy.tls_failure_hint("timed out") is None
+
+
+# ---------------------------------------------------------------------------
+# doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_names_the_active_bundle(monkeypatch, tmp_path):
+    from distil.doctor import _check_tls_trust
+
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(_bundle(tmp_path)))
+    c = _check_tls_trust()
+    assert c.status == "ok" and "corp-ca.pem" in c.detail
+    assert "REQUESTS_CA_BUNDLE" in c.hint
+
+
+def test_doctor_warns_about_a_variable_pointing_nowhere(monkeypatch, tmp_path):
+    """Silently ignored is the worst outcome: the user believes they configured it."""
+    from distil.doctor import _check_tls_trust
+
+    monkeypatch.setenv("SSL_CERT_FILE", str(tmp_path / "missing.pem"))
+    c = _check_tls_trust()
+    assert c.status == "warn" and "SSL_CERT_FILE" in c.detail
+
+
+def test_doctor_is_quiet_on_a_normal_machine():
+    from distil.doctor import _check_tls_trust
+
+    c = _check_tls_trust()
+    assert c.status == "ok" and "system trust store" in c.detail


### PR DESCRIPTION
Unblocks anyone on a network that inspects TLS — today distil simply cannot reach the provider for them, with no way to fix it and nothing that says why.

## The failure, and why it reads as "distil is broken"

Behind an SSL-inspecting network (Zscaler, Netskope, a corporate MITM appliance) every outbound TLS connection is re-signed by an internal CA. **`curl` and the browser read the OS trust store; Python does not.** So the corporate root that makes everything else on the machine work is invisible to distil, and the only symptom is distil failing while every other tool succeeds.

What the user currently gets:

```json
{"error": "upstream connection failed",
 "detail": "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate"}
```

## The fix

The upstream opener honours **`DISTIL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `SSL_CERT_FILE`**, in that order — the names such an environment has *already* exported for curl and requests, rather than a distil-only name nobody has set. On most managed machines this is configured before distil is installed, so it just starts working. There's a single `_OPENER`, so there's a single place to fix it.

**A path that doesn't exist is ignored, not fatal.** Passing a missing file to OpenSSL raises while building the context — that would turn someone's stale shell export into "distil will not start", a worse failure than the one being fixed. `doctor` warns instead, because *silently ignored* is the worst outcome for a user who believes they configured it.

**The error now carries its own fix**, and a *different* sentence when a bundle is already set:

> the bundle at /path/corp-ca.pem (from REQUESTS_CA_BUNDLE) exists but does not contain the issuer your network re-signs with — check it is the full corporate root chain, not a single leaf certificate

Repeating "set `REQUESTS_CA_BUNDLE`" at someone who already did is useless. And every *other* connection error gets **no** certificate hint — pointing at certificates during a DNS failure or a refused connection sends the reader somewhere the problem is not.

**`distil doctor` gains a `TLS trust` check** naming the bundle actually in effect and which variable supplied it, since several can be exported and only the first takes effect.

## No escape hatch, deliberately

There is no flag to disable certificate verification. distil sees every prompt on the machine; *"it works with verification off"* is how that becomes trusting anything on the wire. A test asserts the context still requires certificates **and** hostname checking.

## A latent test bug this exposed

`test_diagnose_swallows_check_exceptions` patched a **hardcoded list** of checks and asserted all results were FAIL. Every check added since it was written was silently uncovered — it only broke when a new check returned non-FAIL. It now discovers checks by name, so the next one is covered automatically. The test was failing for the right reason, but only by luck and one check too late.

## Tests — 14

Precedence across all four variables · a nonexistent path is ignored and doesn't crash the opener · a real bundle is installed on the opener **and still verifies** (`CERT_REQUIRED` + `check_hostname`) · the hint names the fix · the already-configured case gets the other sentence · DNS/refused/timeout get no certificate hint · doctor names the active bundle, warns on a stale one, and is quiet on a normal machine.

| gate | result |
|---|---|
| `ruff` / `format` | clean / 337 files |
| `mypy@1.17.1` | no issues, 132 files |
| `pytest --cov-fail-under=95` | 3300 passed, **95.07%** |

Docs: `docs/ENTERPRISE.md` §3b.