### PR TITLE
chore(homebrew): point the formula at v1.47.0

### DIFF
--- a/packaging/homebrew/distil.rb
+++ b/packaging/homebrew/distil.rb
@@ -8,16 +8,16 @@
 #   brew tap dshakes/tap
 #   brew install dshakes/tap/distil
 #
-# sha256 is for the v1.40.1 source tarball. To recompute for a new version:
+# sha256 is for the v1.47.0 source tarball. To recompute for a new version:
 #   curl -sL https://github.com/dshakes/distil/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
 class Distil < Formula
   desc "Compression with a quality contract — context compression for LLM agentic runtimes"
   homepage "https://github.com/dshakes/distil"
-  url "https://github.com/dshakes/distil/archive/refs/tags/v1.40.1.tar.gz"
-  sha256 "986ab2110c66e6a0bb5f8e20547a148275d375567c524d84ff3a951e67b35957"
+  url "https://github.com/dshakes/distil/archive/refs/tags/v1.47.0.tar.gz"
+  sha256 "91bada5712b98210baa15cf54e6fe06e21a4a4ee12cb1a355aab9eab7ff05cba"
   license "Apache-2.0"
-  version "1.40.1"
+  version "1.47.0"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
`scripts/release.sh` patches `packaging/homebrew/distil.rb` in place after pushing the tag — it fetches the release tarball and rewrites the `url` and `sha256`. This commits that edit so the in-repo formula matches what shipped.

The formula was still on `v1.40.1`, which is expected: the tap is canonical and this file lags until a release refreshes it.

Verified the sha against the actual tarball rather than trusting the script — see below. Packaging-metadata only; nothing a running proxy/wrap/gateway executes.