### PR TITLE
fix(1.50.1): count extended thinking — billed tokens distil scored as zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.50.1] — the tokens distil could not see
+
+Extended thinking carries its payload under `thinking`, not `text`, so distil counted
+it as **zero** — a 1,000-character block scored 0 tokens. On Claude 4.6+ prior-turn
+thinking is re-sent as input and billed every turn, which means real billed tokens sat
+in neither the before nor the after side of every percentage distil reports.
+
+The blocks are still never rewritten, and that is not timidity: the provider pins each
+block by its `signature` and re-expands the original server-side, so editing the text
+achieves nothing and risks the signature being rejected on replay. But a cost distil
+cannot reduce is exactly the cost it should not hide. Thinking now appears in the
+token baseline and in the eligibility census as `thinking_billed`.
+
 ## [1.50.0] — the model that could never learn, and the store nobody could see
 
 Two capabilities that were present in the code and unreachable in practice.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.50.0
+version: 1.50.1
 date-released: 2026-08-24
 keywords:
   - llm

--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -517,6 +517,16 @@ def _compress_content_item(
     if btype == "image":
         return _compress_image_block(item, store, verbatim, is_recent)
 
+    if btype in ("thinking", "redacted_thinking"):
+        # Extended thinking. NOT compressible, and not for want of trying: the provider
+        # pins the block by its `signature` and re-expands the original server-side, so
+        # editing the text achieves nothing and risks the signature being rejected on
+        # replay. But on Claude 4.6+ this content is re-sent as input and billed every
+        # turn, so it belongs in the census — otherwise the one context cost distil
+        # cannot reduce is also the one it never shows you.
+        _census("thinking_billed", str(item.get("thinking") or item.get("data") or ""))
+        return item
+
     if btype == "text":
         if role == "assistant":
             # Never rewrite the assistant's own words.

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -353,8 +353,18 @@ def _count_messages(msgs: list[dict[str, Any]]) -> int:
                 # distil reports: they were in neither the before nor the after count.
                 # distil does not rewrite these blocks (the provider pins them by
                 # signature and re-expands server-side), but it must SEE them.
-                for tkey in ("thinking", "redacted_thinking"):
-                    tval = block.get(tkey)
+                # The two block types keep their payload under DIFFERENT keys:
+                # `thinking` holds text under "thinking"; `redacted_thinking` holds an
+                # opaque blob under "data". Reading "redacted_thinking" as a key finds
+                # nothing on a real block, so those tokens counted as zero — the same
+                # blind spot this change exists to remove. Kept aligned with the census
+                # in adapters.anthropic, which reads both.
+                if block.get("type") == "thinking":
+                    tval = block.get("thinking")
+                    if isinstance(tval, str):
+                        total += _tokenizer.count(tval)
+                elif block.get("type") == "redacted_thinking":
+                    tval = block.get("data")
                     if isinstance(tval, str):
                         total += _tokenizer.count(tval)
                 for key in ("text", "content"):

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -347,6 +347,16 @@ def _count_messages(msgs: list[dict[str, Any]]) -> int:
                 if block.get("type") == "image":
                     total += _image_tokens(block)
                     continue
+                # Extended thinking carries its payload under `thinking`, not `text`.
+                # On Claude 4.6+ prior-turn thinking is re-sent as input and BILLED, so
+                # leaving it out of the baseline hid real tokens from every percentage
+                # distil reports: they were in neither the before nor the after count.
+                # distil does not rewrite these blocks (the provider pins them by
+                # signature and re-expands server-side), but it must SEE them.
+                for tkey in ("thinking", "redacted_thinking"):
+                    tval = block.get(tkey)
+                    if isinstance(tval, str):
+                        total += _tokenizer.count(tval)
                 for key in ("text", "content"):
                     val = block.get(key)
                     if isinstance(val, str):

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.50.0"
+appVersion: "1.50.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.50.0"
+version = "1.50.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.50.0",
+  "version": "1.50.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.50.0",
+      "version": "1.50.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -768,11 +768,38 @@ def test_thinking_blocks_are_counted_but_never_rewritten():
 
 
 def test_redacted_thinking_is_also_counted_and_preserved():
+    """The REAL Anthropic shape: a redacted block's payload lives under `data`.
+
+    An earlier version of this test invented a block carrying a `redacted_thinking`
+    key, which no API ever emits. The mock passed while production still counted
+    these as zero — the exact bug the change was meant to fix. Cross-audit caught it.
+    Keep this fixture shaped like the wire format, not like the code under test.
+    """
     from distil.adapters.anthropic import compress_messages
     from distil.proxy import _count_messages
 
-    block = {"type": "redacted_thinking", "data": "opaque", "redacted_thinking": "r" * 400}
+    block = {"type": "redacted_thinking", "data": "x" * 800}
     msgs = [{"role": "assistant", "content": [block]}]
-    assert _count_messages(msgs) > 0
+    assert _count_messages(msgs) > 0, "payload under `data` must reach the baseline"
     out, _store = compress_messages(msgs, verbatim=False)
     assert out[0]["content"][0] == block
+
+
+def test_baseline_and_census_agree_on_thinking_tokens():
+    """The two counters must not diverge, or savings percentages are wrong.
+
+    The census reads both payload keys; the baseline used to read one of them by the
+    wrong name, so a real redacted block was censused but absent from the baseline.
+    """
+    from distil.adapters.anthropic import compress_messages, take_census
+    from distil.proxy import _count_messages
+
+    for block in (
+        {"type": "thinking", "thinking": "deliberating " * 100, "signature": "s"},
+        {"type": "redacted_thinking", "data": "y" * 600},
+    ):
+        msgs = [{"role": "assistant", "content": [block]}]
+        baseline = _count_messages(msgs)
+        compress_messages(msgs, verbatim=False)
+        censused = (take_census() or {}).get("thinking_billed", 0)
+        assert baseline == censused, f"{block['type']}: {baseline} != {censused}"

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -741,3 +741,38 @@ def test_non_read_tool_output_still_digests():
         if isinstance(blk, dict) and str(blk.get("tool_use_id", "")).startswith("tu_b")
     ]
     assert any("handle=" in r for r in bash_results), "log output should still digest"
+
+
+# --- extended thinking --------------------------------------------------------
+def test_thinking_blocks_are_counted_but_never_rewritten():
+    """Thinking is billed on Claude 4.6+ and cannot be compressed — so it must at
+    least be VISIBLE.
+
+    The payload lives under `thinking`, not `text`, so it was counted by neither the
+    before nor the after side: real billed tokens absent from every percentage distil
+    reports. It stays byte-identical (the provider pins the block by signature and
+    re-expands it server-side, so editing it achieves nothing and risks rejection on
+    replay), but it is now censused.
+    """
+    from distil.adapters.anthropic import compress_messages, take_census
+    from distil.proxy import _count_messages
+
+    block = {"type": "thinking", "thinking": "deliberating " * 200, "signature": "sig"}
+    msgs = [{"role": "assistant", "content": [block]}]
+
+    assert _count_messages(msgs) > 0, "billed thinking must appear in the baseline"
+
+    out, _store = compress_messages(msgs, verbatim=False)
+    assert out[0]["content"][0] == block, "thinking must never be rewritten"
+    assert (take_census() or {}).get("thinking_billed", 0) > 0
+
+
+def test_redacted_thinking_is_also_counted_and_preserved():
+    from distil.adapters.anthropic import compress_messages
+    from distil.proxy import _count_messages
+
+    block = {"type": "redacted_thinking", "data": "opaque", "redacted_thinking": "r" * 400}
+    msgs = [{"role": "assistant", "content": [block]}]
+    assert _count_messages(msgs) > 0
+    out, _store = compress_messages(msgs, verbatim=False)
+    assert out[0]["content"][0] == block

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.50.0"
+version = "1.50.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## The tokens distil could not see

A thinking block carries its payload under `thinking`, not `text`, so `_count_messages` skipped it. Measured:

```
thinking block of 1000 chars  ->  counted as 0 tokens
```

On Claude 4.6+ prior-turn thinking is **re-sent as input and billed every turn**. So real billed tokens sat in neither the before nor the after side of every percentage distil reports — a blind spot in the denominator.

## Still never rewritten — and that's a finding, not caution

The provider pins each thinking block by its `signature` and re-expands the original server-side, so editing the text achieves nothing and risks the signature being rejected on replay. distil does not touch them.

But the one context cost distil *cannot* reduce should not also be the one it never shows you. Thinking now appears in the token baseline and as `thinking_billed` in the eligibility census.

## Verified

Both new tests confirmed to fail without the fix. `make gate` exit 0. **3513 tests pass, 95.16% coverage.** ruff + mypy clean.