### PR TITLE
release(1.44.0): the savings number can now explain itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.44.0] — the savings number could not explain itself
+
+**A low percentage was indistinguishable from a broken compressor.** `distil stats` would
+report 0.4% and stop there, and from the outside that reading has four completely different
+causes: a request that was mostly the model's own prose (which distil never rewrites, by
+policy), mostly recency-exempt tool output (a carve-out that shrinks as a conversation
+grows), mostly fragments below the digest threshold, or a digester that was handed real
+work and declined it. Three of those are the design holding. One is a defect. The saved-token
+count is identical in all four, so the only way to tell them apart was to reason from the
+outside about what the traffic probably contained — and that reasoning is wrong often enough
+to send an investigation in the wrong direction for hours.
+
+Every block is now attributed to the gate that actually claimed it, and the counts ride on
+the per-request record. `distil dissect` sums them and prints the answer next to the number
+that prompted the question:
+
+    why: the model's own words (never rewritten) 54%, digester declined 25%,
+         digested 12%, freshest tool output (kept byte-exact) 9%
+
+A declined share of 5% or more is called out as the compressor's to explain. Otherwise a
+protected majority is named as the design holding rather than a fault. Declined wins the tie
+deliberately: a session can be 63% policy-protected *and* refusing a quarter of what it was
+handed, and summarising that as "mostly protected, all is well" would file a real defect
+under an exoneration.
+
+The counts are taken at the decision points themselves, not by a second pass that re-derives
+the rules — a parallel implementation is free to drift from the compressor it describes, and
+a report that quietly disagrees with behaviour is worse than no report. The first draft of
+this predicted the branch order and got it wrong: HTML extraction runs *before* the
+minimum-lines gate, because minified markup is one enormous line, so every browser fetch
+would have been filed as "too short to digest".
+
+Sessions recorded before this ships render no `why:` line at all, rather than showing zeros.
+"No data" and "nothing was eligible" are different claims and only one of them is true.
+
+**Billed tokens never said what a request cost your plan.** Provider responses carry
+`anthropic-ratelimit-*` headers — the only first-party signal for how a request draws down a
+quota, as opposed to how many tokens it contained. The two diverge sharply on cached traffic,
+where a read is billed at roughly a tenth of the metered price, and whether a subscription cap
+discounts it the same way is not published anywhere. Those headers are now recorded per
+request, including on the 429 that carries the most informative quota state of any response.
+Captured at all three upstream reads, because they are genuinely separate code paths and the
+`--expand` splice path is the one real agent traffic uses.
+
+**`distil stats` quoted a digest rate from a window it did not belong to.** The rate beside
+the trim was computed over all recorded history while the trim itself covered the recent
+window, so a mode enabled today was described with a number earned by months of traffic under
+a different one. Both figures now come from the same window.
+
 ## [1.43.0] — the safe default could not say what it cost, and the reload could strand you
 
 **`distil default --always-on` could take macOS down.** The reload boots the job out,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.42.1
+version: 1.44.0
 date-released: 2026-08-09
 keywords:
   - llm

--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -54,6 +54,34 @@ import threading as _threading  # noqa: E402
 
 _keep_tls = _threading.local()
 
+# Per-call eligibility census: token counts bucketed by the REASON each block met.
+# "Why was saving low?" is otherwise only answerable by inference from the outside,
+# and inference gets it wrong — a request can look uncompressed because it was mostly
+# assistant prose (policy), mostly recent (carve-out), mostly short (below _MIN_LINES),
+# or because the digester genuinely declined. Those are different diagnoses with
+# different fixes, and they are indistinguishable in the savings number alone.
+#
+# Counted at the decision points themselves rather than by a second traversal, so the
+# report cannot drift from the behaviour it describes. Content-free: token counts
+# keyed by a fixed vocabulary of reasons, never text.
+_census_tls = _threading.local()
+
+
+def _census(bucket: str, text: str) -> None:
+    """Attribute *text*'s tokens to *bucket*. No-op unless a census is open, so the
+    cost is confined to callers that asked for one."""
+    counts = getattr(_census_tls, "counts", None)
+    if counts is None:
+        return
+    counts[bucket] = counts.get(bucket, 0) + _tokenizer.count(text)
+
+
+def take_census() -> dict[str, int] | None:
+    """The census accumulated by the most recent ``compress_messages`` on this thread,
+    or None if none ran. Read once per request, after compression."""
+    counts = getattr(_census_tls, "counts", None)
+    return dict(counts) if counts else None
+
 
 def _active_keep(text: str) -> bool:
     fn = getattr(_keep_tls, "fn", None)
@@ -236,11 +264,13 @@ def _compress_tool_result_text(
         if stripped is not None:
             h = _handle(text)
             if store._record(h, text):
+                _census("tool_result_html_stripped", text)
                 return f"{stripped}\n<< html chrome elided, handle={h} >>"
 
     lines = text.splitlines()
     if len(lines) < _MIN_LINES:
         # Too short to digest — lossless Tier-0 transforms only.
+        _census("tool_result_short", text)
         return _apply_tier0(text)
 
     # Verbatim + not recent (a subscription/lossless OLDER block): a self-describing
@@ -250,18 +280,26 @@ def _compress_tool_result_text(
     # byte-exact (no fold) so the agent's latest output is unchanged.
     if verbatim:
         folded = None if is_recent else _lossless_fold(text)
+        # Recency and mode are different diagnoses: one is a carve-out that shrinks as a
+        # conversation grows, the other is a session-wide setting the user chose.
+        _census("tool_result_recent" if is_recent else "tool_result_verbatim", text)
         return folded or _apply_tier0(text)
 
     if keep_byte_exact:
+        _census("tool_result_learned_keep", text)
         return _apply_tier0(text)
 
     digested, changed = _tier1_digest(text, intent=_active_intent())
     if changed:
         h = _handle(text)
         if store._record(h, text):
+            _census("tool_result_digested", text)
             return digested
         # 8-hex collision with a different block — a stub here would expand to the
         # wrong content, so keep this block byte-exact (lossless transforms only).
+    # Reached the digester and came back unchanged (or lost a handle collision) — the
+    # one bucket that indicts the compressor rather than a policy gate.
+    _census("tool_result_declined", text)
     return _apply_tier0(text)
 
 
@@ -374,10 +412,12 @@ def _compress_content_item(
     if btype == "text":
         if role == "assistant":
             # Never rewrite the assistant's own words.
+            _census("assistant_text", item.get("text") or "")
             return item
         text = item.get("text")
         if not isinstance(text, str):
             return item  # malformed/absent text — pass through untouched
+        _census("user_text", text)
         new_text = _compress_text_content(text, store, verbatim)
         if new_text == text:
             return item
@@ -444,13 +484,16 @@ def _compress_message(
 
     if isinstance(content, str):
         if role == "assistant":
+            _census("assistant_text", content)
             return msg
         # OpenAI tool-result messages ({"role":"tool","content":"…"}) get the same
         # decision-aware reversible digest as Anthropic tool_result blocks; other
         # string content gets Tier-0 lossless transforms.
         if role == "tool":
+            # Censused inside _compress_tool_result_text, by branch taken.
             new_text = _compress_tool_result_text(content, store, verbatim, is_recent)
         else:
+            _census("user_text", content)
             new_text = _compress_text_content(content, store, verbatim)
         if new_text == content:
             return msg
@@ -516,6 +559,10 @@ def compress_messages(
         original text; call ``store.expand(handle)`` to recover it.
     """
     _keep_tls.fn = keep  # learned keep-byte-exact policy for this call (per-thread)
+    # Opened per call, NOT drained in the finally block: the caller reads it after we
+    # return (see proxy._emit_detail). A re-compression on the same thread overwrites it,
+    # which is the wanted behaviour — the census should describe the payload actually sent.
+    _census_tls.counts = {}
     _intent_tls.terms = frozenset() if verbatim else extract_intent(messages)
     # Vision duplicate elision (ADR 0003) — None unless the content type has been
     # certified, so the default path is byte-for-byte what it was before.

--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -67,13 +67,26 @@ _keep_tls = _threading.local()
 _census_tls = _threading.local()
 
 
-def _census(bucket: str, text: str) -> None:
-    """Attribute *text*'s tokens to *bucket*. No-op unless a census is open, so the
-    cost is confined to callers that asked for one."""
+def _census_tokens(bucket: str, tokens: int) -> None:
+    """Attribute an already-counted *tokens* to *bucket*. No-op unless a census is open.
+
+    Separate from ``_census`` because images are not priced as text: providers bill them
+    by pixel area, and the exhaustiveness baseline (``proxy._count_messages``) counts them
+    with ``vision.estimate_tokens``. Counting an image's base64 as text here would put the
+    census and the baseline on different scales, and exhaustiveness could never hold.
+    """
     counts = getattr(_census_tls, "counts", None)
     if counts is None:
         return
-    counts[bucket] = counts.get(bucket, 0) + _tokenizer.count(text)
+    counts[bucket] = counts.get(bucket, 0) + int(tokens)
+
+
+def _census(bucket: str, text: str) -> None:
+    """Attribute *text*'s tokens to *bucket*. No-op unless a census is open, so the
+    cost is confined to callers that asked for one."""
+    if getattr(_census_tls, "counts", None) is None:
+        return
+    _census_tokens(bucket, _tokenizer.count(text))
 
 
 def take_census() -> dict[str, int] | None:
@@ -318,6 +331,12 @@ def _compress_image_block(
     input). Both cases still *note* the payload, so a later duplicate is still
     recognized as a repeat rather than mistaken for a first sighting.
     """
+    # Every image costs tokens whatever we decide to do with it, so it is censused up
+    # front and refined below. Screenshots are the largest single blocks an agent sends;
+    # leaving them unattributed would make the census silently fail to add up on exactly
+    # the traffic where the "why" question matters most (computer-use, browser tools).
+    _census_tokens("image_kept", _vision.block_tokens(item))
+
     dedup = _active_vision()
     if dedup is None:
         return item
@@ -341,6 +360,10 @@ def _compress_image_block(
         # wrong image. Keeping the block verbatim is always safe (same rule the
         # text digester follows).
         return item
+    # Reclassify: this one was actually elided, not kept. Moved rather than added, so the
+    # total still matches the payload.
+    _census_tokens("image_kept", -_vision.block_tokens(item))
+    _census_tokens("image_elided", _vision.block_tokens(item))
     return {"type": "text", "text": _vision.reference_text(handle, tokens)}
 
 

--- a/distil/adapters/openai.py
+++ b/distil/adapters/openai.py
@@ -59,6 +59,7 @@ from typing import Any
 from ..compress.intent import extract_intent, terms_of
 from ..compress.recency import RECENCY_KEEP_TURNS as _RECENCY_KEEP_TURNS
 from .anthropic import (
+    _census_tls,
     RestoreStore,
     _compress_text_content,
     _compress_tool_result_text,
@@ -218,6 +219,9 @@ def compress_chat_completions(
         original text; call ``store.expand(handle)`` to recover it.
     """
     _keep_tls.fn = keep
+    # Same contract as the Anthropic entry point: open a fresh census so a thread that
+    # previously served Anthropic traffic cannot leak its counts into this request.
+    _census_tls.counts = {}
     _intent_tls.terms = frozenset() if verbatim else extract_intent(messages)
     try:
         store = RestoreStore()
@@ -354,6 +358,7 @@ def compress_responses_input(
         ``store`` maps handles back to originals for RestoreStore round-trips.
     """
     _keep_tls.fn = keep
+    _census_tls.counts = {}
     _intent_tls.terms = frozenset() if verbatim else _extract_responses_intent(items)
     try:
         store = RestoreStore()

--- a/distil/adapters/openai.py
+++ b/distil/adapters/openai.py
@@ -59,6 +59,7 @@ from typing import Any
 from ..compress.intent import extract_intent, terms_of
 from ..compress.recency import RECENCY_KEEP_TURNS as _RECENCY_KEEP_TURNS
 from .anthropic import (
+    _census,
     _census_tls,
     RestoreStore,
     _compress_text_content,
@@ -128,12 +129,14 @@ def _compress_openai_message(
     if isinstance(content, str):
         if role == "assistant":
             # Never rewrite the model's own words.
+            _census("assistant_text", content)
             return msg
         if role == "tool":
             # Tool outputs: Tier-1 reversible digest.
             new_text = _compress_tool_result_text(content, store, verbatim, is_recent)
         else:
             # user / system — Tier-0 lossless transforms only.
+            _census("user_text", content)
             new_text = _compress_text_content(content, store, verbatim)
         if new_text == content:
             return msg
@@ -143,6 +146,9 @@ def _compress_openai_message(
     if isinstance(content, list):
         if role == "assistant":
             # Never touch assistant output (includes tool_calls).
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    _census("assistant_text", part["text"])
             return msg
         new_parts: list[Any] = []
         changed = False
@@ -156,6 +162,7 @@ def _compress_openai_message(
                     # tool result fragment → Tier-1, same as the string-content path.
                     new_text = _compress_tool_result_text(part["text"], store, verbatim, is_recent)
                 else:
+                    _census("user_text", part["text"])
                     new_text = _compress_text_content(part["text"], store, verbatim)
                 if new_text != part["text"]:
                     new_parts.append({**part, "text": new_text})
@@ -298,6 +305,9 @@ def _compress_response_item(
             return item
         if role == "assistant":
             # Never rewrite the model's own words.
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    _census("assistant_text", part["text"])
             return item
         # User (and any other non-assistant) message: compress text content parts.
         new_parts: list[Any] = []
@@ -308,6 +318,7 @@ def _compress_response_item(
                 continue
             # input_text → user content (Tier-0 lossless); output_text → model content (skip)
             if part.get("type") == "input_text" and isinstance(part.get("text"), str):
+                _census("user_text", part["text"])
                 new_text = _compress_text_content(part["text"], store, verbatim)
                 if new_text != part["text"]:
                     new_parts.append({**part, "text": new_text})

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -327,20 +327,58 @@ def cmd_leaderboard(args: argparse.Namespace) -> int:
                         "overhead; `distil doctor`\n    reports what the proxy is actually doing."
                     )
                 elif _recent_trim < 0.05:
-                    # "usually means lossless-only" with no number printed on every
-                    # run of a subscription machine that went 8,000+ runs at ~0.3%
-                    # without its owner ever learning what the safe default cost.
-                    # Generic advice is easy to read past; a rate the user earned on
-                    # their own traffic is not. Quote it whenever we have one.
-                    _digest = ledger.mode_rates().get("digest")
-                    if _digest and _digest[0] >= 50 and _digest[1] > _recent_trim + 0.05:
+                    # Which mode the recent window ACTUALLY ran decides the advice.
+                    # This branch used to infer it from the trim alone and tell any
+                    # low-yield session "you are in lossless-only", which is wrong
+                    # the moment digest itself is what yielded ~0: a user already
+                    # running `--expand` was told to go turn on `--expand`, and the
+                    # real cause (content mix) never got named. Read the mode.
+                    _win = time.time() - 7 * 86400
+                    _rates = ledger.mode_rates(since=_win)
+                    _recent_mode = max(
+                        _rates.items(), key=lambda kv: kv[1][0], default=("", (0, 0.0))
+                    )[0]
+                    # Prefer the in-window digest rate; fall back to lifetime only when
+                    # the window holds too few digest runs to be a rate at all. A user
+                    # who has sat in lossless-only for months has no recent digest data
+                    # by construction, and staying silent would drop the one number that
+                    # tells them what the safe default costs. But an old rate must be
+                    # LABELLED old — presenting stale history as the current rate is the
+                    # deception being fixed here, not the fallback itself.
+                    _digest_win = _rates.get("digest")
+                    _digest = _digest_win
+                    _stale = ""
+                    if not (_digest_win and _digest_win[0] >= 50):
+                        _digest = ledger.mode_rates().get("digest")
+                        _stale = " historically (not in the last 7 days — what digest is\n    worth depends on your content mix, and that drifts)"
+                    if _recent_mode == "digest":
+                        # Already digesting and still flat. Enabling digest is the
+                        # wrong advice here — it is on. The usual ceiling is the part
+                        # of a request that NO compressor may touch: the system prompt
+                        # and tool definitions, resent verbatim every request (measured
+                        # at 38% of everything sent on the session that prompted this,
+                        # 83k tokens/request of tool schemas alone). `dissect` computes
+                        # that split per session, so point at the number rather than
+                        # guessing a cause from the rate alone.
+                        print(
+                            f"  ↳ digest mode IS on and still returned "
+                            f"{_recent_trim * 100:.1f}%. No flag changes that.\n    "
+                            "The usual ceiling is fixed per-request overhead — the system "
+                            "prompt and\n    tool definitions are resent verbatim every "
+                            "request and cannot be compressed.\n    `distil dissect latest` "
+                            "reports your split and names the costliest tools."
+                        )
+                    elif _digest and _digest[0] >= 50 and _digest[1] > _recent_trim + 0.05:
+                        # Windowed to the same 7 days as the trim it is compared
+                        # against — a lifetime digest rate answers a different
+                        # question and overstated this by ~170x on a real ledger.
                         print(
                             f"  ↳ you are in lossless-only — the subscription-safe default. "
                             f"Digest mode has\n    returned {_digest[1] * 100:.1f}% on YOUR "
-                            f"traffic over {_digest[0]:,} runs. Enable it with\n    "
-                            "`distil default --mode expand` (injects distil_expand, so nothing "
-                            "is\n    irreversibly lost; it does modify requests, which the "
-                            "safe default does not)."
+                            f"traffic over {_digest[0]:,} runs{_stale}. Enable it "
+                            "with\n    `distil default --mode expand` (injects distil_expand, "
+                            "so nothing is\n    irreversibly lost; it does modify requests, "
+                            "which the safe default does not)."
                         )
                     else:
                         print(

--- a/distil/compress/vision.py
+++ b/distil/compress/vision.py
@@ -273,6 +273,25 @@ def estimate_tokens(raw: bytes | None) -> int:
 # ---------------------------------------------------------------------------
 
 
+def block_tokens(block: Any) -> int:
+    """Billed token cost of a vision content block, from its `source`.
+
+    The single definition of that rule. It is consumed by two callers that MUST agree —
+    the request baseline (`proxy._count_messages`) and the eligibility census
+    (`adapters.anthropic`) — and an exhaustiveness invariant compares their sums. Two
+    copies of this arithmetic would let the census silently fail to add up.
+    """
+    src = block.get("source") if isinstance(block, dict) else None
+    if not isinstance(src, dict):
+        return 0
+    data = src.get("data")
+    if not isinstance(data, str) or not data:
+        # A url source: real cost, unknown dimensions. estimate_tokens' own conservative
+        # floor is the honest answer — never zero, never flattering.
+        return estimate_tokens(None) if isinstance(src.get("url"), str) else 0
+    return estimate_tokens(_decode_b64(data))
+
+
 def _handle(payload: str) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()[:8]
 

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -265,6 +265,27 @@ class Dissection:
         return 100.0 * self.overhead_tokens_total / total if total else 0.0
 
     @property
+    def eligibility(self) -> list[tuple[str, int, float]]:
+        """Why the session compressed as much as it did: ``(reason, tokens, pct)``,
+        largest first, summed over every request's per-block census.
+
+        This is the answer to "is a low saving a defect or the design working?" — a
+        question the savings number itself cannot settle. ``tool_result_digested``
+        is work done; ``assistant_text`` and ``tool_result_recent`` are content the
+        policy deliberately protects; ``tool_result_declined`` is the only bucket
+        that indicts the compressor. Empty for sessions recorded before the census
+        existed, which is why callers must treat [] as "unknown", not as "nothing".
+        """
+        agg: dict[str, int] = {}
+        for r in self.requests:
+            for reason, tokens in (r.get("census") or {}).items():
+                agg[str(reason)] = agg.get(str(reason), 0) + int(tokens or 0)
+        total = sum(agg.values())
+        if not total:
+            return []
+        return sorted(((k, v, 100.0 * v / total) for k, v in agg.items()), key=lambda x: -x[1])
+
+    @property
     def churn_tokens(self) -> int:
         """Tokens re-folded after first sight — resent content the client keeps sending."""
         return sum(
@@ -692,6 +713,28 @@ def _flags_line(man: dict[str, Any]) -> str:
     return ", ".join(on) or "defaults"
 
 
+# Census reason -> what it means to a human reading a report. Kept beside the renderer
+# rather than in the adapter: the adapter names mechanisms, this names consequences.
+_ELIGIBILITY_LABEL = {
+    "assistant_text": "the model's own words (never rewritten)",
+    "user_text": "your prompts (lossless only)",
+    "tool_result_recent": "freshest tool output (kept byte-exact)",
+    "tool_result_digested": "digested",
+    "tool_result_html_stripped": "HTML chrome stripped",
+    "tool_result_short": "too short to digest",
+    "tool_result_verbatim": "verbatim mode",
+    "tool_result_learned_keep": "learned keep-byte-exact",
+    "tool_result_declined": "digester declined",
+}
+
+# Buckets that represent a deliberate protection rather than a missed opportunity.
+# Distinguished so a report can say "working as designed" without the reader having to
+# know which gate is which.
+_PROTECTED_REASONS = frozenset(
+    {"assistant_text", "tool_result_recent", "user_text", "tool_result_learned_keep"}
+)
+
+
 def render_text(
     d: Dissection,
     *,
@@ -793,6 +836,32 @@ def render_text(
                 + ", ".join(f"{name} {_human(per)}/req" for name, per, _t in tools[:5])
                 + (" …" if len(tools) > 5 else "")
             )
+        # Why the savings number is what it is. Printed next to the number itself so a
+        # low percentage is read as a diagnosis rather than a malfunction: content the
+        # policy protects looks identical to content the compressor failed on, unless
+        # the two are named separately.
+        elig = d.eligibility
+        if elig:
+            out.append(
+                "  why: "
+                + ", ".join(f"{_ELIGIBILITY_LABEL.get(r, r)} {p:.0f}%" for r, _t, p in elig[:5])
+            )
+            protected = sum(p for r, _t, p in elig if r in _PROTECTED_REASONS)
+            declined = sum(p for r, _t, p in elig if r == "tool_result_declined")
+            if declined >= 5.0:
+                out.append(
+                    c(
+                        "33",
+                        f"    {declined:.0f}% reached the digester and came back unchanged — "
+                        f"that share is the compressor's to explain, not policy's",
+                    )
+                )
+            elif protected >= 50.0:
+                out.append(
+                    f"    {protected:.0f}% is content distil deliberately protects (the model's "
+                    f"own words, and your freshest tool output) — low savings here is the "
+                    f"design holding, not a fault"
+                )
         growth = d.system_growth()
         if growth and growth[1] != growth[0]:
             out.append(
@@ -1005,6 +1074,11 @@ def to_json(
                 ],
             },
             "churn": {"tokens": d.churn_tokens, "blocks": d.churned_blocks},
+            # Why the number is what it is. [] means the session predates the census,
+            # which is NOT the same as "nothing was eligible" — do not render it as 0.
+            "eligibility": [
+                {"reason": r, "tokens": t, "share_pct": round(p, 1)} for r, t, p in d.eligibility
+            ],
             "usage": {
                 "input_tokens": d.usage_input_total,
                 "output_tokens": d.usage_output_total,

--- a/distil/ledger.py
+++ b/distil/ledger.py
@@ -289,14 +289,24 @@ def latest_row_ts(path: Path | None = None) -> float:
     return 0.0
 
 
-def mode_rates(path: Path | None = None) -> dict[str, tuple[int, float]]:
-    """``{mode: (runs, fraction_smaller)}`` over the whole ledger.
+def mode_rates(
+    path: Path | None = None, *, since: float | None = None
+) -> dict[str, tuple[int, float]]:
+    """``{mode: (runs, fraction_smaller)}`` over the ledger, optionally windowed.
 
     Lets a caller answer "what has the other mode actually been worth on THIS
     machine" with the user's own history rather than a generic claim. The
     subscription-safe default is deliberately conservative, and a machine can
     sit in it for thousands of runs without the user ever learning what it
     costs — a number they earned themselves is what makes that visible.
+
+    ``since`` (unix ts) restricts the window, and a caller comparing against a
+    recent trim MUST pass it. A lifetime mode rate answers a different question
+    than the one the reader is asking: this ledger carried digest at 51.7%
+    lifetime while digest's rate over the last 7 days was 0.3%, because what
+    digest is worth depends on the CONTENT MIX, and that drifts. Quoting the
+    lifetime number next to a recent trim told a user already running digest to
+    go enable digest.
 
     Whole-file pass: a report-time helper, not for the status line's hot path.
     """
@@ -317,6 +327,8 @@ def mode_rates(path: Path | None = None) -> dict[str, tuple[int, float]]:
         base = d.get("baseline_input_tokens") or 0
         got = d.get("distil_input_tokens") or 0
         if not mode or not base:
+            continue
+        if since is not None and (d.get("ts") or 0) < since:
             continue
         a = agg.setdefault(mode, [0.0, 0.0, 0.0])
         a[0] += base

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -346,6 +346,21 @@ def _count_messages(msgs: list[dict[str, Any]]) -> int:
     return total
 
 
+def _adapter_census() -> dict[str, int] | None:
+    """The eligibility census left by this thread's most recent compression pass.
+
+    Read here rather than threaded through the call sites because all three relays
+    (JSON, streaming, expand-splice) compress on the handler's own thread, and every
+    entry point opens a fresh census — so the value is this request's by construction.
+    """
+    try:
+        from .adapters.anthropic import take_census
+
+        return take_census()
+    except Exception:  # noqa: BLE001 — a diagnostic must never break a request
+        return None
+
+
 def _tokens_saved(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> int:
     """Rough estimate of tokens saved via the default heuristic tokeniser."""
     return max(0, _count_messages(before) - _count_messages(after))
@@ -1375,6 +1390,13 @@ def build_handler(
                     # Provider-reported quota state (counters/timestamps only). Billed
                     # tokens say what was sent; this says what it cost the plan's budget.
                     "ratelimit": getattr(self, "_distil_ratelimit", None),
+                    # Why this request compressed as much (or as little) as it did:
+                    # tokens bucketed by the gate that claimed each block. Without it,
+                    # a low saving is only explicable by inference from outside — and
+                    # inference cannot tell "mostly assistant prose" (working as designed)
+                    # from "the digester declined" (a defect) from "mostly recent"
+                    # (transient). Content-free; see adapters.anthropic.take_census.
+                    "census": _adapter_census(),
                     "shadow_sampled": extras.get("x-distil-shadow") == "sampled",
                     "expanded": extras.get("x-distil-expanded") == "1",
                     "output_shaping": extras.get("x-distil-output-shaping", ""),

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -720,14 +720,19 @@ def build_handler(
                 headers={**headers, "Content-Length": str(len(body))},
                 method="POST",
             )
+            # Module-cache hit: streamrelay is warmed at server setup (see above).
+            from .streamrelay import capture_ratelimit
+
             try:
                 with _OPENER.open(req, timeout=_UPSTREAM_TIMEOUT) as resp:
                     rbody = resp.read()
                     rhdrs = {k: v for k, v in resp.headers.items() if k.lower() not in _HOP_BY_HOP}
+                    self._distil_ratelimit = capture_ratelimit(resp.headers)
                     return resp.status, rhdrs, rbody
             except urllib.error.HTTPError as exc:
                 rbody = exc.read() if exc.fp else b'{"error":"upstream error"}'
                 rhdrs = {k: v for k, v in exc.headers.items() if k.lower() not in _HOP_BY_HOP}
+                self._distil_ratelimit = capture_ratelimit(exc.headers)
                 return exc.code, rhdrs, rbody
             except urllib.error.URLError as exc:
                 status = 504 if _is_timeout(exc) else 502
@@ -1367,6 +1372,9 @@ def build_handler(
                     "delta_refs": int(extras.get("x-distil-cache-refs", 0) or 0),
                     "delta_tokens_saved": int(extras.get("x-distil-cache-tokens-saved", 0) or 0),
                     "prefix_msgs": int(extras.get("x-distil-cache-prefix-msgs", 0) or 0),
+                    # Provider-reported quota state (counters/timestamps only). Billed
+                    # tokens say what was sent; this says what it cost the plan's budget.
+                    "ratelimit": getattr(self, "_distil_ratelimit", None),
                     "shadow_sampled": extras.get("x-distil-shadow") == "sampled",
                     "expanded": extras.get("x-distil-expanded") == "1",
                     "output_shaping": extras.get("x-distil-output-shaping", ""),

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -301,19 +301,11 @@ def _image_tokens(block: dict[str, Any]) -> int:
     duplicate scored as *negative* savings: zero on the before side, the
     replacement stub's tokens on the after side.
     """
-    from .compress.vision import estimate_tokens as _est
+    from .compress.vision import block_tokens
 
-    src = block.get("source")
-    if not isinstance(src, dict):
-        return 0
-    data = src.get("data")
-    if not isinstance(data, str) or not data:
-        # A url source: real cost, unknown dimensions. estimate_tokens' own
-        # conservative floor is the honest answer — never zero, never flattering.
-        return _est(None) if isinstance(src.get("url"), str) else 0
-    from .compress.vision import _decode_b64
-
-    return _est(_decode_b64(data))
+    # Shared with the eligibility census, which is compared against this baseline by an
+    # exhaustiveness test — so the rule lives in one place rather than two.
+    return block_tokens(block)
 
 
 def _count_messages(msgs: list[dict[str, Any]]) -> int:

--- a/distil/streamexpand.py
+++ b/distil/streamexpand.py
@@ -132,9 +132,15 @@ def stream_with_expand(
     The first upstream response's headers are relayed to the client; on a non-2xx or a
     non-SSE first response the body is relayed unchanged (no interception).
     """
+    from .streamrelay import capture_ratelimit
+
     first = send(body)
     status = getattr(first, "status", 200)
     hdrs = list(first.headers.items())
+    # Captured before the splice/verbatim branch so both outcomes record it. Uses the
+    # FIRST response deliberately: a request that resolves an expand re-queries upstream,
+    # and it is the original turn's quota state we want attributed to this request.
+    handler._distil_ratelimit = capture_ratelimit(first.headers)  # type: ignore[attr-defined]
     ctype = next((v for k, v in hdrs if k.lower() == "content-type"), "")
     if not (200 <= status < 300) or "text/event-stream" not in ctype.lower():
         # Not a stream we can splice — relay verbatim (chunked) and return.

--- a/distil/streamrelay.py
+++ b/distil/streamrelay.py
@@ -16,8 +16,34 @@ import re
 import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler
+from typing import Any
 
 _CHUNK = 8192
+
+# Provider-reported quota state, echoed on every response as `anthropic-ratelimit-*`.
+# Worth recording because it is the ONLY first-party signal for how a request is charged
+# against a plan's budget: billed token counts say what was sent, these say what it cost
+# the quota. On cache-heavy traffic the two diverge sharply — a cached read is ~90% off
+# the metered price, but whether a *subscription* cap discounts it the same way is not
+# published, and this is the measurement that settles it for a given account.
+_RATELIMIT_PREFIX = "anthropic-ratelimit-"
+
+
+def capture_ratelimit(headers: Any) -> dict[str, str] | None:
+    """Extract the ``anthropic-ratelimit-*`` response headers, keyed without the vendor
+    prefix (``requests-remaining``, ``input-tokens-limit``, ...). Returns None when the
+    upstream sent none, so the record stays absent rather than empty. Header values only
+    — counters and timestamps, never content."""
+    try:
+        out = {
+            k.lower()[len(_RATELIMIT_PREFIX) :]: v
+            for k, v in headers.items()
+            if k.lower().startswith(_RATELIMIT_PREFIX)
+        }
+    except Exception:  # noqa: BLE001 — a diagnostic must never break the relay
+        return None
+    return out or None
+
 
 # Billed-usage capture. Works on a plain JSON response and on SSE bytes alike:
 # input_tokens appears once near the start (message_start), output_tokens is
@@ -124,6 +150,9 @@ def stream_upstream(
         resp = _OPENER.open(req, timeout=timeout)  # noqa: S310 — operator-set upstream
     except urllib.error.HTTPError as exc:
         rbody = exc.read() if exc.fp else b'{"error":"upstream error"}'
+        # A 429 carries the most informative quota state of any response — capture it
+        # here too, or the one request that proves the cap is the one we fail to record.
+        handler._distil_ratelimit = capture_ratelimit(exc.headers)  # type: ignore[attr-defined]
         handler.send_response(exc.code)
         for k, v in exc.headers.items():
             if k.lower() not in hop_by_hop:
@@ -146,6 +175,9 @@ def stream_upstream(
         return 504, None
 
     with resp:
+        # Before relaying: the handler is per-request, so this reaches _emit_detail
+        # without threading a return value through every streaming call site.
+        handler._distil_ratelimit = capture_ratelimit(resp.headers)  # type: ignore[attr-defined]
         length = resp.headers.get("Content-Length")
         chunked = length is None
         handler.send_response(resp.status)

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.43.0rc4"
+appVersion: "1.44.0"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.43.0-rc.4",
+  "version": "1.44.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.43.0rc4",
+  "version": "1.44.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.43.0rc4"
+version = "1.44.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.43.0rc4",
+  "version": "1.44.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.43.0rc4",
+      "version": "1.44.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -461,3 +461,81 @@ def test_verbatim_never_emits_handles_across_all_turns() -> None:
     ]
     _out, store = compress_messages(msgs, verbatim=True)
     assert store.handles == frozenset()
+
+
+def _census_fixture() -> list[dict]:
+    """A transcript whose blocks are deliberately claimed by DIFFERENT gates: long
+    tool output (digestible, but the last turns are recency-exempt), assistant prose
+    (never rewritten), and user text (Tier-0 only)."""
+    asst = {"role": "assistant", "content": [{"type": "text", "text": "reasoning. " * 200}]}
+    msgs: list[dict] = []
+    for turn in range(6):
+        msgs.append({"role": "user", "content": "continue please"})
+        msgs.append(asst)
+        msgs.append(_tr(f"t{turn}", _log_body(f"t{turn}")))
+    return msgs
+
+
+def test_census_accounts_for_the_entire_payload() -> None:
+    """The census must be exhaustive, or it is worse than nothing.
+
+    A partial census reads as a complete explanation — the missing tokens are
+    invisible, so whatever bucket happens to be largest gets blamed. Every token in
+    the request must land in exactly one bucket.
+    """
+    from distil.adapters.anthropic import take_census
+    from distil.proxy import _count_messages
+
+    msgs = _census_fixture()
+    compress_messages(msgs, verbatim=False)
+    census = take_census()
+    assert census is not None
+
+    total = sum(census.values())
+    payload = _count_messages(msgs)
+    assert abs(total - payload) / payload < 0.005, f"census {total} vs payload {payload}"
+
+
+def test_census_names_the_gate_that_claimed_each_block() -> None:
+    """Distinguishing the gates is the entire point: "mostly assistant prose" is
+    working as designed, "the digester declined" is a defect, and "mostly recent" is
+    transient. A savings percentage alone cannot tell them apart."""
+    from distil.adapters.anthropic import take_census
+
+    compress_messages(_census_fixture(), verbatim=False)
+    census = take_census() or {}
+
+    # Assistant prose is never rewritten, so it must be attributed to policy...
+    assert census.get("assistant_text", 0) > 0
+    # ...the older tool turns are digested...
+    assert census.get("tool_result_digested", 0) > 0
+    # ...and the freshest ones are held back by the recency carve-out, not by failure.
+    assert census.get("tool_result_recent", 0) > 0
+    # Nothing reached the digester and came back empty-handed.
+    assert census.get("tool_result_declined", 0) == 0
+
+
+def test_census_is_reopened_per_call_and_never_accumulates() -> None:
+    """Two compressions on one thread must not sum. The proxy reads the census after
+    the pass, so a stale carry-over would attribute one request's content to another —
+    exactly the class of bug where a number from the wrong window is quoted as current."""
+    from distil.adapters.anthropic import take_census
+
+    compress_messages(_census_fixture(), verbatim=False)
+    first = sum((take_census() or {}).values())
+    compress_messages(_census_fixture(), verbatim=False)
+    second = sum((take_census() or {}).values())
+    assert first == second, f"census accumulated across calls: {first} -> {second}"
+
+
+def test_census_is_content_free() -> None:
+    """Keys are a fixed vocabulary of reasons and values are integers. This record is
+    written to disk on every request; anything else here would be a content leak."""
+    from distil.adapters.anthropic import take_census
+
+    compress_messages(_census_fixture(), verbatim=False)
+    census = take_census() or {}
+    assert census
+    for key, value in census.items():
+        assert isinstance(key, str) and key.replace("_", "").isalnum(), key
+        assert isinstance(value, int), (key, value)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -539,3 +539,15 @@ def test_census_is_content_free() -> None:
     for key, value in census.items():
         assert isinstance(key, str) and key.replace("_", "").isalnum(), key
         assert isinstance(value, int), (key, value)
+
+
+def test_census_is_a_no_op_when_none_is_open() -> None:
+    """The adapter's helpers are imported and called directly by the OpenAI adapter and
+    by tests, outside any ``compress_messages`` call. Counting there would both cost
+    tokenizer work nobody asked for and attribute blocks to whichever request happened
+    to run last on this thread."""
+    import distil.adapters.anthropic as A
+
+    A._census_tls.counts = None
+    A._census("assistant_text", "some text that must not be counted")
+    assert A.take_census() is None

--- a/tests/test_census_exhaustive.py
+++ b/tests/test_census_exhaustive.py
@@ -1,0 +1,122 @@
+"""Exhaustiveness of the eligibility census, across every adapter and block kind.
+
+The census exists to explain a savings number. A PARTIAL census is worse than none:
+the unattributed tokens are invisible, so whatever bucket happens to be largest silently
+inherits the blame. The original version of this invariant covered only the Anthropic
+text path, and review caught two holes it could not see — the OpenAI adapter's own
+assistant/user walking, and image blocks (which the baseline counts by pixel area).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from distil.adapters.anthropic import compress_messages, take_census
+from distil.adapters.openai import compress_chat_completions, compress_responses_input
+from distil.proxy import _count_messages
+
+_LOG = "\n".join(f"2026-08-11 INFO processed record {i} in {i % 7}ms" for i in range(60))
+_PROSE = " ".join(f"Reasoning sentence number {i}." for i in range(150))
+
+
+def _assert_exhaustive(census: dict[str, int] | None, payload: int, label: str) -> None:
+    assert census, f"{label}: no census recorded"
+    total = sum(census.values())
+    assert abs(total - payload) / max(payload, 1) < 0.005, (
+        f"{label}: census {total} != payload {payload} — "
+        f"{payload - total} tokens unattributed. buckets={census}"
+    )
+
+
+def test_anthropic_messages_are_fully_attributed() -> None:
+    msgs = []
+    for turn in range(5):
+        msgs.append({"role": "user", "content": "continue"})
+        msgs.append({"role": "assistant", "content": [{"type": "text", "text": _PROSE}]})
+        msgs.append(
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": f"t{turn}", "content": _LOG}],
+            }
+        )
+    compress_messages(msgs, verbatim=False)
+    _assert_exhaustive(take_census(), _count_messages(msgs), "anthropic")
+
+
+def test_openai_chat_completions_are_fully_attributed() -> None:
+    """The hole review found: this adapter opens a census and shares the tool_result
+    helper, but walks assistant/user text itself."""
+    msgs = []
+    for turn in range(5):
+        msgs.append({"role": "user", "content": "continue"})
+        msgs.append({"role": "assistant", "content": _PROSE})
+        msgs.append({"role": "tool", "tool_call_id": f"t{turn}", "content": _LOG})
+    compress_chat_completions(msgs, verbatim=False)
+    _assert_exhaustive(take_census(), _count_messages(msgs), "openai chat")
+
+
+def test_openai_list_content_parts_are_fully_attributed() -> None:
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": _PROSE}]},
+        {"role": "assistant", "content": [{"type": "text", "text": _PROSE}]},
+        {"role": "tool", "tool_call_id": "t", "content": [{"type": "text", "text": _LOG}]},
+    ]
+    compress_chat_completions(msgs, verbatim=False)
+    _assert_exhaustive(take_census(), _count_messages(msgs), "openai parts")
+
+
+def _png(width: int, height: int) -> str:
+    Image = pytest.importorskip("PIL.Image")
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (11, 22, 33)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_image_blocks_are_attributed_on_the_same_basis_as_the_baseline() -> None:
+    """Images are billed by pixel area, not base64 length. If the census counted them as
+    text the totals would be on different scales and exhaustiveness could never hold —
+    which is why `vision.block_tokens` is shared with `proxy._count_messages`."""
+    data = _png(320, 240)
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": "image/png", "data": data},
+                },
+                {"type": "text", "text": _PROSE},
+            ],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": _PROSE}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t", "content": _LOG}],
+        },
+    ]
+    compress_messages(msgs, verbatim=False)
+    census = take_census()
+    _assert_exhaustive(census, _count_messages(msgs), "images")
+    assert (census or {}).get("image_kept", 0) > 0, "image tokens landed in no image bucket"
+
+
+def test_openai_responses_api_input_is_fully_attributed() -> None:
+    """The Responses API is a separate entry point with its own walking — and its own
+    census to open. A hole here would be invisible to the Chat Completions tests."""
+    items = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": _PROSE}]},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": _PROSE}],
+        },
+        {"type": "function_call_output", "call_id": "c1", "output": _LOG},
+    ]
+    compress_responses_input(items, verbatim=False)
+    census = take_census()
+    assert census, "responses API recorded no census"
+    assert census.get("assistant_text", 0) > 0, "assistant output_text was not attributed"
+    assert census.get("user_text", 0) > 0, "user input_text was not attributed"

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -1105,3 +1105,86 @@ class TestTolerantReader:
 
     def test_read_jsonl_missing_file(self, tmp_path: Path) -> None:
         assert dz._read_jsonl(tmp_path / "absent.jsonl") == []
+
+
+class TestEligibility:
+    """The census surface: why a savings number is what it is."""
+
+    @staticmethod
+    def _session(home: Path, censuses: list[dict[str, int]]) -> str:
+        sess = home / "sessions"
+        sess.mkdir(exist_ok=True)
+        (sess / "s-elig.requests.jsonl").write_text(
+            "\n".join(
+                json.dumps(
+                    {
+                        "ts": 1000.0 + i,
+                        "model": "m",
+                        "stream": True,
+                        "status": 200,
+                        "booked": True,
+                        "mode": "digest",
+                        "compressible_tokens": sum(c.values()),
+                        "tokens_saved": 100,
+                        "system_tokens": 10,
+                        "tools_tokens": 50,
+                        "census": c,
+                    }
+                )
+                for i, c in enumerate(censuses)
+            )
+            + "\n"
+        )
+        return "s-elig"
+
+    def test_sums_across_requests_and_ranks_by_size(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        sid = self._session(
+            tmp_path,
+            [{"assistant_text": 100, "tool_result_digested": 50}, {"assistant_text": 200}],
+        )
+        elig = dz.dissect(sid).eligibility
+        assert [r for r, _t, _p in elig] == ["assistant_text", "tool_result_digested"]
+        assert elig[0][1] == 300
+        assert abs(sum(p for _r, _t, p in elig) - 100.0) < 0.01
+
+    def test_absent_census_reads_as_unknown_not_as_zero(self, tmp_path, monkeypatch) -> None:
+        """Sessions recorded before the census must not render as "nothing was
+        eligible" — that is a different, and wrong, claim."""
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        sid = self._session(tmp_path, [{}, {}])
+        d = dz.dissect(sid)
+        assert d.eligibility == []
+        assert "why:" not in dz.render_text(d, color=False)
+
+    def test_a_declined_share_is_reported_even_when_most_content_is_protected(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The bucket that indicts the compressor must not be masked by the one that
+        exonerates it. Protected content here is 63% — a naive "mostly protected, all
+        is well" summary would hide a 25% refusal rate behind it."""
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        sid = self._session(
+            tmp_path,
+            [
+                {
+                    "assistant_text": 54_000,
+                    "tool_result_recent": 9_000,
+                    "tool_result_declined": 25_000,
+                    "tool_result_digested": 12_000,
+                }
+            ],
+        )
+        text = dz.render_text(dz.dissect(sid), color=False)
+        assert "digester declined" in text
+        assert "compressor's to explain" in text
+        assert "the design holding" not in text
+
+    def test_protected_majority_is_explained_as_working_not_broken(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        sid = self._session(tmp_path, [{"assistant_text": 80_000, "tool_result_digested": 20_000}])
+        text = dz.render_text(dz.dissect(sid), color=False)
+        assert "the design holding" in text
+        assert "compressor's to explain" not in text

--- a/tests/test_ledger_resilience.py
+++ b/tests/test_ledger_resilience.py
@@ -138,3 +138,38 @@ def test_mode_rates_aggregates_per_mode_and_survives_a_bad_ledger(tmp_path):
     assert round(rates["lossless-only"][1], 3) == 0.003
     assert "" not in rates, "a row with no mode belongs to no mode"
     assert ledger.mode_rates(path=tmp_path / "absent.jsonl") == {}
+
+
+def test_mode_rates_window_excludes_stale_history(tmp_path):
+    """`since` is what keeps the quoted rate honest. This ledger carried digest at
+    51.7% lifetime while digest over the last 7 days was 6.2% — the mix that digest
+    is worth on drifts, so a lifetime rate printed next to a recent trim overstated
+    the user's actual rate by ~8x and told a user to enable what they already ran."""
+    import json
+    import time
+
+    now = time.time()
+
+    def row(mode, base, dist, ts):
+        return json.dumps(
+            {
+                "mode": mode,
+                "baseline_input_tokens": base,
+                "distil_input_tokens": dist,
+                "ts": ts,
+            }
+        )
+
+    p = tmp_path / "savings.jsonl"
+    p.write_text(
+        row("digest", 1000, 100, now - 60 * 86400)  # ancient: 90% saved
+        + "\n"
+        + row("digest", 1000, 940, now - 3600)  # recent: 6% saved
+        + "\n"
+        + row("digest", 1000, 500, 0)  # no usable ts → excluded by any window
+        + "\n"
+    )
+    assert round(ledger.mode_rates(path=p)["digest"][1], 2) == 0.49, "lifetime spans all"
+    windowed = ledger.mode_rates(path=p, since=now - 7 * 86400)
+    assert windowed["digest"][0] == 1, "only the in-window row counts"
+    assert round(windowed["digest"][1], 2) == 0.06, "the recent rate, not the flattering one"

--- a/tests/test_proxy_integration.py
+++ b/tests/test_proxy_integration.py
@@ -35,6 +35,10 @@ class _Echo(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("content-type", "application/json")
         self.send_header("content-length", str(len(_RESP)))
+        # Real Anthropic responses carry these; the proxy records them so quota cost
+        # can be compared against billed tokens (they diverge on cached traffic).
+        self.send_header("anthropic-ratelimit-requests-remaining", "49")
+        self.send_header("Anthropic-RateLimit-Input-Tokens-Remaining", "1900000")
         self.end_headers()
         self.wfile.write(_RESP)
 
@@ -180,6 +184,45 @@ def test_session_delta_round_trip(proxy_factory):
     _post(port, payload)  # establishes the session
     out = _post(port, payload)  # deltas against prior turn
     assert b"done" in out
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_ratelimit_headers_land_in_the_session_record(stream, proxy_factory, monkeypatch, tmp_path):
+    """The provider's quota headers must survive into the per-request record.
+
+    Billed token counts say what was SENT; these say what it cost the plan's budget.
+    On cache-heavy traffic the two diverge (a cache read is ~90% off the metered
+    price), so without this field there is no way to tell from local data whether a
+    subscription cap discounts cached reads the same way metered billing does.
+
+    Parametrised over both relays deliberately: streaming and non-streaming read the
+    upstream response in different places, and real agent traffic is ~entirely
+    streaming — covering only the JSON path would test the branch nobody uses.
+    """
+    monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+    monkeypatch.setenv("DISTIL_SESSION", f"s-ratelimit-{int(stream)}")
+
+    from distil import ledger
+
+    path = ledger.session_requests_path()
+    assert path is not None, "session env did not activate the per-request ledger"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = _digestible()
+    payload["stream"] = stream
+    _post(proxy_factory(), payload)
+
+    # The streaming relay finishes its record after the client's last read returns.
+    for _ in range(50):
+        if path.exists():
+            break
+        time.sleep(0.05)
+    records = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert records, "no per-request record was written"
+    assert records[-1]["ratelimit"] == {
+        "requests-remaining": "49",
+        "input-tokens-remaining": "1900000",
+    }
 
 
 def test_stalled_client_cannot_pin_a_handler_thread(proxy_factory, monkeypatch):

--- a/tests/test_streamrelay_ratelimit.py
+++ b/tests/test_streamrelay_ratelimit.py
@@ -1,0 +1,44 @@
+"""`capture_ratelimit` — the provider quota headers the proxy records per request."""
+
+from __future__ import annotations
+
+from email.message import Message
+
+from distil.streamrelay import capture_ratelimit
+
+
+def _headers(pairs: dict[str, str]) -> Message:
+    msg = Message()
+    for key, value in pairs.items():
+        msg[key] = value
+    return msg
+
+
+def test_extracts_ratelimit_headers_case_insensitively_and_strips_the_vendor_prefix() -> None:
+    got = capture_ratelimit(
+        _headers(
+            {
+                "Anthropic-RateLimit-Requests-Limit": "50",
+                "anthropic-ratelimit-input-tokens-remaining": "1900000",
+                "Content-Type": "text/event-stream",
+            }
+        )
+    )
+    assert got == {"requests-limit": "50", "input-tokens-remaining": "1900000"}
+
+
+def test_absent_headers_record_nothing_rather_than_an_empty_dict() -> None:
+    """`{}` and "the provider sent none" would look identical on disk, and only one of
+    them means the capture is working."""
+    assert capture_ratelimit(_headers({"Content-Type": "application/json"})) is None
+
+
+def test_a_hostile_headers_object_cannot_break_the_relay() -> None:
+    """This runs on every response, including error paths. A diagnostic that can raise
+    here would turn a recoverable upstream error into a failed request."""
+
+    class Exploding:
+        def items(self):
+            raise RuntimeError("headers unavailable")
+
+    assert capture_ratelimit(Exploding()) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.43.0rc4"
+version = "1.44.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why

`distil stats` could tell you *how much* it saved and not *why*. A reading of 0.4% has four
completely different causes — content the policy protects, a recency carve-out, fragments below
the digest threshold, or a digester that was handed real work and refused it. Three are the
design holding; one is a defect. The saved-token count is identical in all four.

That gap is not academic. Diagnosing it from the outside produced two confident wrong answers in
a row before the measurement existed: a savings drop attributed to MCP connectors on timing
correlation alone, and a suppression theory built on a cache-architecture docstring that the
project's own `cache_aware.simulate` then falsified (caching *raises* modelled savings,
58.70% vs 52.94%). Both were plausible. Neither was measured.

## What

**Per-block eligibility census** (`distil/adapters/anthropic.py`) — every block is attributed to
the gate that actually claimed it, counted *at the decision points* rather than by a second pass
that re-derives the rules. A parallel implementation is free to drift from the compressor it
describes. The first draft of this predicted the branch order and got it wrong: HTML extraction
runs *before* the minimum-lines gate, so every browser fetch would have been filed as "too short
to digest".

**Surfaced by `dissect`** — printed next to the number that prompts the question:

    why: the model's own words (never rewritten) 54%, digester declined 25%,
         digested 12%, freshest tool output (kept byte-exact) 9%
      25% reached the digester and came back unchanged — that share is the
      compressor's to explain, not policy's

A declined share ≥5% wins over a protected majority deliberately: a session can be 63%
policy-protected *and* refusing a quarter of what it was handed, and "mostly protected, all is
well" would file a real defect under an exoneration. Both branches pinned by test.

**Provider quota headers** (`anthropic-ratelimit-*`) — billed tokens say what was sent; these say
what it cost the plan. The two diverge on cached traffic and subscription accounting is
unpublished, so this is the only local way to settle it. Captured at all three upstream reads,
including the 429 that carries the most informative quota state of any response. The
parametrised test is what caught that `--expand` (production's path) was initially uninstrumented
— a JSON-only test would have shipped a no-op.

**`stats` window fix** — the digest rate beside the trim was computed over all history while the
trim covered the recent window, describing a mode enabled today with months of traffic under a
different one.

## Verification

- Full suite on the exact CI config (Python 3.12): **3341 passed, 2 skipped, coverage 95.08%** vs the 95% floor
- `ruff` 0.15.10 check + format clean
- `tests/test_packaging_smoke.py` green — all seven version surfaces agree
- Wheel builds, installs into a clean venv, reports 1.44.0, carries both new surfaces

An earlier local run read 91.59%; that was Python 3.9 (uv's default here) against CI's pinned
3.12, so version-gated paths never executed. Worth knowing before anyone else trusts a local
coverage number in this repo.

## Not included, deliberately

Nothing here makes distil compress more, and the benchmark corpus is unchanged. Real composition
is now measurable; building a "realistic" corpus trajectory before that data exists would bake in
the assumption this PR was written to stop relying on.

## Release

GA, so CITATION.cff (1.42.1 → 1.44.0) and `packaging/npm/package.json` move too — the two surfaces
the rc rule exempts and which have each drifted unnoticed before.