### PR TITLE
release(1.48.0): the saving on a subscription is the window, not the bill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.48.0] — the saving on a subscription is the window, not the bill
+
+**A reader was right and our copy was wrong.** distil's README said a flat-rate
+Pro/Max plan gets "context and latency, not the bill". But fewer tokens per turn means
+more turns before the rate-limit window closes, and on a flat-rate plan that window
+*is* the currency. The copy is fixed and this release makes the saving real.
+
+**The proxy can't help there, by design.** Anthropic's consumer terms (§3, item 7)
+restrict automated access on subscription credentials, so distil deliberately runs
+`--lossless-only` on a subscription and measures **0.27%**. Your account isn't worth a
+few percent.
+
+**So use the door that's open.** `distil hook --install` wires a Claude Code
+`PostToolUse` hook: the agent compresses its own tool output, in its own process,
+through a documented first-party extension point. No proxy, no credentials touched.
+Because a hook sees each result once and cannot rewrite history, compression is
+append-only *by construction* — the fix direction our own cache-busting investigation
+identified, enforced by the platform rather than by our discipline.
+
+Measured on a paired live A/B, both arms answering correctly: tool_result **−38.6%**,
+`cache_creation` **−67.4%**, cost-weighted **−68.3%**, decision-equivalence **5/5**.
+Critically `cache_read` did *not* collapse — the proxy digest's failure mode does not
+reproduce here.
+
+**And the number that doesn't flatter us:** on distil's own eval corpus the hook saves
+**0.00%**. Savings are shape-dependent — verbose JSON 28–33%, duplicated log runs up to
+99%, prose and unique-line output ~0% — and our corpus contains none of the winning
+shapes. Published because quoting only the favourable fixtures is the overclaim we
+criticise in others.
+
+- `distil hook --install / --selftest / --uninstall` — idempotent, preserves foreign
+  hooks, refuses to clobber an unreadable `settings.json`
+- `distil quota` — the rate-limit windows, read-only, fails open to "unavailable"
+  rather than a fabricated zero
+- `docs/subscription.html` with an animated diagram and a troubleshooting table
+- The provider-compaction paper (`docs/paper/provider_compaction.tex`), arXiv-ready,
+  every number generated from run artifacts by a script that refuses to emit LaTeX
+  unless each report's protocol hash matches its pre-registration
+
+Credit where it's due: Headroom shipped subscription quota telemetry against this
+endpoint before we did. They built the instrument for the subscription user's real
+currency while our copy still said that currency didn't count.
+
+Windows note: three defects in this work were Windows-only (`os.uname()` in the code,
+then in the test that proved the fix, then pytest IDs blowing the 32,767-character
+environment-variable cap). All fixed, and the last one is now fenced by a guard
+verified to actually fail.
+
 ## [1.47.0] — the key file was world-readable, and the audit trail wasn't watching
 
 **Two things an enterprise security review would have caught before you did.** The

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.47.0
+version: 1.48.0
 date-released: 2026-08-15
 keywords:
   - llm

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.47.0"
+appVersion: "1.48.0"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.47.0"
+version = "1.48.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.47.0",
+  "version": "1.48.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.47.0",
+      "version": "1.48.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.47.0"
+version = "1.48.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Version bump for 1.48.0. All **seven** locations: `pyproject.toml`, `CITATION.cff`, `server.json` (×2), `packaging/npm/package.json`, `plugins/distil/.claude-plugin/plugin.json`, `packaging/helm/distil-gateway/Chart.yaml` (`appVersion`).

## What ships

The subscription work merged in #139:

- **`distil hook --install / --selftest / --uninstall`** — Claude Code `PostToolUse` hook. Idempotent, preserves foreign hooks, refuses to clobber an unreadable `settings.json`.
- **`distil quota`** — rate-limit windows, read-only, fails open to "unavailable" rather than a fabricated zero.
- **`docs/subscription.html`** — animated diagram, three-command setup, troubleshooting table.
- **The provider-compaction paper** — arXiv-ready, every number generated from run artifacts.

## Measured, not claimed

| Metric | Change |
|---|---|
| tool_result delivered | −38.6% |
| `cache_creation` | −67.4% |
| cost-weighted | −68.3% |
| decision-equivalence | 5/5 |
| **distil's own corpus** | **0.00%** |

That last row is published deliberately. Savings are shape-dependent (JSON 28–33%, duplicated log runs up to 99%, prose ~0%) and our corpus contains none of the winning shapes.

## Gate

- 3466 passed, 2 skipped
- Coverage **95.20%** (floor 95%)
- `make lint` clean, packaging smoke 16 passed

## Note

Homebrew `distil.rb` lags by design — the tap is canonical.