### PR TITLE
release(1.48.1): a page that answers "which one am I?" before the jargon does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.48.1] — a page that answers "which one am I?" before the jargon does
+
+**Docs and one nudge.** Nothing new is callable and no behaviour changed, so this is
+a patch: if you are tracking releases for capability, skip it.
+
+distil has seven ways to run and the names are all jargon — wrap, hook, proxy, MCP,
+library, gateway, statusline. A newcomer had to learn our vocabulary before they could
+tell which one applied to them. `docs/which-mode.html` inverts that: two plain
+questions (how do you pay, what are you running) and the answer falls out, with an
+animated decision tree and honest savings ranges per surface.
+
+The page leads with the thing most compression tools bury: **the mode barely matters,
+what your tools print matters enormously** — JSON 28–33%, repeated log lines up to
+99%, prose ~0%, and 0.00% on distil's own corpus.
+
+- `distil onboard` now closes with a pointer to that page. It already detects your OS,
+  agents and billing, but it could never mention MCP, the library, or the gateway,
+  because those cannot be detected — which is how the MCP server (the only thing that
+  works in Claude Desktop) stayed invisible to most installs.
+- The provider-compaction paper gains an affiliation and its arXiv category
+  (`cs.SE` primary, `cs.LG` cross-list), plus the submission step that is easy to get
+  wrong: upload the `.tex` **and** its generated macro fragment, or every number
+  renders as `--`.
+- A nav-markup guard, after review caught two links sharing one `<li>` — a defect that
+  had already shipped across 35 pages in the previous release's nav.
+
 ## [1.48.0] — the saving on a subscription is the window, not the bill
 
 **A reader was right and our copy was wrong.** distil's README said a flat-rate

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.48.0
+version: 1.48.1
 date-released: 2026-08-15
 keywords:
   - llm

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.48.0"
+appVersion: "1.48.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.48.0"
+version = "1.48.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.48.0",
+  "version": "1.48.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.48.0",
+      "version": "1.48.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.48.0"
+version = "1.48.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
**Patch, not a minor.** Since 1.48.0 the only shipped-code change is **14 lines in `onboard.py`** — one extra guidance step. Everything else is docs, tests, and the paper.

Nothing new is callable, no behavior changed. A minor bump would overstate the delta to anyone tracking releases for capability.

## Ships

- **`docs/which-mode.html`** — two plain questions instead of seven jargon names, animated decision tree, honest per-shape savings ranges
- **`distil onboard`** now points at it — closing the gap where MCP, library, and gateway were never mentioned, because they can't be auto-detected
- **The paper** gains an affiliation and its arXiv category (`cs.SE` / `cs.LG`)
- **A nav-markup guard**, after review caught two links sharing one `<li>` — a defect already live across 35 pages

## Version locations

All seven: `pyproject.toml`, `CITATION.cff`, `server.json` (×2), `packaging/npm/package.json`, `plugins/distil/.claude-plugin/plugin.json`, `packaging/helm/distil-gateway/Chart.yaml`.

## Gate

3473 passed · coverage **95.21%** · lint clean · packaging smoke 16 passed