### PR TITLE
release(1.43.0rc4): pin the build backend so the wheel is publishable

### DIFF
--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.43.0rc3"
+appVersion: "1.43.0rc4"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.43.0-rc.3",
+  "version": "1.43.0-rc.4",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.43.0rc3",
+  "version": "1.43.0rc4",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.43.0rc3"
+version = "1.43.0rc4"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The
@@ -70,7 +70,16 @@ distil-mcp = "distil.mcp_server:serve"
 distil-llm = "distil.mcp_server:serve"
 
 [build-system]
-requires = ["hatchling"]
+# PINNED, like ruff and mypy in CI, and for the same reason: an unpinned build
+# backend drifts and breaks the release. hatchling 1.32 emits
+# `Metadata-Version: 2.5`, which the publish action's bundled twine rejects with
+# "not a valid metadata version" — so v1.43.0rc3 built green and published
+# nothing. Worse, it was invisible locally: this machine had an older hatchling
+# cached, so `uv build` produced an acceptable 2.4 wheel while CI produced an
+# unpublishable one. Local and CI must build the SAME artifact.
+# Lifting this pin requires the publish action to accept 2.5 first — see the
+# metadata assertion in tests/test_packaging_smoke.py.
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 # Keep local cruft (alt venvs, caches, result dumps) out of the sdist — an

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.43.0rc3",
+  "version": "1.43.0rc4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.43.0rc3",
+      "version": "1.43.0rc4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -56,6 +56,38 @@ def _pyproject() -> dict:
     return {"project": project}
 
 
+#: Highest Metadata-Version the release pipeline's publisher accepts. twine inside
+#: pypa/gh-action-pypi-publish rejects anything newer with "not a valid metadata
+#: version", which fails the upload AFTER the tag is pushed and the build is green.
+MAX_METADATA_VERSION = (2, 4)
+
+
+def _assert_publishable_metadata(wheel: Path) -> None:
+    """The wheel must carry metadata the publisher will actually accept.
+
+    v1.43.0rc3 built green, tagged, and published NOTHING: an unpinned hatchling
+    resolved to 1.32 in CI and emitted `Metadata-Version: 2.5`. It was invisible
+    locally because this machine had an older hatchling cached, so the local
+    smoke test built an acceptable wheel while CI built an unpublishable one.
+
+    Checking the artifact — rather than trusting the pin in pyproject — is what
+    makes this catch the next drift, including one that arrives through a
+    transitive resolution nobody edited.
+    """
+    import zipfile
+
+    with zipfile.ZipFile(wheel) as z:
+        name = next(n for n in z.namelist() if n.endswith(".dist-info/METADATA"))
+        first = z.read(name).decode("utf-8", "replace").splitlines()[0]
+    assert first.startswith("Metadata-Version:"), f"no metadata version line: {first!r}"
+    got = tuple(int(x) for x in first.split(":", 1)[1].strip().split("."))
+    assert got <= MAX_METADATA_VERSION, (
+        f"wheel declares Metadata-Version {'.'.join(map(str, got))}, but the publish "
+        f"action rejects anything above {'.'.join(map(str, MAX_METADATA_VERSION))}. "
+        "The build backend drifted — pin it in pyproject, or upgrade the publisher first."
+    )
+
+
 @pytest.fixture(scope="module")
 def installed(tmp_path_factory) -> Path:
     """Build the wheel and install it into a clean venv. Returns the venv's bin/."""
@@ -73,6 +105,7 @@ def installed(tmp_path_factory) -> Path:
         pytest.skip(f"uv build unavailable/failed: {build.stderr[-300:]}")
     wheels = list(wheel_dir.glob("*.whl"))
     assert wheels, "uv build produced no wheel"
+    _assert_publishable_metadata(wheels[0])
 
     venv = work / "venv"
     subprocess.run(["uv", "venv", str(venv)], check=True, capture_output=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.43.0rc3"
+version = "1.43.0rc4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
**v1.43.0rc3 tagged, built green, and published nothing.**

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Cause

`build-system.requires` was an unpinned `hatchling`. CI resolved **1.32**, which emits `Metadata-Version: 2.5` — newer than the twine bundled in `pypa/gh-action-pypi-publish` accepts. Same class as the unpinned `ruff` that reddened `main` during 1.26.0: a tool nobody edited moved underneath the pipeline.

Verified directly rather than inferred:

| constraint | emitted |
|---|---|
| `hatchling` (→ 1.32.0) | `Metadata-Version: 2.5` ✗ rejected |
| `hatchling<1.32` | `Metadata-Version: 2.4` ✓ |

## Why the local gate missed it

This is the part worth fixing, not just the pin. **This machine had an older hatchling cached**, so `uv build` produced an acceptable 2.4 wheel — and `release.sh`'s own clean-install smoke test passed, on an artifact CI would never produce.

Local and CI were building *different wheels*, and only one of them was publishable. It wasn't the one being tested.

## Changes

- **`pyproject.toml`** — `hatchling<1.32`, with the reason and the condition for lifting it (the publisher must accept 2.5 first).
- **`tests/test_packaging_smoke.py`** — assert the built wheel's `Metadata-Version` is one the publisher accepts. It inspects the **artifact**, not the pin, so it also catches a drift arriving through a transitive resolution nobody edited. Verified to fire by lowering the ceiling to 2.3.

## rc3's tag

Left where it is. Nothing consumed it, no artifact was published, and rewriting a pushed tag is worse than spending a version number.

| gate | result |
|---|---|
| `ruff` / `format` | clean / 340 files |
| packaging smoke | 16 passed |
| `pytest --cov-fail-under=95` | 3326 passed, **95.05%** |