### PR TITLE
fix(ci): stop paper-build going red on a push it can never satisfy

### DIFF
--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -54,6 +54,10 @@ jobs:
 
       # Close the staleness loop: on push to main, commit the rebuilt PDFs so the
       # tracked artifacts can never drift from the source again. (PRs only verify.)
+      # CAVEAT (see #128): a branch ruleset requiring status checks on every push
+      # to main can make this push impossible to satisfy — see the comment below.
+      # When that happens the loop is NOT closed: PDFs on main can drift from
+      # source until a maintainer resolves the ruleset conflict.
       - name: Commit rebuilt PDFs
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
@@ -71,7 +75,12 @@ jobs:
             # is a repo-settings decision for a human, not something to route around
             # here — surface it and let the paper build itself stay the signal.
             if ! git push 2>push.err; then
-              if grep -q 'required status checks\|GH013' push.err; then
+              # Match ONLY the specific required-status-checks rejection text.
+              # GH013 alone is a generic ruleset-violation code shared by unrelated
+              # protections (signed commits, linear history, ...) — matching on it
+              # bare would silently wave through failures this bot should never
+              # treat as expected.
+              if grep -q 'required status checks are expected' push.err; then
                 cat push.err
                 echo "::warning title=paper-build: PDFs not pushed::Branch ruleset on main blocked the bot's direct push (see #128). Rebuilt PDFs differ from what's committed until a maintainer resolves it."
               else

--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -75,16 +75,18 @@ jobs:
             # is a repo-settings decision for a human, not something to route around
             # here — surface it and let the paper build itself stay the signal.
             if ! git push 2>push.err; then
-              # Match ONLY the specific required-status-checks rejection text.
-              # GH013 alone is a generic ruleset-violation code shared by unrelated
-              # protections (signed commits, linear history, ...) — matching on it
-              # bare would silently wave through failures this bot should never
-              # treat as expected.
-              if grep -qi 'required status checks are expected' push.err; then
-                cat push.err
+              cat push.err
+              # A single rejection can bundle several rule violations on one push
+              # (e.g. required checks AND signed commits). Only tolerate this if
+              # EVERY reported violation is the required-status-checks one — GH013
+              # alone is a generic ruleset code shared by unrelated protections, so
+              # matching on it (or on this text appearing ANYWHERE in the output)
+              # would silently wave through a real violation riding alongside it.
+              bullets=$(grep '^remote: - ' push.err || true)
+              other=$(printf '%s\n' "$bullets" | grep -vi 'required status checks are expected' || true)
+              if [ -n "$bullets" ] && [ -z "$other" ]; then
                 echo "::warning title=paper-build: PDFs not pushed::Branch ruleset on main blocked the bot's direct push (see #128). Rebuilt PDFs differ from what's committed until a maintainer resolves it."
               else
-                cat push.err
                 exit 1
               fi
             fi

--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -80,7 +80,7 @@ jobs:
               # protections (signed commits, linear history, ...) — matching on it
               # bare would silently wave through failures this bot should never
               # treat as expected.
-              if grep -q 'required status checks are expected' push.err; then
+              if grep -qi 'required status checks are expected' push.err; then
                 cat push.err
                 echo "::warning title=paper-build: PDFs not pushed::Branch ruleset on main blocked the bot's direct push (see #128). Rebuilt PDFs differ from what's committed until a maintainer resolves it."
               else

--- a/.github/workflows/paper-build.yml
+++ b/.github/workflows/paper-build.yml
@@ -65,7 +65,20 @@ jobs:
             git commit -m "paper: rebuild PDFs from source [skip ci]"
             # a concurrent push to main must not fail the build; integrate first
             git pull --rebase origin main
-            git push
+            # A ruleset requiring status checks on every push to main can never be
+            # satisfied by this direct push: the bot's new commit is [skip ci], so
+            # it can never accrue the checks the ruleset waits for (see #128). That
+            # is a repo-settings decision for a human, not something to route around
+            # here — surface it and let the paper build itself stay the signal.
+            if ! git push 2>push.err; then
+              if grep -q 'required status checks\|GH013' push.err; then
+                cat push.err
+                echo "::warning title=paper-build: PDFs not pushed::Branch ruleset on main blocked the bot's direct push (see #128). Rebuilt PDFs differ from what's committed until a maintainer resolves it."
+              else
+                cat push.err
+                exit 1
+              fi
+            fi
           else
             echo "PDFs already match source."
           fi


### PR DESCRIPTION
## What's red

`paper-build` on `main` failed at the "Commit rebuilt PDFs" step (run [31699681957](https://github.com/dshakes/distil/actions/runs/31699681957), commit `fdb96b2`):

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

(I hit the exact same rejection pushing this very fix directly to `main` — confirms direct pushes to `main` are categorically blocked right now, not just this bot's.)

## Root cause

The paper compiles fine — that part of the job is healthy. The failing step is a convenience step that, after a successful build, commits the rebuilt PDFs and pushes straight to `main`.

A ruleset on `main` now requires 2 status checks before a push is accepted. This step can never satisfy that, structurally:

1. The bot's commit doesn't exist until it's pushed, so it can't have already-completed check runs recorded against it — required-status-checks rejects any brand-new commit pushed directly to a protected ref.
2. The commit message is `paper: rebuild PDFs from source [skip ci]`, which tells Actions to skip triggering workflows for that push — so it would never accrue checks even given time.

Not transient/flaky: compare the one-off "fetch first" race on 2026-07-17 (self-healed next run) — this is a different, permanent failure mode.

## What this PR does

Catches that specific rejection (`GH013` / "required status checks") in the push step and downgrades it to a `::warning::` instead of failing the job. Any other push failure still fails the step hard, same as before. This restores `paper-build` to green.

**This is a band-aid, not a fix.** The auto-commit-to-main mechanism is now permanently dormant — rebuilt PDFs will no longer actually land on `main` via this path. Filed #128 with the real options (bypass the ruleset for the bot, redesign as PR+auto-merge with a PAT, or drop the step and rely on contributors committing PDFs pre-merge) — that's a repo-settings/design decision for a maintainer, not something to guess at from a CI log.

## Verification

- `uv run pytest` (with coverage): 3354 passed, 2 skipped, coverage 95.07%
- `uvx ruff check distil tests`: clean
- `uvx mypy distil`: clean
- `uv run distil bench` / `verify` / `validate`: all PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWHNpDGpWfAMbLL8soxuq)_