### PR TITLE
fix(tests): skip the audit unreadable-trail test under root, like doctor already does

### DIFF
--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -199,6 +199,10 @@ def test_reader_handles_blank_lines_and_a_missing_file(tmp_path) -> None:
     sys.platform == "win32",
     reason="chmod 0000 does not make a file unreadable on Windows, so the failure path cannot be provoked",
 )
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="chmod 0o000 is a no-op for root (bypasses permission bits)",
+)
 def test_unreadable_trail_reads_as_empty(tmp_path) -> None:
     """A trail that cannot be opened must not raise into the CLI."""
     import os


### PR DESCRIPTION
## Summary

Scheduled CI green-keeper run: GitHub Actions on `main` is fully green (all 20 most recent runs succeeded), but the local-gate re-verification step turned up a real bug — `tests/test_audit.py::test_unreadable_trail_reads_as_empty` fails when the suite runs as root (uid 0), because `chmod(0o000)` is a no-op for root and the file stays readable.

This is invisible on GitHub-hosted runners (non-root), which is why CI itself never caught it. But `tests/test_doctor.py::test_check_mode_unreadable_file` already hits the identical situation (`chmod 0o000` on a service file) and guards it with:

```python
@pytest.mark.skipif(
    hasattr(os, "geteuid") and os.geteuid() == 0,
    reason="chmod 0o000 is a no-op for root (bypasses permission bits)",
)
```

right next to its existing win32 skip. `test_audit.py`'s analogous test only had the win32 half. This PR adds the matching root guard, mirroring the existing precedent exactly rather than inventing a new pattern or weakening the test's intent.

## Test plan

- [x] `uv run --with pytest --with pillow python -m pytest -q` — 3448 passed, 10 skipped (was 3448 passed, 1 failed, 9 skipped before the fix)
- [x] `uvx ruff@0.15.10 check distil tests` — clean
- [x] `uvx ruff@0.15.10 format --check .` — clean
- [x] `uvx mypy@1.17.1 --python-version 3.12 --ignore-missing-imports distil` — clean
- [x] `uv run distil bench` — GATE: PASS
- [x] `uv run distil verify` — FIDELITY: PASS
- [x] `uv run distil validate` — VALIDATE: PASS


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJ4AKy7dRUrtYJ2ywwhBhf)_