### PR TITLE
test(audit): guard the unreadable-trail assert against root

### DIFF
--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -199,6 +199,11 @@ def test_reader_handles_blank_lines_and_a_missing_file(tmp_path) -> None:
     sys.platform == "win32",
     reason="chmod 0000 does not make a file unreadable on Windows, so the failure path cannot be provoked",
 )
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod 0o000 is a no-op on Windows")
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="chmod 0o000 is a no-op for root (bypasses permission bits)",
+)
 def test_unreadable_trail_reads_as_empty(tmp_path) -> None:
     """A trail that cannot be opened must not raise into the CLI."""
     import os

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -195,26 +195,29 @@ def test_reader_handles_blank_lines_and_a_missing_file(tmp_path) -> None:
     assert [e["key_id"] for e in audit.read_events()] == ["gk_1"]
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="chmod 0000 does not make a file unreadable on Windows, so the failure path cannot be provoked",
-)
-@pytest.mark.skipif(
-    hasattr(os, "geteuid") and os.geteuid() == 0,
-    reason="chmod 0o000 is a no-op for root (bypasses permission bits)",
-)
-def test_unreadable_trail_reads_as_empty(tmp_path) -> None:
-    """A trail that cannot be opened must not raise into the CLI."""
-    import os
+def test_unreadable_trail_reads_as_empty(tmp_path, monkeypatch) -> None:
+    """A trail that cannot be opened must not raise into the CLI.
+
+    Simulated via a PermissionError from Path.open rather than chmod 0o000:
+    chmod is a no-op for root and on Windows, which would silently drop this
+    coverage in exactly the containers/CI this test exists to guard.
+    """
+    from pathlib import Path
+    from typing import Any
 
     from distil import audit
 
     audit.record(audit.AUTH_OK, key_id="gk_1")
-    os.chmod(audit.audit_path(), 0o000)
-    try:
-        assert audit.read_events() == []
-    finally:
-        os.chmod(audit.audit_path(), 0o600)
+
+    real_open = Path.open
+
+    def _unreadable(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == audit.audit_path():
+            raise PermissionError("simulated: audit trail is unreadable")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _unreadable)
+    assert audit.read_events() == []
 
 
 def test_gateway_audit_cli_renders_filters_and_json(tmp_path, capsys) -> None:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -199,7 +199,6 @@ def test_reader_handles_blank_lines_and_a_missing_file(tmp_path) -> None:
     sys.platform == "win32",
     reason="chmod 0000 does not make a file unreadable on Windows, so the failure path cannot be provoked",
 )
-@pytest.mark.skipif(sys.platform == "win32", reason="chmod 0o000 is a no-op on Windows")
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="chmod 0o000 is a no-op for root (bypasses permission bits)",


### PR DESCRIPTION
## What

Adds the two skip guards (`win32` + `geteuid()==0`) to `tests/test_audit.py::test_unreadable_trail_reads_as_empty`.

## Why

`chmod 0o000` is a no-op for root: the trail stays readable, so `read_events()` returns the recorded row instead of `[]` and the test fails. CI runners are non-root, so this never fires in CI — but a **root** gate run (e.g. a containerized green-keeper) hits a false failure on an otherwise-green tree.

The identical `chmod 0o000` test in `tests/test_doctor.py` (`test_check_mode_unreadable_file`) already carries both guards verbatim; this mirrors them. The assertion is unchanged where it can hold — nothing is weakened, no product code changes.

## Verification (local, run as root)

- `uv run --with pytest --with pillow python -m pytest -q` → **3448 passed, 10 skipped** (the previously-failing test is now the 10th skip)
- `uvx ruff check distil tests` → clean; `uvx ruff format --check .` → clean
- `uvx mypy --python-version 3.12 --ignore-missing-imports distil` → clean
- `uv run distil bench` / `verify` / `validate` → all **PASS**

## Scope

Test-only, 5 insertions. No thresholds, gates, versions, tags, or workflows touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3v51W3tz3KWqcLP3KHykR)_