### PR TITLE
fix(runtime): export the minted session id — and the session-learning it unblocks

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -3002,8 +3002,70 @@ def cmd_calibrate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _learn_write(args: argparse.Namespace) -> int:
+    """`distil learn --write` — persist a session's measured finding for the agent.
+
+    The analysis already exists in `dissect`; what was missing is that it lived in
+    a report a human reads once, while the agent that produced the cost never saw
+    it and did the same thing next session.
+    """
+    from pathlib import Path as _Path
+
+    from . import corrections
+    from .dissect import dissect, list_sessions, resolve_sid
+
+    sid = resolve_sid(args.session) if args.session else None
+    if sid is None and args.session:
+        # resolve_sid enumerates from the LEDGER, which batches its writes. A live
+        # session can therefore have per-request records on disk — everything this
+        # command actually reads — while the ledger has not flushed a row for it
+        # yet, and be rejected as "no such session". Accept an exact id whose
+        # records exist, so the answer does not depend on flush timing.
+        from .ledger import session_requests_path as _reqs
+
+        candidate = _reqs(args.session)
+        if candidate is not None and candidate.exists():
+            sid = args.session
+        else:
+            print(f"✗ no session matching {args.session!r} — `distil dissect` lists them")
+            return 1
+    if sid is None:
+        sessions = list_sessions()
+        if not sessions:
+            print("no sessions recorded yet — run one:  distil wrap -- claude")
+            return 1
+        sid = sessions[0].sid
+
+    block = corrections.build_block(dissect(sid))
+    if block is None:
+        # Deliberate: a note written off a thin session states a pattern from too
+        # little evidence, and a file of weak claims is one the agent skims.
+        print(
+            f"nothing earned from session {sid} yet — no single content type dominated,\n"
+            "or the session was too small to generalise from. Nothing written."
+        )
+        return 0
+
+    path = _Path(args.write)
+    if corrections.is_tracked_instruction_file(path) and not args.force:
+        print(f"✗ {path} looks like a TRACKED instruction file your teammates review.")
+        print("  distil will not edit that unasked. Either:")
+        print(f"    distil learn --write {path.with_suffix('')}.local.md   # gitignored, yours")
+        print(f"    distil learn --write {path} --force                   # you decided")
+        return 1
+
+    status = corrections.apply_block(path, block)
+    print(f"✓ {status} the distil block in {path}  (session {sid})")
+    if status != "unchanged":
+        print("  Everything outside the markers was left byte-for-byte as it was.")
+    return 0
+
+
 def cmd_learn(args: argparse.Namespace) -> int:
     """Show the keep policy Distil has learned from your real expand signals."""
+    if getattr(args, "write", None):
+        return _learn_write(args)
+
     from .learn import ExpandStats
 
     stats = ExpandStats.load()
@@ -3678,6 +3740,20 @@ def build_parser() -> argparse.ArgumentParser:
     ln.add_argument("--threshold", type=float, default=0.25, help="expand-rate to keep byte-exact")
     ln.add_argument(
         "--min-samples", type=int, default=5, help="min digests before a policy applies"
+    )
+    ln.add_argument(
+        "--write",
+        nargs="?",
+        const="CLAUDE.local.md",
+        metavar="FILE",
+        help="write what a session MEASURED into your agent's instruction file "
+        "(default CLAUDE.local.md, which is gitignored by convention)",
+    )
+    ln.add_argument("--session", help="session id to learn from (default: the most recent one)")
+    ln.add_argument(
+        "--force",
+        action="store_true",
+        help="--write: allow writing to a TRACKED instruction file your teammates review",
     )
     ln.set_defaults(func=cmd_learn)
 

--- a/distil/corrections.py
+++ b/distil/corrections.py
@@ -27,7 +27,12 @@ import re
 from pathlib import Path
 from typing import Any
 
-BEGIN = "<!-- distil:begin — measured from your sessions; edit above or below, not inside -->"
+# ASCII on purpose. These are machine-read delimiters, and they get compared against
+# bytes from a file distil did not write. An em-dash here rendered as a replacement
+# character on a cp1252 Windows console, so the marker no longer matched itself and
+# the block was appended a second time instead of updated. Typography in a delimiter
+# buys nothing and costs that.
+BEGIN = "<!-- distil:begin - measured from your sessions; edit above or below, not inside -->"
 END = "<!-- distil:end -->"
 
 #: What each block signature means in a sentence the agent can act on. Keyed to the
@@ -124,20 +129,26 @@ def apply_block(path: Path, block: str) -> str:
     instructions are not distil's to rewrite, and a tool that reformats the file
     around its edit is one people stop pointing at real files.
     """
-    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    # surrogateescape, not plain utf-8: this file belongs to the user and distil did
+    # not write it. An instruction file saved by a Windows editor is frequently
+    # cp1252, and a strict utf-8 read raises UnicodeDecodeError — turning "add a note
+    # to your file" into a traceback, on the exact platform least likely to be
+    # holding a utf-8 file. Round-tripping through surrogateescape preserves those
+    # bytes exactly, which is also what the byte-for-byte promise below requires.
+    existing = path.read_text(encoding="utf-8", errors="surrogateescape") if path.exists() else ""
     pattern = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END), re.DOTALL)
     if pattern.search(existing):
         updated = pattern.sub(lambda _m: block, existing, count=1)
         if updated == existing:
             return "unchanged"
-        path.write_text(updated, encoding="utf-8")
+        path.write_text(updated, encoding="utf-8", errors="surrogateescape")
         return "updated"
     sep = (
         ""
         if not existing or existing.endswith("\n\n")
         else ("\n" if existing.endswith("\n") else "\n\n")
     )
-    path.write_text(existing + sep + block + "\n", encoding="utf-8")
+    path.write_text(existing + sep + block + "\n", encoding="utf-8", errors="surrogateescape")
     return "created" if not existing else "updated"
 
 

--- a/distil/corrections.py
+++ b/distil/corrections.py
@@ -37,7 +37,16 @@ END = "<!-- distil:end -->"
 
 #: What each block signature means in a sentence the agent can act on. Keyed to the
 #: dominant content type distil actually measured, because the useful advice differs:
-#: filtering a log at the source is a different move from re-reading a diff.
+#: filtering a log at the source is a different move from narrowing a JSON payload.
+#:
+#: The keys MUST be exactly the classes ``learn._content_class`` can return. The
+#: first version of this table was written from imagination — it carried `diff`,
+#: `traceback` and `columnar`, which that function never produces, and omitted
+#: `json`, which it produces constantly. The dead keys were harmless; the missing
+#: one meant `learn --write` silently declined on every JSON-dominated session,
+#: which is most of them. `distil dissect` has a WIDER display vocabulary that
+#: includes diff/traceback/columnar — it is not the producer of these signatures,
+#: and copying from it is how the mistake happened. A test pins both directions.
 _GUIDANCE = {
     "log": (
         "large log output",
@@ -45,25 +54,16 @@ _GUIDANCE = {
         "`grep -m`, or a narrower time window. Most of a log's tokens are lines "
         "nobody reads.",
     ),
-    "diff": (
-        "large diffs",
-        "Prefer `--stat` first and fetch only the hunks you need. A full diff of a "
-        "large change is mostly context you already have.",
-    ),
-    "traceback": (
-        "stack traces",
-        "The first and last frames usually carry the signal; the middle is framework "
-        "noise. Quote the frames you are reasoning about rather than the whole trace.",
-    ),
     "code": (
         "code listings",
         "Read the specific symbol or range you need rather than whole files — the "
         "surrounding file is rarely what the decision turns on.",
     ),
-    "columnar": (
-        "tabular data",
-        "Ask for the columns and rows you need. Wide tables cost tokens per cell, "
-        "most of which never enter the reasoning.",
+    "json": (
+        "large JSON payloads",
+        "Ask for the fields you need rather than whole documents — most of a JSON "
+        "response is structure the decision never touches. Where a tool supports a "
+        "query or projection, use it at the source.",
     ),
     "error": (
         "error output",

--- a/distil/corrections.py
+++ b/distil/corrections.py
@@ -135,21 +135,40 @@ def apply_block(path: Path, block: str) -> str:
     # to your file" into a traceback, on the exact platform least likely to be
     # holding a utf-8 file. Round-tripping through surrogateescape preserves those
     # bytes exactly, which is also what the byte-for-byte promise below requires.
-    existing = path.read_text(encoding="utf-8", errors="surrogateescape") if path.exists() else ""
+    # newline="" on BOTH sides, or Python's universal-newline translation quietly
+    # rewrites every line ending in the file: read converts CRLF to LF, write
+    # converts it back on Windows and to LF everywhere else. Pointing this at a
+    # CRLF file from a LF machine would reformat the whole thing, which is a
+    # whole-file diff in `git status` for a tool that claims to touch only its own
+    # block. The promise below is byte-for-byte; this is what makes it true.
+    existing = ""
+    if path.exists():
+        with open(path, encoding="utf-8", errors="surrogateescape", newline="") as fh:
+            existing = fh.read()
+    # Match the file's prevailing line ending so the inserted block does not leave
+    # a mixed-ending file behind.
+    nl = "\r\n" if "\r\n" in existing else "\n"
+    block = block.replace("\r\n", "\n").replace("\n", nl)
     pattern = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END), re.DOTALL)
     if pattern.search(existing):
         updated = pattern.sub(lambda _m: block, existing, count=1)
         if updated == existing:
             return "unchanged"
-        path.write_text(updated, encoding="utf-8", errors="surrogateescape")
+        _write(path, updated)
         return "updated"
     sep = (
         ""
-        if not existing or existing.endswith("\n\n")
-        else ("\n" if existing.endswith("\n") else "\n\n")
+        if not existing or existing.endswith(nl + nl)
+        else (nl if existing.endswith(nl) else nl + nl)
     )
-    path.write_text(existing + sep + block + "\n", encoding="utf-8", errors="surrogateescape")
+    _write(path, existing + sep + block + nl)
     return "created" if not existing else "updated"
+
+
+def _write(path: Path, text: str) -> None:
+    """Write without newline translation — see apply_block."""
+    with open(path, "w", encoding="utf-8", errors="surrogateescape", newline="") as fh:
+        fh.write(text)
 
 
 def is_tracked_instruction_file(path: Path) -> bool:

--- a/distil/corrections.py
+++ b/distil/corrections.py
@@ -1,0 +1,152 @@
+"""Turn what a session measured into a note the agent reads next time.
+
+`distil dissect` already knows which content dominated a session's tokens — large
+logs, diffs, tracebacks, tabular output. That analysis is shown once, in a report
+a human reads and closes, and the agent that produced the cost never sees it. Next
+session it does the same thing again.
+
+This writes the finding where the agent will actually read it: a managed block in
+the project's agent instruction file. The guidance is keyed to what was measured on
+THIS project, not generic advice — "your tool output here is mostly large logs" is
+worth saying; "consider being efficient" is not.
+
+What it will not do
+-------------------
+It writes only to a `*.local.md` file by default, because those are gitignored by
+convention and a tracked `CLAUDE.md` is a file the user's teammates read and review.
+Editing that without being asked is distil modifying a repo it was invited to
+observe. `--force` is required to target a tracked file, and it says so.
+
+It also declines to write anything it cannot support with a number. A correction
+file that fills up with plausible-sounding advice teaches the agent to skim it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+BEGIN = "<!-- distil:begin — measured from your sessions; edit above or below, not inside -->"
+END = "<!-- distil:end -->"
+
+#: What each block signature means in a sentence the agent can act on. Keyed to the
+#: dominant content type distil actually measured, because the useful advice differs:
+#: filtering a log at the source is a different move from re-reading a diff.
+_GUIDANCE = {
+    "log": (
+        "large log output",
+        "Filter logs at the source rather than reading them whole — `tail -n`, "
+        "`grep -m`, or a narrower time window. Most of a log's tokens are lines "
+        "nobody reads.",
+    ),
+    "diff": (
+        "large diffs",
+        "Prefer `--stat` first and fetch only the hunks you need. A full diff of a "
+        "large change is mostly context you already have.",
+    ),
+    "traceback": (
+        "stack traces",
+        "The first and last frames usually carry the signal; the middle is framework "
+        "noise. Quote the frames you are reasoning about rather than the whole trace.",
+    ),
+    "code": (
+        "code listings",
+        "Read the specific symbol or range you need rather than whole files — the "
+        "surrounding file is rarely what the decision turns on.",
+    ),
+    "columnar": (
+        "tabular data",
+        "Ask for the columns and rows you need. Wide tables cost tokens per cell, "
+        "most of which never enter the reasoning.",
+    ),
+    "error": (
+        "error output",
+        "Capture the error and the command that produced it, not the full surrounding "
+        "output stream.",
+    ),
+    "prose": (
+        "long text output",
+        "Prefer a targeted search over reading whole documents when you are looking for one fact.",
+    ),
+}
+
+
+def build_block(dissection: Any, *, min_tokens: int = 20_000) -> str | None:
+    """The managed block for one session, or None when there is nothing earned.
+
+    Returns None below *min_tokens*: a note written off a trivial session states a
+    pattern from too little evidence, and a file of weak claims is one the agent
+    learns to skim.
+    """
+    kinds = dissection.blocks_by_kind()
+    # Denominator from the SAME source as the numerator. Using baseline_tokens
+    # here looked more impressive — a share of all input tokens — but it is
+    # derived from ledger rows while the kinds come from per-request records, and
+    # the ledger batches its writes. A session whose records are on disk but whose
+    # ledger has not flushed yet then divides by zero and silently declines
+    # forever. Found by running this against a live proxy rather than a fixture.
+    total = sum(tokens for _sig, _n, tokens in kinds)
+    if not kinds or total < min_tokens:
+        return None
+    top_sig, blocks, tokens = kinds[0]
+    label, advice = _GUIDANCE.get(str(top_sig).split(":")[0], (None, None))
+    if label is None:
+        return None  # an unrecognised signature earns silence, not invented advice
+    share = 100.0 * tokens / total if total else 0.0
+    # A clear majority, not merely the largest slice. Against this denominator a
+    # three-way split still shows ~36% for the biggest, and calling that "the
+    # largest single source of context cost" would be a claim the data does not
+    # support. Half or more is a pattern; a plurality is a coincidence.
+    if share < 50.0:
+        return None
+
+    return (
+        f"{BEGIN}\n"
+        f"## Context cost in this project\n\n"
+        f"Measured by distil over a recent session: **{label}** accounted for "
+        f"{tokens:,} of {total:,} tokens in the bulky content it handled "
+        f"({share:.0f}%), across {blocks} distinct blocks — the largest single "
+        f"source of context cost here.\n\n"
+        f"{advice}\n\n"
+        f"Detail that is elided by distil stays recoverable: call `distil_expand` "
+        f"with the handle in a `<< … handle=… >>` marker to get the exact original "
+        f"back, rather than re-running the command that produced it.\n"
+        f"{END}"
+    )
+
+
+def apply_block(path: Path, block: str) -> str:
+    """Insert or replace the managed block in *path*. Returns 'created' | 'updated'
+    | 'unchanged'.
+
+    Everything outside the markers is preserved byte-for-byte — the user's own
+    instructions are not distil's to rewrite, and a tool that reformats the file
+    around its edit is one people stop pointing at real files.
+    """
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    pattern = re.compile(re.escape(BEGIN) + r".*?" + re.escape(END), re.DOTALL)
+    if pattern.search(existing):
+        updated = pattern.sub(lambda _m: block, existing, count=1)
+        if updated == existing:
+            return "unchanged"
+        path.write_text(updated, encoding="utf-8")
+        return "updated"
+    sep = (
+        ""
+        if not existing or existing.endswith("\n\n")
+        else ("\n" if existing.endswith("\n") else "\n\n")
+    )
+    path.write_text(existing + sep + block + "\n", encoding="utf-8")
+    return "created" if not existing else "updated"
+
+
+def is_tracked_instruction_file(path: Path) -> bool:
+    """Whether *path* is a shared, committed instruction file rather than a local one.
+
+    `CLAUDE.local.md` and friends are gitignored by convention and are the user's
+    own scratch; `CLAUDE.md` / `AGENTS.md` are reviewed by their teammates. distil
+    writing into the second without being asked is editing a repo it was invited to
+    observe, so that requires --force.
+    """
+    return ".local." not in path.name

--- a/distil/runtime.py
+++ b/distil/runtime.py
@@ -54,9 +54,23 @@ class RuntimeSavings:
             # agent — and the status line it spawns — inherit, so per-session
             # savings correlate across the proxy and the status line. Falls back
             # to one-id-per-proxy-process when wrap didn't set it.
+            #
+            # EXPORT the fallback, do not just hold it. Every session-scoped path
+            # (`session_marker_path`, `session_requests_path`,
+            # `session_manifest_path`) resolves the id from os.environ. An
+            # always-on proxy runs under launchd/systemd, which does not inherit a
+            # shell environment, so the variable is unset: the id minted here went
+            # onto ledger rows while every one of those helpers returned None and
+            # silently wrote nothing. `distil dissect` then reported blocks=0 on
+            # sessions worth over a million tokens — the analysis was not broken,
+            # its input was never recorded.
+            #
+            # setdefault, not assignment: a real `distil wrap` id must always win,
+            # or the proxy would rename the session its agent is already using.
             self.session_id = (
                 os.environ.get("DISTIL_SESSION") or f"s{int(time.time())}-{os.getpid()}"
             )
+            os.environ.setdefault("DISTIL_SESSION", self.session_id)
 
     @property
     def tokens_saved(self) -> int:

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,182 @@
+"""Writing a measured finding into the agent's instruction file.
+
+Two things make this safe to point at a real file: it never claims more than it
+measured, and it never touches anything outside its own markers. Both are easy to
+lose in a refactor and expensive to lose in the field — the first turns the file
+into advice the agent learns to skim, the second turns distil into a tool that
+rewrites files people asked it only to observe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from distil import corrections
+
+
+class _Dissection:
+    """Stand-in with just the surface build_block reads."""
+
+    def __init__(self, kinds, baseline):
+        self._kinds = kinds
+        self.baseline_tokens = baseline
+
+    def blocks_by_kind(self):
+        return self._kinds
+
+
+# ---------------------------------------------------------------------------
+# It only says what it measured
+# ---------------------------------------------------------------------------
+
+
+def test_a_dominant_pattern_is_reported_with_its_numbers() -> None:
+    block = corrections.build_block(_Dissection([("log", 12, 60_000), ("code", 3, 40_000)], 0))
+    assert block is not None
+    assert "60,000" in block and "100,000" in block and "60%" in block
+    assert "large log output" in block
+    assert "12 distinct blocks" in block
+
+
+def test_a_session_too_small_to_generalise_from_earns_nothing() -> None:
+    """A pattern stated from one small session is a claim the data cannot carry."""
+    assert corrections.build_block(_Dissection([("log", 2, 900)], 0)) is None
+
+
+def test_no_dominant_pattern_earns_nothing() -> None:
+    """A plurality is not a pattern. Three kinds split ~36/33/31 is not "your
+    project is mostly logs", and saying so would be a claim the data cannot carry."""
+    kinds = [("log", 5, 15_000), ("diff", 5, 14_000), ("code", 5, 13_000)]
+    assert corrections.build_block(_Dissection(kinds, 0)) is None
+
+
+def test_an_unrecognised_signature_earns_silence_not_invented_advice() -> None:
+    assert corrections.build_block(_Dissection([("wat", 9, 90_000)], 0)) is None
+
+
+def test_the_advice_differs_by_what_was_measured() -> None:
+    """Generic advice is what gets skimmed; the useful move differs per content type."""
+    log = corrections.build_block(_Dissection([("log", 9, 90_000)], 0))
+    diff = corrections.build_block(_Dissection([("diff", 9, 90_000)], 0))
+    assert log and diff and log != diff
+    assert "tail" in log and "--stat" in diff
+
+
+# ---------------------------------------------------------------------------
+# It never touches anything outside its markers
+# ---------------------------------------------------------------------------
+
+
+def test_creating_preserves_existing_content(tmp_path: Path) -> None:
+    p = tmp_path / "CLAUDE.local.md"
+    p.write_text("# My rules\n\nAlways run the linter.\n")
+    assert corrections.apply_block(p, "BLOCKB") in ("created", "updated")
+    text = p.read_text()
+    assert text.startswith("# My rules\n\nAlways run the linter.\n")
+    assert "BLOCKB" in text
+
+
+def test_updating_replaces_only_the_managed_region(tmp_path: Path) -> None:
+    p = tmp_path / "CLAUDE.local.md"
+    first = f"{corrections.BEGIN}\nold finding\n{corrections.END}"
+    p.write_text(f"# Mine\n\n{first}\n\n## After\nkeep me\n")
+    second = f"{corrections.BEGIN}\nnew finding\n{corrections.END}"
+    assert corrections.apply_block(p, second) == "updated"
+    text = p.read_text()
+    assert "new finding" in text and "old finding" not in text
+    assert "# Mine" in text and "## After" in text and "keep me" in text
+
+
+def test_rewriting_the_same_block_is_a_no_op(tmp_path: Path) -> None:
+    """Re-running must not churn the file — a tool that rewrites on every run
+    produces noise in `git status` and gets removed from people's workflows."""
+    p = tmp_path / "CLAUDE.local.md"
+    block = f"{corrections.BEGIN}\nsame\n{corrections.END}"
+    corrections.apply_block(p, block)
+    before = p.read_text()
+    assert corrections.apply_block(p, block) == "unchanged"
+    assert p.read_text() == before
+
+
+def test_a_missing_file_is_created(tmp_path: Path) -> None:
+    p = tmp_path / "CLAUDE.local.md"
+    assert corrections.apply_block(p, "X") == "created"
+    assert p.exists()
+
+
+# ---------------------------------------------------------------------------
+# Which files it may write unasked
+# ---------------------------------------------------------------------------
+
+
+def test_local_files_are_distils_to_write() -> None:
+    for name in ("CLAUDE.local.md", "AGENTS.local.md", "GEMINI.local.md"):
+        assert corrections.is_tracked_instruction_file(Path(name)) is False
+
+
+def test_tracked_files_are_not() -> None:
+    """CLAUDE.md is reviewed by the user's teammates. Editing it unasked is distil
+    modifying a repo it was invited to observe."""
+    for name in ("CLAUDE.md", "AGENTS.md", "GEMINI.md"):
+        assert corrections.is_tracked_instruction_file(Path(name)) is True
+
+
+# ---------------------------------------------------------------------------
+# The command
+# ---------------------------------------------------------------------------
+
+
+def _args(**kw):
+    import argparse
+
+    d = dict(write=None, session=None, force=False, threshold=0.25, min_samples=5)
+    d.update(kw)
+    return argparse.Namespace(**d)
+
+
+def test_the_command_refuses_a_tracked_file_and_offers_both_ways_out(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    from distil import cli
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_learn_write", cli._learn_write)  # ensure we exercise the real one
+    from distil import dissect as _d
+
+    monkeypatch.setattr(_d, "list_sessions", lambda: [type("S", (), {"sid": "s1"})()])
+    monkeypatch.setattr(_d, "dissect", lambda sid: _Dissection([("log", 9, 90_000)], 0))
+
+    rc = cli.cmd_learn(_args(write="CLAUDE.md"))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert not (tmp_path / "CLAUDE.md").exists(), "a tracked file was written unasked"
+    assert "--force" in out and "CLAUDE.local.md" in out, "both ways out must be offered"
+
+
+def test_the_command_writes_the_local_file(tmp_path, monkeypatch, capsys) -> None:
+    from distil import cli
+    from distil import dissect as _d
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_d, "list_sessions", lambda: [type("S", (), {"sid": "s1"})()])
+    monkeypatch.setattr(_d, "dissect", lambda sid: _Dissection([("log", 9, 90_000)], 0))
+
+    rc = cli.cmd_learn(_args(write="CLAUDE.local.md"))
+    assert rc == 0
+    text = (tmp_path / "CLAUDE.local.md").read_text()
+    assert corrections.BEGIN in text and "large log output" in text
+    assert "90,000" in text
+
+
+def test_a_thin_session_writes_nothing_at_all(tmp_path, monkeypatch, capsys) -> None:
+    from distil import cli
+    from distil import dissect as _d
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_d, "list_sessions", lambda: [type("S", (), {"sid": "s1"})()])
+    monkeypatch.setattr(_d, "dissect", lambda sid: _Dissection([("log", 1, 500)], 0))
+
+    rc = cli.cmd_learn(_args(write="CLAUDE.local.md"))
+    assert rc == 0
+    assert not (tmp_path / "CLAUDE.local.md").exists(), "wrote a claim it had not earned"
+    assert "Nothing written" in capsys.readouterr().out

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -69,9 +69,9 @@ def test_the_advice_differs_by_what_was_measured() -> None:
 
 def test_creating_preserves_existing_content(tmp_path: Path) -> None:
     p = tmp_path / "CLAUDE.local.md"
-    p.write_text("# My rules\n\nAlways run the linter.\n")
+    p.write_text("# My rules\n\nAlways run the linter.\n", encoding="utf-8")
     assert corrections.apply_block(p, "BLOCKB") in ("created", "updated")
-    text = p.read_text()
+    text = p.read_text(encoding="utf-8")
     assert text.startswith("# My rules\n\nAlways run the linter.\n")
     assert "BLOCKB" in text
 
@@ -79,10 +79,10 @@ def test_creating_preserves_existing_content(tmp_path: Path) -> None:
 def test_updating_replaces_only_the_managed_region(tmp_path: Path) -> None:
     p = tmp_path / "CLAUDE.local.md"
     first = f"{corrections.BEGIN}\nold finding\n{corrections.END}"
-    p.write_text(f"# Mine\n\n{first}\n\n## After\nkeep me\n")
+    p.write_text(f"# Mine\n\n{first}\n\n## After\nkeep me\n", encoding="utf-8")
     second = f"{corrections.BEGIN}\nnew finding\n{corrections.END}"
     assert corrections.apply_block(p, second) == "updated"
-    text = p.read_text()
+    text = p.read_text(encoding="utf-8")
     assert "new finding" in text and "old finding" not in text
     assert "# Mine" in text and "## After" in text and "keep me" in text
 
@@ -93,9 +93,9 @@ def test_rewriting_the_same_block_is_a_no_op(tmp_path: Path) -> None:
     p = tmp_path / "CLAUDE.local.md"
     block = f"{corrections.BEGIN}\nsame\n{corrections.END}"
     corrections.apply_block(p, block)
-    before = p.read_text()
+    before = p.read_text(encoding="utf-8")
     assert corrections.apply_block(p, block) == "unchanged"
-    assert p.read_text() == before
+    assert p.read_text(encoding="utf-8") == before
 
 
 def test_a_missing_file_is_created(tmp_path: Path) -> None:
@@ -163,7 +163,7 @@ def test_the_command_writes_the_local_file(tmp_path, monkeypatch, capsys) -> Non
 
     rc = cli.cmd_learn(_args(write="CLAUDE.local.md"))
     assert rc == 0
-    text = (tmp_path / "CLAUDE.local.md").read_text()
+    text = (tmp_path / "CLAUDE.local.md").read_text(encoding="utf-8")
     assert corrections.BEGIN in text and "large log output" in text
     assert "90,000" in text
 
@@ -180,3 +180,34 @@ def test_a_thin_session_writes_nothing_at_all(tmp_path, monkeypatch, capsys) -> 
     assert rc == 0
     assert not (tmp_path / "CLAUDE.local.md").exists(), "wrote a claim it had not earned"
     assert "Nothing written" in capsys.readouterr().out
+
+
+def test_a_file_that_is_not_utf8_is_read_and_preserved(tmp_path: Path) -> None:
+    """A user's instruction file saved by a Windows editor is frequently cp1252.
+
+    distil did not write that file and has no business demanding an encoding for
+    it. A strict utf-8 read raises UnicodeDecodeError, turning "add a note to your
+    file" into a traceback — on the platform least likely to be holding utf-8.
+    This is the same class as the cp1252 crash in `distil stats`: a tool must not
+    fail on the file it was pointed at.
+    """
+    p = tmp_path / "CLAUDE.local.md"
+    # 0x97 is an em-dash in cp1252 and invalid as a lone utf-8 byte.
+    p.write_bytes(b"# My rules \x97 written on Windows\n\nAlways run the linter.\n")
+
+    block = f"{corrections.BEGIN}\nfinding\n{corrections.END}"
+    assert corrections.apply_block(p, block) in ("created", "updated")
+
+    raw = p.read_bytes()
+    assert b"\x97" in raw, "the user's own bytes were mangled, not preserved"
+    assert b"# My rules" in raw and b"Always run the linter." in raw
+    assert block.encode() in raw
+
+
+def test_the_markers_are_ascii(tmp_path: Path) -> None:
+    """They are compared against bytes from a file distil did not write, and are
+    echoed to consoles whose encoding it does not control. An em-dash here came
+    back as a replacement character on a cp1252 console, so the marker stopped
+    matching itself and the block was appended twice instead of updated."""
+    corrections.BEGIN.encode("ascii")
+    corrections.END.encode("ascii")

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -201,7 +201,7 @@ def test_a_file_that_is_not_utf8_is_read_and_preserved(tmp_path: Path) -> None:
     raw = p.read_bytes()
     assert b"\x97" in raw, "the user's own bytes were mangled, not preserved"
     assert b"# My rules" in raw and b"Always run the linter." in raw
-    assert block.encode() in raw
+    assert b"distil:begin" in raw and b"finding" in raw
 
 
 def test_the_markers_are_ascii(tmp_path: Path) -> None:
@@ -211,3 +211,26 @@ def test_the_markers_are_ascii(tmp_path: Path) -> None:
     matching itself and the block was appended twice instead of updated."""
     corrections.BEGIN.encode("ascii")
     corrections.END.encode("ascii")
+
+
+def test_line_endings_are_not_rewritten(tmp_path: Path) -> None:
+    """A CRLF file must come back CRLF, and an LF file LF.
+
+    Python's universal-newline translation silently rewrites every line ending on
+    the way in and out. For a tool that claims to touch only its own block, that
+    is a whole-file diff in `git status` — the churn that gets a tool removed from
+    someone's workflow, and a direct contradiction of the byte-for-byte promise.
+    """
+    crlf = tmp_path / "crlf.local.md"
+    crlf.write_bytes(b"# Windows file\r\n\r\nRule one.\r\n")
+    corrections.apply_block(crlf, f"{corrections.BEGIN}\nfinding\n{corrections.END}")
+    raw = crlf.read_bytes()
+    assert b"# Windows file\r\n" in raw, "the user's CRLF endings were rewritten"
+    assert b"\n" in raw and raw.count(b"\r\n") == raw.count(b"\n"), (
+        "mixed line endings were left behind"
+    )
+
+    lf = tmp_path / "lf.local.md"
+    lf.write_bytes(b"# Unix file\n\nRule one.\n")
+    corrections.apply_block(lf, f"{corrections.BEGIN}\nfinding\n{corrections.END}")
+    assert b"\r\n" not in lf.read_bytes(), "CRLF was introduced into an LF file"

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -57,9 +57,9 @@ def test_an_unrecognised_signature_earns_silence_not_invented_advice() -> None:
 def test_the_advice_differs_by_what_was_measured() -> None:
     """Generic advice is what gets skimmed; the useful move differs per content type."""
     log = corrections.build_block(_Dissection([("log", 9, 90_000)], 0))
-    diff = corrections.build_block(_Dissection([("diff", 9, 90_000)], 0))
-    assert log and diff and log != diff
-    assert "tail" in log and "--stat" in diff
+    js = corrections.build_block(_Dissection([("json", 9, 90_000)], 0))
+    assert log and js and log != js
+    assert "tail" in log and "fields you need" in js
 
 
 # ---------------------------------------------------------------------------
@@ -234,3 +234,45 @@ def test_line_endings_are_not_rewritten(tmp_path: Path) -> None:
     lf.write_bytes(b"# Unix file\n\nRule one.\n")
     corrections.apply_block(lf, f"{corrections.BEGIN}\nfinding\n{corrections.END}")
     assert b"\r\n" not in lf.read_bytes(), "CRLF was introduced into an LF file"
+
+
+class TestTheGuidanceTableMatchesRealSignatures:
+    """The table is keyed to strings another module produces. Nothing but a test
+    keeps those in step, and the first version of it was written from imagination:
+    it carried `diff`, `traceback` and `columnar` — which `learn._content_class`
+    never emits — and omitted `json`, which it emits constantly. The dead keys were
+    harmless. The missing one made `distil learn --write` decline silently on every
+    JSON-dominated session, which is most of them.
+    """
+
+    #: Representative inputs for each branch of learn._content_class, so the set of
+    #: classes is DERIVED from the producer rather than restated here.
+    SAMPLES = (
+        '{"result": [1, 2, 3], "ok": true}',
+        "Traceback (most recent call last):\n  File x\nError: boom",
+        "def handler(request):\n    return None",
+        "2026-01-01T00:00:00Z INFO starting worker pool\n" * 3,
+        "The quick brown fox jumps over the lazy dog and keeps going.",
+    )
+
+    def _produced(self) -> set[str]:
+        from distil.learn import _content_class
+
+        return {_content_class(t) for t in self.SAMPLES}
+
+    def test_every_class_the_producer_emits_has_guidance(self) -> None:
+        missing = self._produced() - set(corrections._GUIDANCE)
+        assert not missing, (
+            f"learn._content_class emits {sorted(missing)} with no guidance — "
+            "learn --write declines silently on those sessions"
+        )
+
+    def test_the_table_has_no_keys_the_producer_cannot_emit(self) -> None:
+        """Dead keys are how the table drifts: they look like coverage and are not."""
+        dead = set(corrections._GUIDANCE) - self._produced()
+        assert not dead, f"guidance for signatures that never occur: {sorted(dead)}"
+
+    def test_json_specifically_produces_a_block(self) -> None:
+        """The regression itself: the most common class, previously silent."""
+        block = corrections.build_block(_Dissection([("json:xl", 9, 90_000)], 0))
+        assert block is not None and "JSON" in block

--- a/tests/test_session_identity.py
+++ b/tests/test_session_identity.py
@@ -1,0 +1,108 @@
+"""One session id, or the per-session state silently writes nothing.
+
+The savings recorder mints a fallback session id when `distil wrap` did not set
+one. Ledger rows carried that id; every session-scoped PATH resolves the id from
+`os.environ`, which still had nothing. So on an always-on install — launchd and
+systemd do not inherit a shell environment — the request records, the manifest
+and the liveness marker were all no-ops, while the ledger looked healthy.
+
+The visible symptom was `distil dissect` reporting `blocks=0` for sessions worth
+more than a million tokens. The analysis was fine; its input was never recorded.
+
+This is the third surface of one root cause. The other two (a status line calling
+routed sessions "bypassing", ledger rows attributed to the proxy rather than the
+wrap) were fixed where they showed. This tests the cause.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from distil import ledger
+from distil.runtime import RuntimeSavings as Savings
+
+
+class TestTheIdIsExportedNotJustHeld:
+    def test_a_minted_id_reaches_the_environment(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(ledger_path=tmp_path / "savings.jsonl")
+        assert s.session_id, "no id was minted"
+        assert os.environ.get("DISTIL_SESSION") == s.session_id, (
+            "the id went onto ledger rows but not into the environment, so every "
+            "session_*_path() helper still resolves to None"
+        )
+
+    def test_the_path_helpers_resolve_to_that_same_id(self, monkeypatch, tmp_path):
+        """The actual invariant: one id, and every consumer sees it."""
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(ledger_path=tmp_path / "savings.jsonl")
+
+        for resolve in (
+            ledger.session_marker_path,
+            ledger.session_requests_path,
+            ledger.session_manifest_path,
+        ):
+            p = resolve()
+            assert p is not None, f"{resolve.__name__} still returns None — writes are dropped"
+            assert s.session_id in p.name, (
+                f"{resolve.__name__} resolved to a DIFFERENT session than the ledger rows"
+            )
+
+    def test_a_wrap_session_is_never_renamed(self, monkeypatch, tmp_path):
+        """setdefault, not assignment. Overwriting would rename the session the
+        agent and its status line are already using, splitting one session in two."""
+        monkeypatch.setenv("DISTIL_SESSION", "s-from-wrap")
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(ledger_path=tmp_path / "savings.jsonl")
+        assert s.session_id == "s-from-wrap"
+        assert os.environ["DISTIL_SESSION"] == "s-from-wrap"
+
+    def test_an_explicit_session_id_still_wins(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(session_id="explicit", ledger_path=tmp_path / "savings.jsonl")
+        assert s.session_id == "explicit"
+
+
+class TestPerRequestStateIsActuallyWritten:
+    """The end the user sees: records on disk, and dissect able to read them."""
+
+    def test_a_request_record_lands_on_disk(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(ledger_path=tmp_path / "savings.jsonl")
+
+        ledger.append_session_request({"ts": 1.0, "blocks": [{"sig": "log", "tokens": 900}]})
+        path = ledger.session_requests_path()
+        assert path is not None and path.exists(), (
+            "append_session_request silently no-opped — this is the bug, restated"
+        )
+        rec = json.loads(path.read_text().splitlines()[0])
+        assert rec["blocks"][0]["sig"] == "log"
+        assert s.session_id in path.name
+
+    def test_dissect_sees_the_blocks_it_previously_reported_as_zero(self, monkeypatch, tmp_path):
+        """The symptom that exposed all of this: blocks=0 on a large session."""
+        monkeypatch.delenv("DISTIL_SESSION", raising=False)
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        s = Savings(ledger_path=tmp_path / "savings.jsonl")
+
+        ledger.append_session_request(
+            {
+                "ts": 1.0,
+                "blocks": [
+                    {"h": "aaaa1111", "sig": "log", "tokens": 5_000},
+                    {"h": "bbbb2222", "sig": "diff", "tokens": 1_000},
+                ],
+            }
+        )
+
+        from distil.dissect import dissect
+
+        d = dissect(s.session_id)
+        assert d.blocks, "dissect still sees no blocks — the record did not reach it"
+        kinds = dict((k, tok) for k, _n, tok in d.blocks_by_kind())
+        assert kinds.get("log") == 5_000 and kinds.get("diff") == 1_000


### PR DESCRIPTION
Two commits: a root-cause fix, and the feature that was blocked on it. They're coupled — the feature reads exactly the data the fix restores, and is inert without it.

---

# 1. The fix — one id, two views, disagreeing

`RuntimeSavings` mints a fallback session id when `distil wrap` didn't set one. That id goes onto **ledger rows**. But every session-scoped *path* — `session_marker_path`, `session_requests_path`, `session_manifest_path` — resolves the id from `os.environ`, which still had nothing in it.

An always-on proxy runs under launchd or systemd. **Neither inherits a shell environment.** So on every always-on install those helpers returned `None` and their writes were silently dropped. The ledger looked healthy throughout, because it uses the *held* value.

**Symptom:** `distil dissect` reporting `blocks=0` on a session worth 1.4M input tokens. The analysis was never broken; its input was never recorded.

```
proxy pid 21385 → DISTIL_SESSION in its environment: 0
newest per-request file:  s1786148684   (days old)
newest ledger session:    s1786412346-21385   (current)
```

Fix: `setdefault` the minted id into the environment. **`setdefault`, not assignment** — a real `distil wrap` id must win, or the proxy would rename the session its own agent and status line are already using, splitting one session in two.

### Third surface of one cause

| surface | fixed |
|---|---|
| status line calling routed sessions "bypassing" | #110 |
| ledger rows attributed to the proxy, not the wrap | #110 |
| per-request records, manifest and marker never written | **here** |

The first two were fixed where they showed. This fixes the cause, and the tests assert the *invariant* — one id, every consumer sees it — so the next surface fails in CI instead of shipping.

**Verified red on the parent**: 4 of 6 fail there, including the `blocks=0` symptom.

**Verified in a real proxy process** started with no `DISTIL_SESSION`, exactly as launchd runs it:

```
requests recorded: 1 → 12
blocks: 1 → 12          (shipped build: 0)
by kind: [('log:xl', 12, 106676)]
```

---

# 2. `distil learn --write` — the finding, where the agent reads it

`dissect` already knows what dominated a session. That lives in a report a human reads once; the agent that produced the cost never sees it, so next session it repeats it. This writes a managed block into `CLAUDE.local.md`:

> Measured by distil over a recent session: **large log output** accounted for 106,676 of 106,676 tokens in the bulky content it handled (100%), across 12 distinct blocks — the largest single source of context cost here.
>
> Filter logs at the source rather than reading them whole — `tail -n`, `grep -m`, or a narrower time window.

### Deliberate limits, each tested

- **Only `*.local.md`.** A tracked `CLAUDE.md` is reviewed by the user's teammates; editing it unasked is distil modifying a repo it was invited to observe. `--force` required, both ways out printed.
- **Byte-for-byte outside the markers**, and re-running an unchanged finding is a no-op. A tool that churns the file shows up in `git status` and gets removed from workflows.
- **Silence is the default.** Declines under 20k tokens of bulky content, or when no kind reaches 50% of it, or for a signature with no guidance written. A file of plausible advice teaches the agent to skim it.

### Two bugs found by running it against a live proxy, not fixtures

Neither would have surfaced in unit tests:

1. The share was computed against `baseline_tokens` (ledger-derived) while the numerator came from per-request records. The ledger batches writes, so a session with records on disk but no flushed row divided by zero and declined **forever**. Both sides now come from one source, and the sentence states that denominator honestly.
2. `--session` rejected an exact id whose records exist, because `resolve_sid` also enumerates from the ledger. Accepting it makes the answer independent of flush timing.

---

| gate | result |
|---|---|
| `ruff` / `format` | clean / 340 files |
| `mypy@1.17.1` | no issues, 133 files |
| `pytest --cov-fail-under=95` | 3320 passed, **95.04%** |

**If you'd rather merge the fix alone**, say so — the feature can move to its own branch. That needs a force-push to this one, which I won't do unasked.