### PR TITLE
release(1.43.0rc2): agent coverage, image downscaling, corporate TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,39 @@ records what the boundary actually is: consent, not recoverability. distil does 
 a first-party session unasked. Recoverability is still why a digest is *safe* once opted
 into; it is not why the default exists.
 
+**Two more agents, and one of them needed more than a preset.** `distil wrap` now routes
+**Grok CLI** (`GROK_BASE_URL`; the `/v1` belongs to the base URL there, unlike the OpenAI
+SDK which appends it) and **OpenHands**. OpenHands reads `LLM_BASE_URL` *only* when run
+with `--override-with-envs` — without it the agent reads its own settings file and ignores
+the environment entirely, so a preset alone would print success while routing nothing.
+`wrap` checks argv and says so before the session starts. The IDE extensions (cursor,
+copilot, cline, continue, windsurf) remain deliberately absent — no argv to wrap and no
+published env contract — and a test now pins that so the reasoning survives the next
+person who reads the list and sees a gap.
+
+**Oversized images can be downscaled, behind a recovery handle.** Duplicate elision cannot
+touch a *first* occurrence, so a 2400x1200 screenshot still cost its full ~1,600 input
+tokens every turn. [ADR 0007](docs/adr/0007-downscaling-behind-a-recovery-handle.md)
+permits downscaling in exactly one form: the original goes into the RestoreStore first,
+and the smaller image is emitted **as a pair** with a note stating what changed and the
+handle that returns the untouched original. A downscaled image emitted alone would be
+silent loss and is not allowed. It ships **off**, behind its own certificate, with **no
+bundled certificate** — `vision`'s shipped result certifies a provably identical image,
+while this is a claim about whether losing detail changes decisions on *your* screenshots,
+which nobody else's corpus can answer. Needs the optional `[image]` extra; inert without
+it, so the stdlib-only guarantee is unchanged for anyone who does not opt in.
+
+**Networks that inspect TLS no longer make distil look broken.** Behind a corporate MITM
+appliance every outbound connection is re-signed by an internal CA. `curl` and the browser
+read the OS trust store; Python does not — so distil failed certificate verification while
+every other tool on the machine worked. The upstream opener now honours `DISTIL_CA_BUNDLE`
+/ `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` / `SSL_CERT_FILE` (the names such an environment
+has already exported), a verification failure returns the sentence that fixes it rather
+than a raw OpenSSL string, and `distil doctor` names the bundle actually in effect. A path
+that does not exist is ignored rather than fatal — a stale shell export must not stop the
+proxy starting. There is no option to disable verification. See
+[`docs/ENTERPRISE.md`](docs/ENTERPRISE.md) §3b.
+
 ## [1.42.1] — the upgrade could not claim the port it had just been given
 
 **`distil default --always-on` was broken on Linux in 1.42.0**, in both directions,

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.43.0rc1"
+appVersion: "1.43.0rc2"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.43.0-rc.1",
+  "version": "1.43.0-rc.2",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.43.0rc1",
+  "version": "1.43.0rc2",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.43.0rc1"
+version = "1.43.0rc2"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.43.0rc1",
+  "version": "1.43.0rc2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.43.0rc1",
+      "version": "1.43.0rc2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.43.0rc1"
+version = "1.43.0rc2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Release candidate 2 for **1.43.0**.

## Why rc2 rather than promoting rc1

rc1 soaked for one day before `main` moved **seven commits** past it — four of them runtime-affecting: two new wrap presets, a new image transform, and the upstream TLS path. A soak measures a build, and the build changed. `RELEASING.md` says restart the clock, so this does.

## New since rc1

- **#114** — `distil wrap` routes **Grok CLI** and **OpenHands**. OpenHands only reads `LLM_BASE_URL` with `--override-with-envs`; without it a preset would print success while routing nothing, so `wrap` checks argv and says so.
- **#115** — **image downscaling behind a recovery handle** ([ADR 0007](docs/adr/0007-downscaling-behind-a-recovery-handle.md)). Original into the RestoreStore, smaller image emitted *paired* with a note carrying the handle. Ships **off**, no bundled certificate, inert without the optional `[image]` extra.
- **#116** — **corporate CA bundle support** with errors that name their own fix, plus a `doctor` check. No option to disable verification.

The `[1.43.0]` CHANGELOG entry now describes all of it — rc2 is what soaks for that final.

## Version locations — six

| file | value |
|---|---|
| `pyproject.toml`, `server.json` ×2, `plugin.json` | `1.43.0rc2` |
| `packaging/npm/package.json` | `1.43.0-rc.2` — npm rejects the PEP 440 spelling |
| `packaging/helm/.../Chart.yaml` `appVersion` | `1.43.0rc2` |
| `CITATION.cff` | **deliberately not bumped** — cites the GA artifact |

## Gates

| gate | result |
|---|---|
| `ruff` / `format` | clean / 337 files |
| packaging smoke | 16 passed |
| `pytest --cov-fail-under=95` | 3300 passed, **95.07%** |

After merge: tag `v1.43.0rc2` → CI publishes to PyPI as a prerelease (Homebrew and the Docker image skip automatically for rc tags). Then a fresh 3-day soak before the final.