### PR TITLE
release(1.43.0rc3): one candidate with everything in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,56 @@ records what the boundary actually is: consent, not recoverability. distil does 
 a first-party session unasked. Recoverability is still why a digest is *safe* once opted
 into; it is not why the default exists.
 
+**Two more agents, and one needed more than a preset.** `distil wrap` routes **Grok
+CLI** (`GROK_BASE_URL`; the `/v1` belongs to the base URL there, unlike the OpenAI SDK
+which appends it) and **OpenHands**. OpenHands reads `LLM_BASE_URL` *only* when run with
+`--override-with-envs` — without it the agent reads its own settings file and ignores the
+environment entirely, so a preset alone would print success while routing nothing. `wrap`
+checks argv and says so before the session starts. The IDE extensions (cursor, copilot,
+cline, continue, windsurf) remain deliberately absent — no argv to wrap and no published
+env contract — and a test now pins that.
+
+**Oversized images can be downscaled, behind a recovery handle.** Duplicate elision cannot
+touch a *first* occurrence, so a 2400x1200 screenshot still cost its full ~1,600 input
+tokens every turn. [ADR 0007](docs/adr/0007-downscaling-behind-a-recovery-handle.md) permits
+downscaling in exactly one form: the original goes into the RestoreStore first, and the
+smaller image is emitted **as a pair** with a note stating what changed and the handle that
+returns the untouched original. A downscaled image emitted alone would be silent loss and
+is not allowed. Ships **off**, behind its own certificate, with **no bundled certificate** —
+`vision`'s shipped result certifies a provably identical image, while this is a claim about
+whether losing detail changes decisions on *your* screenshots. Needs the optional `[image]`
+extra; inert without it.
+
+**Networks that inspect TLS no longer make distil look broken.** Behind a corporate MITM
+appliance every outbound connection is re-signed by an internal CA. `curl` and the browser
+read the OS trust store; Python does not — so distil failed certificate verification while
+every other tool on the machine worked. The upstream opener now honours `DISTIL_CA_BUNDLE`
+/ `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` / `SSL_CERT_FILE`, a verification failure returns
+the sentence that fixes it rather than a raw OpenSSL string, and `distil doctor` names the
+bundle actually in effect. A path that does not exist is ignored rather than fatal. There is
+no option to disable verification. See [`docs/ENTERPRISE.md`](docs/ENTERPRISE.md) §3b.
+
+**`distil dissect` was reporting almost nothing on always-on installs, and the cause was one
+unexported variable.** The savings recorder mints a session id when `distil wrap` did not set
+one and put it on ledger rows — but every session-scoped *path* resolves that id from the
+environment, and an always-on proxy runs under launchd or systemd, neither of which inherits
+a shell environment. So per-request records, the session manifest and the liveness marker
+were all silently dropped while the ledger looked healthy. `dissect` reported `blocks=0` on
+sessions worth over a million input tokens: the analysis was never broken, its input was
+never recorded. This was the third surface of that one cause — the status line calling
+fully-routed sessions "bypassing", and ledger rows attributed to the proxy rather than the
+wrap, were the first two.
+
+**`distil learn --write` puts what a session measured where the agent will read it.** That
+analysis has always lived in a report a human reads once; the agent that produced the cost
+never saw it, so it repeated itself next session. This writes a managed block into
+`CLAUDE.local.md` keyed to *your* project: which content type dominated, how much of the
+bulky content it was, and the move that reduces it. It writes only to a `*.local.md` file
+unless forced (a tracked `CLAUDE.md` is reviewed by your teammates), preserves everything
+outside its markers byte-for-byte — including line endings and non-UTF-8 bytes — and
+declines entirely when no single content type reached half the measured volume. A file of
+plausible advice is one the agent learns to skim.
+
 ## [1.42.1] — the upgrade could not claim the port it had just been given
 
 **`distil default --always-on` was broken on Linux in 1.42.0**, in both directions,

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.43.0rc1"
+appVersion: "1.43.0rc3"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.43.0-rc.1",
+  "version": "1.43.0-rc.3",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.43.0rc1",
+  "version": "1.43.0rc3",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.43.0rc1"
+version = "1.43.0rc3"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.43.0rc1",
+  "version": "1.43.0rc3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.43.0rc1",
+      "version": "1.43.0rc3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.43.0rc1"
+version = "1.43.0rc3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The single candidate to soak. `main` and this tag will describe the same build.

rc1 soaked for a day before `main` moved six commits past it. rc2 was cut and then superseded before it was ever tagged, because `main` moved again. rc3 is cut from current `main` with everything in it.

## Everything since rc1

| PR | |
|---|---|
| #114 | Grok CLI and OpenHands wrap presets |
| #115 | image downscaling behind a recovery handle — ships **off**, no bundled certificate |
| #116 | corporate CA bundle + TLS errors that name their own fix |
| #118 | the session-identity fix, `distil learn --write`, and two Windows faults the gate caught |

`main` is at `0bb4d27`; this branch is that plus the version bump and CHANGELOG.

## A note on the CHANGELOG

The rc2 branch carried an earlier draft of the `[1.43.0]` entry and was **closed unmerged**, so `main`'s entry still described only rc1. This re-adds all of it.

Worth stating plainly: the version bump would have been green either way, because **the CHANGELOG is not gated**. The packaging smoke test checks that six version locations agree; nothing checks that the release notes describe the release. I caught this by reading the file rather than by a failing test.

## Version locations — six

| file | value |
|---|---|
| `pyproject.toml`, `server.json` ×2, `plugin.json` | `1.43.0rc3` |
| `packaging/npm/package.json` | `1.43.0-rc.3` — npm rejects the PEP 440 spelling |
| `packaging/helm/.../Chart.yaml` `appVersion` | `1.43.0rc3` |
| `CITATION.cff` | **deliberately not bumped** — cites the GA artifact |

## Gates

| gate | result |
|---|---|
| `ruff` / `format` | clean / 340 files |
| packaging smoke | 16 passed |
| `pytest --cov-fail-under=95` | 3326 passed, **95.05%** |

After merge: tag `v1.43.0rc3` → CI publishes to PyPI as a prerelease (Homebrew and the Docker image skip automatically for rc tags). Then the 3-day soak.