### PR TITLE
release(1.47.0rc2): re-cut so the soak runs against a fully-gated artifact

### DIFF
--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.47.0rc1"
+appVersion: "1.47.0rc2"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.47.0-rc.1",
+  "version": "1.47.0-rc.2",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.47.0rc1",
+  "version": "1.47.0rc2",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.47.0rc1"
+version = "1.47.0rc2"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.47.0rc1",
+  "version": "1.47.0rc2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.47.0rc1",
+      "version": "1.47.0rc2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.47.0rc1"
+version = "1.47.0rc2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Re-cut of `1.47.0rc1`. **The code is byte-identical** — nothing was wrong with it.

## Why re-cut

rc1 was validated by a preflight gate that was quietly weaker than CI. The release venv lacked `cryptography` and `opentelemetry`, so those tests `importorskip`'d themselves:

| | passed | skipped |
|---|---|---|
| gate that validated rc1 | 3381 | 6 |
| CI | 3385 | 2 |

Four tests — at-rest crypto among them — never ran against the published artifact. All four pass now, so this is not a defect fix; it is so the 3-day soak clock runs against an artifact whose gate actually matched CI, instead of one carrying a caveat. #133 added the guard that makes that state impossible to reach silently again.

## Version surfaces

All bumped to `1.47.0rc2` (npm as `1.47.0-rc.2`, SemVer spelling). `CITATION.cff` stays at `1.46.0` — the last GA — per the prerelease convention the packaging guard enforces. CHANGELOG stays under the final `[1.47.0]`: the rc soaks for it.

Packaging smoke 16/16.