### PR TITLE
release(1.50.1rc1): soak the agent-loop correctness work

### DIFF
--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
 version: 0.1.1
-appVersion: "1.50.1"
+appVersion: "1.50.1rc1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -6,8 +6,11 @@ description: >-
 type: application
 # Chart version tracks the chart; appVersion tracks the distil release it defaults to.
 # Bump `version` on any template change, `appVersion` on a distil upgrade.
+# NEVER set appVersion to an rc: release.yml skips the container build for rc tags
+# (an rc must not move `latest`), so the image that tag names is never published and
+# a default `helm install` would ImagePullBackOff. rc soakers install the wheel.
 version: 0.1.1
-appVersion: "1.50.1rc1"
+appVersion: "1.50.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.50.1",
+  "version": "1.50.1-rc.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.1rc1",
+  "version": "1.50.1-rc.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.1",
+  "version": "1.50.1rc1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.50.1"
+version = "1.50.1rc1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,8 +88,28 @@ ok "working tree clean"
 # version agreement across every surface that ships a version string
 # (distil/__init__.py is single-sourced from pyproject since 5e1173b — no literal to check)
 CITE_V="$(grep -E '^version:' CITATION.cff | sed -E 's/.*: *([0-9][^ ]*).*/\1/')"
+# npm and the Claude plugin manifest use SemVer, so an rc is `X.Y.Z-rc.N` there
+# while PEP 440 surfaces use `X.Y.ZrcN`. Derive both spellings once.
+SEMVER_V="$(printf '%s' "$VERSION" | sed -E 's/rc([0-9]+)$/-rc.\1/')"
+
 if [ "$IS_RC" -eq 1 ]; then
   info "rc release — CITATION.cff stays at the last citable final ($CITE_V)"
+  # Everything EXCEPT CITATION still gets checked. Skipping these on rcs recreated
+  # the very blind spot the checks were added for: plugin.json sat at 1.8.6 for 22
+  # releases because nothing checked it, and an unchecked rc is how it starts again.
+  PLUGIN_V="$(grep -E '^\s*"version":' plugins/distil/.claude-plugin/plugin.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  [ "$PLUGIN_V" = "$SEMVER_V" ] || die "plugin.json is $PLUGIN_V, expected $SEMVER_V (SemVer spelling of $VERSION)"
+  SERVER_V="$(grep -E '^\s*"version":' server.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  [ "$SERVER_V" = "$VERSION" ] || die "server.json is $SERVER_V, pyproject is $VERSION"
+  NPM_V="$(grep -E '^\s*"version":' packaging/npm/package.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+  [ "$NPM_V" = "$SEMVER_V" ] || die "packaging/npm/package.json is $NPM_V, expected $SEMVER_V"
+  # release.yml skips the container build for rc tags, so an rc appVersion would
+  # point a default `helm install` at an image that is never published.
+  CHART_V="$(grep -E '^appVersion:' packaging/helm/distil-gateway/Chart.yaml | sed -E 's/.*: *"?([^"]+)"?.*/\1/')"
+  case "$CHART_V" in
+    *rc*) die "Chart.yaml appVersion is $CHART_V — an rc image is never built; pin it to the last GA" ;;
+  esac
+  ok "rc versions consistent (plugin.json, server.json, npm as $SEMVER_V; chart pinned to $CHART_V)"
 else
   [ "$CITE_V" = "$VERSION" ] || die "CITATION.cff is $CITE_V, pyproject is $VERSION"
   # The Claude Code plugin manifest is a shipped surface too — it sat at 1.8.6 for

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.50.1",
+  "version": "1.50.1rc1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.50.1",
+      "version": "1.50.1rc1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_packaging_smoke.py
+++ b/tests/test_packaging_smoke.py
@@ -374,8 +374,12 @@ def test_claude_plugin_manifests_are_valid_and_current() -> None:
         assert manifest.exists(), f"{entry['name']}: no .claude-plugin/plugin.json"
         plugin = json.loads(manifest.read_text())
         assert plugin["name"] == entry["name"], "marketplace/plugin name mismatch"
-        assert plugin["version"] == version, (
-            f"plugin.json is {plugin['version']}, package is {version} — the plugin "
+        # The plugin manifest follows SemVer (like npm), so a PEP 440 rc `X.Y.ZrcN`
+        # is spelled `X.Y.Z-rc.N` here. Compare against that spelling rather than
+        # forcing a non-SemVer string a marketplace validator could reject.
+        expected = re.sub(r"rc(\d+)$", r"-rc.\1", version)
+        assert plugin["version"] == expected, (
+            f"plugin.json is {plugin['version']}, expected {expected} — the plugin "
             "manifest drifts silently because nothing bumps it at release time"
         )
 
@@ -456,6 +460,18 @@ def test_helm_chart_defaults_to_this_release() -> None:
             app = line.split(":", 1)[1].strip().strip('"').strip("'")
             break
     assert app, "Chart.yaml has no appVersion"
+
+    if "rc" in version:
+        # An rc is the one case where tracking the release is WRONG: release.yml
+        # skips the container build for rc tags (an rc must never move `latest`), so
+        # the image that tag names is never published and a default `helm install`
+        # would ImagePullBackOff. The chart must stay on the last GA; rc soakers
+        # install the wheel via pipx. Found by cross-audit on the 1.50.1rc1 release.
+        assert "rc" not in app, (
+            f"Chart.yaml appVersion is {app}, but no container image is built for rc "
+            f"tags — pin it to the last GA release instead"
+        )
+        return
     assert app == version, (
         f"Chart.yaml appVersion is {app} but this release is {version} — a default "
         f"`helm install` would deploy ghcr.io/dshakes/distil:{app}"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.50.1"
+version = "1.50.1rc1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Release candidate — soak before final

Three merged releases (1.49.0, 1.50.0, 1.50.1) changed the streaming request path, the token baseline, the cache path and the compression policy — with **zero hours of real use** between them.

PR #150 also showed a green local gate is not sufficient on its own: an independent cross-audit caught a bug my own tests endorsed, because the fixture was shaped like the implementation rather than like the wire format. That is precisely the class of defect bake time catches and review does not.

So this soaks as an rc first, per `RELEASING.md`.

## Versioning

- PEP 440 surfaces → `1.50.1rc1` (pyproject, server.json, plugin.json, helm appVersion)
- npm → `1.50.1-rc.1` (semver prerelease)
- `CITATION.cff` holds at the last **final** (1.50.1) — matching the `v1.47.0rc1` precedent
- CHANGELOG stays under `[1.50.1]` — the rc soaks *for* it

## Verified

Release preflight: **3514 passed, 2 skipped** — skip count matches CI exactly, so the preflight venv is not the silently-weaker-than-CI trap. Clean-wheel install smoke test passes (`distil 1.50.1rc1`, bench gate runs).

## After merge

Tag `v1.50.1rc1` → `release.yml` publishes the prerelease to PyPI (Homebrew and Docker skipped for rcs). Then a 3-day soak on real agent sessions, and re-measure `distil shadow-stats` — the proxy currently runs 1.48.1, so none of the fixes are live yet.