### PR TITLE
fix(tests): skip the unreadable-trail assert under root, matching the doctor precedent

### DIFF
--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -199,6 +199,10 @@ def test_reader_handles_blank_lines_and_a_missing_file(tmp_path) -> None:
     sys.platform == "win32",
     reason="chmod 0000 does not make a file unreadable on Windows, so the failure path cannot be provoked",
 )
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="chmod 0o000 is a no-op for root (bypasses permission bits)",
+)
 def test_unreadable_trail_reads_as_empty(tmp_path) -> None:
     """A trail that cannot be opened must not raise into the CLI."""
     import os


### PR DESCRIPTION
## Summary
- `test_unreadable_trail_reads_as_empty` chmods the audit trail to `0o000` and asserts `read_events()` comes back empty. Root bypasses permission bits, so under a root euid the chmod is a no-op and the trail reads back non-empty — a false failure with no product regression behind it.
- GitHub Actions' `ubuntu-latest` runners are non-root, so this never surfaces there — CI on `main` is currently green (verified the last 20 runs, all `success`/`skipped`). It's real in any root-euid environment (e.g. a root-user container) that runs the suite, which is how it was found during a routine local-gate re-verification.
- `test_doctor.py::test_check_mode_unreadable_file` already carries this exact `skipif(os.geteuid() == 0, ...)` guard for the identical reason; this sibling test in `test_audit.py` was just missed when it was added.

## Test plan
- [x] `uv run --with pytest --with pillow python -m pytest -q` — 3444 passed, 7 skipped (matches CI's `gate` job command)
- [x] `uvx ruff@0.15.10 check distil tests` — clean
- [x] `uvx ruff@0.15.10 format --check tests/test_audit.py` — already formatted
- [x] `uvx mypy@1.17.1 --python-version 3.12 --ignore-missing-imports distil` — clean
- [x] `uv run distil bench` / `uv run distil verify` / `uv run distil validate` — all PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgDqE37WSjET7B46jd62Xn)_