### PR TITLE
release(1.45.1): the explainer command was the one reporting uncalibrated numbers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.45.0
+version: 1.45.1
 date-released: 2026-08-09
 keywords:
   - llm

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.45.0"
+appVersion: "1.45.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.45.0"
+version = "1.45.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.45.0",
+  "version": "1.45.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.45.0",
+      "version": "1.45.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.45.0"
+version = "1.45.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Release PR for **1.45.1**. Ships the dissect calibration fix merged in #125.

## What's in it

`distil dissect` compared the **raw** heuristic token count against billed usage and warned whenever they diverged by more than 50%. On opus that fired every time — the heuristic runs ~2.3x low there, and distil already knows it: the calibration store learned that exact factor from billed usage, and `stats` and the web dashboard both apply it.

The one command whose job is explaining the numbers was the one reporting them uncalibrated, telling users to distrust percentages that were fine.

On a live 304-request session: `x0.47` → `x1.07`, warning gone. Unlearned models still report identity, so the tripwire keeps catching real drift.

## Version bump — all 7 locations

- `pyproject.toml`
- `CITATION.cff`
- `server.json` (x2)
- `packaging/npm/package.json`
- `plugins/distil/.claude-plugin/plugin.json`
- `packaging/helm/distil-gateway/Chart.yaml` (`appVersion`)

Plus `uv.lock`. Verified no stale `1.45.0` remains outside the Homebrew tap, which lags by design.

## Verification

- `tests/test_packaging_smoke.py`: **16 passed** — the gate that caught the 1.35.0 miss
- Full CI gate on py3.12: **3352 passed, 2 skipped**, coverage **95.09%** (floor 95%)