### PR TITLE
release(1.47.0): the key file was world-readable, and the audit trail wasn't watching

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.46.0
-date-released: 2026-08-13
+version: 1.47.0
+date-released: 2026-08-15
 keywords:
   - llm
   - context-compression

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.47.0rc1"
+appVersion: "1.47.0"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.47.0-rc.1",
+  "version": "1.47.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.47.0rc1",
+  "version": "1.47.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.47.0rc1"
+version = "1.47.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.47.0rc1",
+  "version": "1.47.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.47.0rc1",
+      "version": "1.47.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.47.0rc1"
+version = "1.47.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Final for the audit work merged in #131. Code is **byte-identical to `1.47.0rc1`** plus the version bump.

## Shipping the final directly

Maintainer elected to skip the 3-day rc soak. Recording the tradeoff rather than pretending it wasn't made:

`RELEASING.md` asks runtime-behaviour changes to bake, and this one rewrote encryption-at-rest and gateway auth. Every gate is green and the reviewer cleared it — but **nine CI rounds found nine real defects** in this work, several visible only under CPU contention or on Windows, which cannot be tested locally. That is exactly the profile the soak window exists for ("fixes were correct in review and wrong under real use; the missing ingredient was bake time, not more review").

Called explicitly by the maintainer, so it ships.

## What's in it

- **Key files no longer world-readable at creation.** Master key and gateway key file were written at the process umask — measured `0o644` — then chmod'd. Both now create `0600`. Re-probed: 1,855 samples, only `0o600`.
- **The gateway had no audit log at all** (`grep -c audit` → 0). Now append-only, flock-guarded, 0600 JSONL across every refusal path including OIDC rejection, RBAC denial, and both daily-quota paths. Content-free: identifiers and outcomes, never prompt text or the raw key.
- **Key expiry** (`--expires-in-days`), enforced through the same `is_active` chokepoint as revocation. Backward compatible.
- **3.2 MB context: 1014 ms → 719 ms**, savings unchanged. Encryption byte-identical across 627 cases; keep decisions identical across 400,000 differential cases.
- **Minified JSON 10.5% → 57.5%**, nested → 91.2%, verified in-context lossless.

## Version surfaces

All seven at `1.47.0`. Unlike the rc, this **does** bump `CITATION.cff` (to 1.47.0, dated today) — it names a real GA now. Packaging smoke 16/16.

## Gate strength

Cut behind a full-strength preflight: the release venv now carries `cryptography` and `opentelemetry`, so it validates at **3385 passed / 2 skipped**, matching CI exactly. rc1 was gated at 3381/6 before #133 closed that hole — this final does not inherit that caveat.

## Known limitation, documented in code

Concurrent *first touch* of a brand-new key store can still leave two creators on different keys. Five attempts to close it each passed on POSIX and broke Windows differently; it wants a Windows runner in the loop.