### PR TITLE
fix(dissect): calibrate the token estimate before crying "off by 50%"

### DIFF
--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -319,25 +319,36 @@ class Dissection:
         return sum(1 for r in self.requests if r.get("usage_input_tokens") is not None)
 
     def calibration(self) -> tuple[int, int] | None:
-        """(heuristic_estimate, billed) input tokens over requests that carry usage.
+        """(calibrated_estimate, billed) input tokens over requests that carry usage.
 
-        Estimate = overhead + compressible-after-savings; billed = the API's own
+        Estimate = (overhead + compressible-after-savings) x the per-model factor
+        distil has already learned from billed usage; billed = the API's own
         usage.input_tokens. This is what turns "we think we saved X" into a
-        measured claim (and shows how honest the heuristic tokenizer is).
+        measured claim (and shows how honest the calibrated count is).
         """
-        est = billed = 0
+        from .calibration import factor as _factor
+
+        est_f = billed = 0.0
+        _fac: dict[str, float] = {}
         for r in self.requests:
             u = r.get("usage_input_tokens")
             if u is None:
                 continue
-            est += int(r.get("overhead_tokens") or 0) + max(
+            raw = int(r.get("overhead_tokens") or 0) + max(
                 0, int(r.get("compressible_tokens") or 0) - int(r.get("tokens_saved") or 0)
             )
+            # The heuristic tokenizer is systematically off per model (opus ~2.3x on this
+            # ledger), and distil already learns that ratio from billed usage. Report the
+            # calibrated estimate — otherwise every calibrated session cries "off by >50%".
+            m = str(r.get("model") or "")
+            if m not in _fac:
+                _fac[m] = _factor(m)[0]
+            est_f += raw * _fac[m]
             # Full billed input = uncached + cached prefix. input_tokens alone omits the cached
             # portion (billed under cache_read/creation), which would make est >> billed and the
             # calibration meaningless on prompt-cached traffic.
             billed += int(u) + int(r.get("usage_cache_tokens") or 0)
-        return (est, billed) if billed else None
+        return (round(est_f), round(billed)) if billed else None
 
     @property
     def headroom_multiplier(self) -> float:
@@ -438,7 +449,7 @@ class Dissection:
             est, billed = cal
             if est and (est / billed > 1.5 or est / billed < 0.67):
                 out.append(
-                    f"heuristic token estimate is off by >50% vs billed usage "
+                    f"token estimate is off by >50% vs billed usage "
                     f"({est:,} est vs {billed:,} billed) — treat % figures as rough"
                 )
         return out
@@ -888,7 +899,7 @@ def render_text(
             out.append(
                 f"  billed usage (from API responses): {_human(d.usage_input_total)} in / "
                 f"{_human(d.usage_output_total)} out over {d.usage_requests} requests; "
-                f"heuristic estimate {_human(est)} vs billed {_human(billed)} "
+                f"estimate {_human(est)} vs billed {_human(billed)} "
                 f"(x{est / billed:.2f})"
                 if billed
                 else ""

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -598,7 +598,20 @@ class TestInsights:
         assert d.usage_requests == 2
         est, billed = d.calibration()
         # r1: 700 + (5000-3500) = 2200; r2: 500 + (2000-1200) = 1300
+        # no learned factor yet -> identity, so the raw heuristic is reported as-is
         assert est == 3500 and billed == 3300
+
+    def test_calibration_applies_learned_factor(self) -> None:
+        """A model whose heuristic is known to run 2x low must not be reported as
+        '2x off' — distil already learned the factor, so it belongs in the estimate."""
+        from distil import calibration
+
+        for _ in range(calibration.MIN_SAMPLES):
+            calibration.record("m-big", 1000, 2000)
+        est, billed = dz.dissect("s200-1").calibration()
+        assert billed == 3300
+        # 2200 x2.0 (m-big, learned) + 1300 x2.0 (m-small falls back to the pooled ratios)
+        assert est == 7000
 
     def test_headroom_multiplier(self) -> None:
         d = dz.dissect("s200-1")
@@ -626,7 +639,7 @@ class TestInsights:
         assert "digest folds 3.90k (83%)" in text
         assert "20% of everything sent" in text
         assert "2.00k tokens re-digested" in text
-        assert "heuristic estimate 3.50k vs billed 3.30k" in text
+        assert "estimate 3.50k vs billed 3.30k" in text
         assert "~2.6x" in text  # flat-rate headroom
         assert "buffered (forced by expand) 1 req @ 9.0s" in text
         assert "regret: log:l blocks pulled back 1/1" in text


### PR DESCRIPTION
## What

`distil dissect` compared the **raw** heuristic token count against billed usage and warned whenever the two diverged by more than 50%:

```
⚠ heuristic token estimate is off by >50% vs billed usage
  (8,803,160 est vs 18,715,230 billed) — treat % figures as rough
```

On opus that fires every time. The heuristic runs ~2.3x low there — and distil already knows it. The calibration store has learned that exact factor from billed usage, and every other surface (`stats`, the web dashboard) applies it.

So the one command whose job is explaining the numbers was the one command reporting them uncalibrated, telling the user to distrust percentages that were fine.

## The fix

`SessionDetail.calibration()` now multiplies the raw estimate by the per-model factor already in the store.

Unlearned models still report identity — `calibration.factor()` is identity until `MIN_SAMPLES` — so the tripwire keeps firing on *real* drift, which is the only thing it was ever meant to catch.

Also drops "heuristic" from the two rendered labels, since the number no longer is one.

## Verification

On a live 304-request session, the same command before and after:

```
before:  heuristic estimate 8.80M vs billed 18.72M (x0.47)   ⚠ warning shown
after:   estimate 76.35M vs billed 71.57M (x1.07)            no warning
```

- Full CI gate on py3.12: **3352 passed, 2 skipped**, coverage **95.09%** (floor 95%)
- `ruff@0.15.10` check + format: clean
- New test `test_calibration_applies_learned_factor` asserts the factor is applied; the identity-until-`MIN_SAMPLES` path was already covered by the existing test