### PR TITLE
release(1.46.0): every managed install was running blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,82 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.46.0] — every managed install was running blind
+
+**If you installed distil the managed way, your proxy has never sampled a single
+decision-equivalence check.** `distil wrap` defaults `--shadow 0.02` and
+`--retention 0.05`; `distil proxy` defaulted both to `0.0`. The `com.distil.proxy`
+launch agent runs **proxy**. So the two quality loops that make distil's central
+claim checkable — shadow's live decision-change rate and the fact-retention meter —
+were off on every managed install since the daemon shipped. A 93-minute, 767-request
+session sampled 0. The same work under `wrap` would have sampled ~15.
+
+Both defaults now match `wrap`, so existing installs are fixed by upgrading; no
+reinstall. `--shadow 0` / `--retention 0` still opt out. Retention costs nothing
+either way (in-process scan, counts only); shadow spends ~2% extra tokens on sampled
+requests, which is the price of having evidence at all.
+
+### `distil dissect` reported three different denominators for the same session
+
+Reading one report end to end, four numbers disagreed:
+
+- The request-detail lines summed **all** requests while the savings headline counts
+  **booked** (2xx, non-retry) ones. 153 unbooked retries contributed 9.85M overhead
+  tokens and 3.75M of "savings" that were never billed.
+- `overhead_share` divided by the **pre**-compression payload — measuring the fixed
+  tax against tokens distil had already removed. It read 28% where the session's own
+  numbers implied 42%.
+
+Both now use the booked population and the post-compression denominator. "Savings by
+mechanism" reconciles with the headline it decomposes: a 3.75M discrepancy became
+72k (0.34%), which is heuristic-vs-ledger tokenizer rounding. Same defect shape as
+1.44.0's, which fixed it in `savings` and did not carry dissect along.
+
+### "Everything summarized stays recoverable" was false while it printed
+
+The restore store has a 500-blob LRU cap, not just a TTL. A single session folded 704
+blocks and evicted 204 of them **mid-session** — including its most re-used fold, one
+referenced by 272 requests — while the report promised full recoverability. It now
+reports the measured count. The cap is configurable (`DISTIL_RESTORE_CAP`, default
+raised 500 → 5000). A cap of 0 now means "no count cap" instead of evicting
+everything, which is what `[:-0]` did.
+
+### A flat 0.0% per-model row is now explained, not left looking broken
+
+One model showed exactly 0.0% across 152 requests. That is policy, not a failure: the
+traffic was 100% user-role string content with no tools — subagent calls — which
+routes to Tier-0 lossless by design. The row now says so.
+
+### Papers and published claims, audited against the code
+
+- Both papers compile with **zero undefined references**. Fixed a missing
+  `\bibitem`, a dangling cross-reference, and a figure quoting a number no artifact
+  produces.
+- The headline macro fallback silently rendered a **different operating point** as
+  the headline (0.1% certified savings) when the generated macros were absent. It now
+  warns at build time.
+- `docs/paper/generated/headtohead_orig.tex` was untracked, so the built PDF rendered
+  numbers absent from version control.
+- The paper described cache-monotonicity as holding by construction. That property was
+  **false in shipped code** until 1.45.0 fixed it. The passage now describes the
+  breakpoint anchoring that actually ships, and reports the measured failure.
+- The NeurIPS variant was missing the live-validation negative result — the section
+  where a real grader failed the live margin twice, reproducibly. Ported.
+- The security whitepaper said OIDC and role-based access control were "not
+  implemented"; `distil/authz.py` implements both. Corrected to the honest gap
+  (SAML, SCIM).
+- Docs said the proxy needs Python 3.11+; the floor is 3.9.
+- The site advertised 25.3% aggregate corpus savings over "8 domains" (listing 7).
+  `distil bench` reports **48.4% over 9 domains**. We were underselling by ~22pp
+  against our own free, offline gate.
+
+## [1.45.1] — the explainer command was the one reporting uncalibrated numbers
+
+`distil dissect` compared the raw heuristic token estimate against billed usage, so
+its "off by >50%" tripwire fired on essentially every calibrated session. Calibration
+is applied on every other surface; dissect is the surface whose entire job is
+explaining the numbers, and it was the one quoting them uncalibrated.
+
 ## [1.45.0] — the compressor was rewriting the cache it was supposed to protect
 
 **On cached agent traffic, distil cost about twice what sending nothing compressed would

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.45.1
-date-released: 2026-08-09
+version: 1.46.0
+date-released: 2026-08-13
 keywords:
   - llm
   - context-compression

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.45.1"
+appVersion: "1.46.0"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.45.1"
+version = "1.46.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.45.1",
+  "version": "1.46.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.45.1",
+      "version": "1.46.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.45.1"
+version = "1.46.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Cuts 1.46.0 from the work merged in #127.

## Why minor, not patch

Two changes alter behavior for existing installs on upgrade:

- **`distil proxy` now defaults `--shadow 0.02` / `--retention 0.05`** (matching `wrap`). Shadow makes a real extra upstream call on ~2% of requests. That is the point — it is how the decision-equivalence claim stays checkable — but it is a cost change, not a silent bugfix.
- **`DISTIL_RESTORE_CAP` default raised 500 → 5000**, so a managed install holds more restore blobs on disk.

## The headline

The reporting fixes are what prompted this, but the one that matters most is the daemon: `com.distil.proxy` runs `distil proxy`, whose defaults differed from `wrap`'s. **Every managed install has been running with no shadow evidence and no retention meter since the daemon shipped.** A 93-minute, 767-request session sampled 0; the same work under `wrap` samples ~15. Upgrading fixes it — no reinstall, no config.

## Also in this release

- **dissect** reported three different denominators for one session; the mechanism split now reconciles with the headline it decomposes (3.75M discrepancy → 72k rounding).
- **"Everything summarized stays recoverable" was false while it printed** — a 500-blob LRU had evicted 204 of 704 folds mid-session, including the one referenced by 272 requests.
- **Papers**: zero undefined references; the macro fallback no longer silently renders a different operating point as the headline; the cache-monotonicity passage describes the mechanism that actually ships *and* the measured failure it previously hid; the NeurIPS variant regained the live-validation negative result.
- **Docs**: the security whitepaper no longer denies a control the code implements (OIDC/RBAC); the Python floor is 3.9 not 3.11; the site publishes **48.4% corpus savings** where it had advertised 25.3% — we were underselling by ~22pp against our own free gate.
- Adds the **1.45.1 CHANGELOG entry**, which was never written.

## Verification

- 3332 passed / 17 skipped (py3.12)
- packaging smoke 16/16 — the gate that catches version drift across all seven locations
- ruff 0.15.10 + mypy 1.17.1 clean
- `import distil` → 1.46.0
- All seven version locations bumped: pyproject, CITATION.cff, server.json (×2), npm package.json, plugin.json, helm Chart `appVersion`. `date-released` refreshed.

Tag `v1.46.0` follows once this is merged; CI trusted-publishes to PyPI from the tag.