### PR TITLE
fix(savings): measure the percentage over all traffic, and count cached input

### DIFF
--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -299,7 +299,16 @@ class Dissection:
 
     @property
     def usage_input_total(self) -> int:
-        return sum(int(r.get("usage_input_tokens") or 0) for r in self.requests)
+        """Full billed input: uncached + the cached prefix (cache_read/creation).
+
+        ``usage.input_tokens`` alone omits everything served from cache, which on an
+        agent session is most of the input — reporting it as "billed in" made output
+        look like ~95% of billed traffic when it is well under 1%.
+        """
+        return sum(
+            int(r.get("usage_input_tokens") or 0) + int(r.get("usage_cache_tokens") or 0)
+            for r in self.requests
+        )
 
     @property
     def usage_output_total(self) -> int:
@@ -1237,7 +1246,8 @@ def _svg_stack_timeline(requests: list[dict[str, Any]]) -> str:
         ]
         billed = r.get("usage_input_tokens")
         if billed is not None:
-            tip_rows.append(("", "billed input", f"{int(billed):,}"))
+            billed = int(billed) + int(r.get("usage_cache_tokens") or 0)
+            tip_rows.append(("", "billed input", f"{billed:,}"))
         if r.get("duration_ms") is not None:
             tip_rows.append(("", "duration", f"{int(r['duration_ms']) / 1000:.1f}s"))
         y = 8 + plot_h

--- a/distil/runtime.py
+++ b/distil/runtime.py
@@ -128,8 +128,11 @@ class RuntimeSavings:
             for mid, (n, before, after) in self.by_model.items():
                 if before == 0:
                     continue  # nothing measured — a zero-baseline record is noise
-                if before <= after:
-                    continue  # nothing saved (e.g. a verbatim/lossless-only window) — a 0-row is noise
+                # A window that saved nothing IS recorded. Dropping it kept its
+                # baseline out of the denominator too, so the reported percentage
+                # was savings over the traffic that happened to compress rather
+                # than over all traffic — 7.9% on a session whose honest rate was
+                # 1.9%. A 0-saving row costs a line and buys an honest number.
                 price = pricing.resolve(mid)
                 per_tok = price.input if price is not None else 0.0
                 ledger.record(

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -832,6 +832,27 @@ class TestAnomalies:
         warnings = dz.dissect("s900-1").anomalies()
         assert any("off by >50% vs billed" in w for w in warnings)
 
+    def test_cached_prefix_counts_as_billed_input(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """input_tokens alone omits the cached prefix, which inflates the output share."""
+        monkeypatch.setenv("DISTIL_HOME", str(tmp_path))
+        self._session(
+            tmp_path,
+            [
+                self._req(
+                    usage_input_tokens=20,
+                    usage_cache_tokens=9980,
+                    usage_output_tokens=100,
+                )
+            ],
+        )
+        d = dz.dissect("s900-1")
+        assert d.usage_input_total == 10_000
+        assert d.calibration() == (60, 10_000)
+        # 100/10100, not the 83% you get from counting uncached input only.
+        assert any("(1% of billed traffic)" in h for h, _ in d.headlines())
+
 
 class TestHeadlines:
     @pytest.fixture(autouse=True)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -148,15 +148,20 @@ def test_render_html_uses_real_ledger_numbers(tmp_path):
     assert "live-proxy" in html  # the real source label, not dummy data
 
 
-def test_zero_savings_window_writes_no_ledger_row(tmp_path):
-    """A verbatim/lossless-only window (before == after) must not add 0-rows."""
+def test_zero_savings_window_stays_in_the_denominator(tmp_path):
+    """A window that saved nothing is still traffic, so it must reach the ledger.
+
+    Dropping it kept its baseline out of the denominator as well, which reported
+    savings over the traffic that compressed instead of over all traffic.
+    """
     led = tmp_path / "savings.jsonl"
     rs = RuntimeSavings(model="claude-opus-4-8", ledger_path=led)
     rs.record(1000, 1000)
     rs.record(500, 500)
-    rs.flush()
-    assert not led.exists() or led.read_text() == ""
-    # A window that DID save still writes.
+    assert rs.flush() is True
     rs.record(1000, 600)
     assert rs.flush() is True
-    assert ledger.summary(led).total_tokens_saved == 400
+    s = ledger.summary(led)
+    assert s.total_tokens_saved == 400
+    # 400 saved out of 2500 sent — not 400 out of the 1000 that happened to fold.
+    assert s.total_baseline_tokens == 2500


### PR DESCRIPTION
Two reporting defects, both in numbers users quote publicly. Found while reading a `distil dissect latest` on a real 590-request session.

## 1. The savings percentage was computed over the wrong denominator

`RuntimeSavings.flush()` batches ~10 requests per window and dropped any window where nothing was saved. That removed the window's **baseline** from the denominator as well — so the reported rate was savings over the traffic that happened to compress, not over all traffic.

On the session that surfaced this:

| | ledger (what dissect printed) | actual, all 590 booked requests |
|---|---|---|
| baseline | 11.77M | 61.06M |
| saved | 932k | 1.13M |
| **rate** | **7.9%** | **1.9%** |

466 of 590 requests saved nothing; their 53.7M tokens were excluded from both sides of the ratio.

A window with `before > 0` is now recorded even when it saved nothing. Savings and dollar totals are unchanged — only the denominator grows, so reported percentages drop to the truth.

This also closes a self-contradiction in the report: the headline saving (932k, from the ledger) disagreed with the mechanism decomposition (1.13M, from the request detail). The two sources converge exactly once no window is dropped.

## 2. Cached input was not counted as billed input

`Dissection.usage_input_total` summed `usage.input_tokens` alone, which omits everything served from cache — on an agent session that is nearly all of the input. Consequences in the same report:

- "The model wrote 308.95k output tokens (**95%** of billed traffic)" — real share 0.2%.
- "billed usage: **16.58k in**" one clause before "billed **155.19M**" in the same sentence.

`calibration()` already had the correct rule (`input_tokens + cache_tokens`) with a comment explaining exactly why; the property did not. Fixed at the property so the headline, the request-detail line, the JSON export, the HTML summary, and the per-request tooltip all agree.

## Tests

- `tests/test_dissect.py::test_cached_prefix_counts_as_billed_input` — new; verified failing without the fix (`assert 20 == 10000`).
- `tests/test_runtime.py::test_zero_savings_window_stays_in_the_denominator` — rewritten. It previously asserted the drop as intended behavior (`test_zero_savings_window_writes_no_ledger_row`); that intent is what the bug was.

## Verification

- Full suite: 3347 passed, 2 skipped.
- CI coverage gate as CI runs it (`--cov-fail-under=95`, py3.12): **95.09%**, exit 0.
- `ruff@0.15.10 check` + `format --check`: clean.

## Note for release

This makes existing users' reported percentage **drop**. It should read as "the number was wrong and is now right," not as a regression. Worth checking whether the site rollup displays a rate anywhere before release — the census accrues savings *deltas*, which are unchanged, but baseline totals grow.