### PR TITLE
fix(release): the preflight venv could make the gate weaker than CI, silently

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,6 +51,34 @@ nothing installed, and doesn't need to be kept in sync. Bump before a release:
 - `CITATION.cff` → `version` and `date-released`
 - add a `## [X.Y.Z]` section to `CHANGELOG.md`
 
+### One-time: the `.venv` the preflight tests run in
+
+`scripts/release.sh` runs its test gate as `.venv/bin/python -m pytest -q` — the repo
+venv, not `uv run`. That venv needs the test dependencies, and it needs **all** of
+them:
+
+```bash
+uv venv                                     # creates .venv if it isn't there
+uv pip install -e .                         # distil itself
+uv pip install pytest pytest-asyncio aiohttp pillow cryptography opentelemetry-sdk
+```
+
+Two ways this bites, both seen for real when cutting `1.47.0rc1`:
+
+- **No pytest at all** → the driver reports `✗ tests failed — not releasing` and
+  stops. Loud and safe: nothing was pushed. Misleading wording, though — the tests
+  did not fail, they never ran.
+- **Missing the optional extras** → far worse, because it is *silent*. Tests that
+  need `cryptography` or `opentelemetry` call `importorskip` and quietly skip
+  themselves, so the gate goes green having tested less than CI does. The release
+  run read `3381 passed, 6 skipped` where CI reads `3385 passed, 2 skipped`: four
+  tests, including at-rest crypto coverage, never executed.
+
+If the skip count from the preflight run does not match CI's, the venv is
+incomplete — fix the venv rather than shrugging at a green gate. Do **not** reach
+for `--skip-tests` to get past either case; that turns a gate that just did its job
+into no gate at all.
+
 Then, from a clean `main`:
 
 ```bash

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -124,6 +124,22 @@ fi
 if [ "$SKIP_TESTS" -eq 1 ]; then
   info "skipping tests (--skip-tests)"
 else
+  # Check the venv can actually RUN the suite before blaming the code. Without
+  # this, a venv with no pytest reports "tests failed — not releasing", which
+  # sends you hunting through a green codebase for a phantom regression.
+  if ! .venv/bin/python -c "import pytest" >/dev/null 2>&1; then
+    die ".venv has no pytest — the test gate cannot run (see RELEASING.md, 'the .venv the preflight tests run in')"
+  fi
+  # The optional extras matter MORE than pytest itself, because missing them fails
+  # silently: those tests importorskip themselves and the gate goes green having
+  # covered less than CI. Cutting 1.47.0rc1 read 6 skipped where CI reads 2 — four
+  # tests, at-rest crypto among them, never ran.
+  missing=""
+  for mod in cryptography opentelemetry PIL aiohttp; do
+    .venv/bin/python -c "import $mod" >/dev/null 2>&1 || missing="$missing $mod"
+  done
+  [ -n "$missing" ] && die ".venv is missing:$missing — those tests would silently skip, making this gate weaker than CI (see RELEASING.md)"
+
   info "running test suite…"
   run ".venv/bin/python -m pytest -q" || die "tests failed — not releasing"
   ok "tests pass"


### PR DESCRIPTION
Found while cutting `1.47.0rc1`. Two failure modes, and the second is the one that matters.

`scripts/release.sh` runs its test gate as `.venv/bin/python -m pytest -q` — the repo venv, not `uv run` — but nothing documented that the venv must exist or what belongs in it.

**Loud:** no pytest → `✗ tests failed — not releasing`, stops before pushing anything. Safe, but the wording sends you hunting through a green codebase for a regression that isn't there.

**Silent, and the real bug:** pytest present, optional extras missing. Tests needing `cryptography` or `opentelemetry` `importorskip` themselves, so the gate goes green having covered **less than CI**:

| | passed | skipped |
|---|---|---|
| release venv (before) | 3381 | 6 |
| CI | 3385 | 2 |

Four tests — at-rest crypto coverage among them — never executed, and `1.47.0rc1` shipped behind that gate. It looked identical to a passing one.

## Changes

- **RELEASING.md** — documents the venv as a one-time setup step, names both failure modes, and says to compare the preflight skip count against CI's. Also: don't reach for `--skip-tests` to get past either, which turns a gate that just did its job into no gate at all.
- **release.sh** — checks the venv can run the suite *before* running it, naming the missing modules instead of reporting "tests failed" or quietly passing.

## Verified against real venvs, not by reading

- empty venv → fires the no-pytest guard
- pytest + aiohttp + pillow, no crypto/otel (the exact state that caused the silent gap) → fires the second guard, naming `cryptography opentelemetry`
- complete venv → silent, no false positive

The repo venv now runs **3385 passed, 2 skipped**, matching CI exactly.

Docs + release tooling only — nothing a running proxy/wrap/gateway executes, so this is soak-exempt per RELEASING.md's own rule and does not disturb the `1.47.0rc1` soak in progress.