### PR TITLE
fix(1.50.2): a failure that healed itself was still reported as a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.50.2] — a failure that healed itself was still reported as a failure
+
+distil recorded **5,397 non-2xx requests across 18,455** and discarded the reason
+every time. Only the status survived, so the one question a broken session raises —
+*why?* — had no answer in distil's own logs, and `dissect` guessed on the user's
+behalf: *"upstream errors or rate limiting."*
+
+That guess spans two opposite diagnoses. "Your conversation outgrew the context
+window" means nothing is wrong with distil; "distil sent a malformed body" means
+everything is. A tool whose pitch is proof rather than trust should not be unable to
+tell those apart, and this one wasn't: the missing field caused a real misdiagnosis of
+a live session, where a size correlation looked causal and was not.
+
+Two things now get recorded:
+
+- **The provider's error `type`** (`invalid_request_error`, `rate_limit_error`, …) —
+  a short enum. The human message is deliberately NOT stored: it quotes request
+  content (`"prompt is too long: 231721 tokens > 200000"`). Streaming responses are
+  relayed frame-by-frame and never buffered, so those record `http_<status>`.
+- **Whether a retry recovered it.** A non-2xx immediately followed by a same-size 2xx
+  is the SDK doing its job. On the session that prompted this, **100% of the 400s were
+  retried and succeeded** — a ~30% "failure rate" in which nothing was ever lost.
+  Reporting that as failure sends people hunting a bug that already healed.
+
+Sessions recorded before this release report no reasons rather than an invented one.
+
 ## [1.50.1] — the tokens distil could not see
 
 Extended thinking carries its payload under `thinking`, not `text`, so distil counted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [1.50.2] — a counter could end a session
+
+**Session survival, not savings.** A proxy sits in the request path of a live agent
+session, so the contract is narrow: distil may fail to *compress*, but it must never
+fail to *serve*. It could.
+
+Token accounting — `_count_messages`, whose entire output is a response header and a
+ledger row — ran **unguarded** in the request path. Compression was protected, the
+retention meter was protected, but the counting was not. An exception there escaped
+the handler and closed the connection: the client saw `RemoteDisconnected` and the
+turn was lost. A tokenizer edge case on unusual content would have ended a live
+session over a number nobody reads in the moment.
+
+Now guarded, and the failure is honest about itself: a request whose counts did not
+compute goes **unbooked** rather than entering the savings ledger with a fabricated
+zero. A wrong number in the savings history is worse than a missing one — every
+published percentage derives from that ledger.
+
+Three end-to-end tests drive the real handler over a real socket, because a
+`try/except` in the source is a claim and only a served response is a measurement:
+a crash inside compression, a crash inside accounting, and a body distil cannot
+parse (forwarded as-is, so the provider's own error reaches the agent rather than
+one distil invented).
+
 ## [1.50.2] — a failure that healed itself was still reported as a failure
 
 distil recorded **5,397 non-2xx requests across 18,455** and discarded the reason

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.50.1
+version: 1.50.2
 date-released: 2026-08-24
 keywords:
   - llm

--- a/distil/dissect.py
+++ b/distil/dissect.py
@@ -250,6 +250,48 @@ class Dissection:
     def expand_resolved(self) -> int:
         return sum(1 for r in self.requests if r.get("expanded"))
 
+    def retried_and_recovered(self) -> int:
+        """Non-2xx requests immediately followed by a same-size 2xx — i.e. a retry
+        that worked.
+
+        Without this a session reads as ~30% failing when nothing was actually lost:
+        the SDK retried and succeeded every time. Distinguishing "transient, healed"
+        from "fatal" is the whole value of the number — a rate alone caused a real
+        misdiagnosis of a live session (a size correlation that looked causal and
+        was not).
+        """
+        rows = sorted(self.requests, key=lambda r: r.get("ts") or 0)
+
+        def size(r: dict[str, Any]) -> int:
+            return int(r.get("compressible_tokens") or 0) + int(r.get("overhead_tokens") or 0)
+
+        n = 0
+        for i, r in enumerate(rows):
+            st = r.get("status")
+            if isinstance(st, int) and 200 <= st < 300:
+                continue
+            nxt = rows[i + 1] if i + 1 < len(rows) else None
+            if not nxt:
+                continue
+            nst = nxt.get("status")
+            if isinstance(nst, int) and 200 <= nst < 300 and abs(size(nxt) - size(r)) <= 2000:
+                n += 1
+        return n
+
+    def error_reasons(self) -> list[tuple[str, int]]:
+        """Provider error types for the non-2xx requests, most frequent first.
+
+        Recorded per request as a short enum (`invalid_request_error`,
+        `rate_limit_error`, …). Never the human message, which can quote content.
+        Empty for sessions captured before 1.50.2, which recorded only the status.
+        """
+        counts: dict[str, int] = {}
+        for r in self.requests:
+            et = r.get("error_type")
+            if isinstance(et, str) and et:
+                counts[et] = counts.get(et, 0) + 1
+        return sorted(counts.items(), key=lambda kv: -kv[1])
+
     @property
     def expand_missed(self) -> int:
         """Handles the agent asked for that the store could not return.
@@ -530,9 +572,28 @@ class Dissection:
                 "DISTIL_RESTORE_CAP or DISTIL_RESTORE_TTL_DAYS)"
             )
         if n >= 5 and self.unbooked_requests / n > 0.2:
+            # Name the actual reason. "upstream errors or rate limiting" was a guess
+            # dressed as a diagnosis, and it is the difference between "your prompt
+            # exceeded the context window" (nothing to fix in distil) and "distil sent
+            # a malformed body" (everything to fix) — opposite conclusions from the
+            # same line.
+            why = self.error_reasons()
+            recovered = self.retried_and_recovered()
+            detail = ""
+            if why:
+                detail = " — " + ", ".join(f"{k} x{v}" for k, v in why)
+            if recovered:
+                # The difference between "your session is broken" and "the SDK did its
+                # job". A non-2xx immediately followed by a 2xx of the same size is a
+                # retry that worked: no work was lost, and reporting it as a failure
+                # sends people hunting a bug that already healed itself.
+                detail += (
+                    f"\n                   {recovered} of them were retried "
+                    "immediately and SUCCEEDED — transient, no work lost"
+                )
             out.append(
                 f"{self.unbooked_requests}/{n} requests were not booked (non-2xx or "
-                "SDK-retried) — upstream errors or rate limiting during this session"
+                f"SDK-retried){detail}"
             )
         if flags.get("lossless_only") and self.billing == "metered":
             out.append(

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -980,9 +980,23 @@ def build_handler(
                 # Live retention meter: sampled, content-free (counts only), fail-open.
                 if _retention_meter is not None and _retention_meter.enabled:
                     _retention_meter.observe(original, compressed, store)
-                before_tok = _count_messages(original)
-                after_tok = _count_messages(compressed)
-                saved = max(0, before_tok - after_tok)
+                # Accounting is bookkeeping, and bookkeeping must never be
+                # load-bearing for the response. These feed headers and the savings
+                # ledger only, yet an exception here escaped the handler and closed
+                # the connection — the client saw RemoteDisconnected and the turn was
+                # lost. A tokenizer edge case on unusual content would end a live
+                # session over a number nobody reads in the moment.
+                try:
+                    before_tok = _count_messages(original)
+                    after_tok = _count_messages(compressed)
+                except Exception:  # noqa: BLE001 — a counter must never break a request
+                    log.debug("token accounting failed; serving without it", exc_info=True)
+                    before_tok = after_tok = None
+                saved = (
+                    max(0, before_tok - after_tok)
+                    if before_tok is not None and after_tok is not None
+                    else 0
+                )
                 body = {**body, "messages": compressed}
                 extras = {
                     "x-distil-compressed": "1",
@@ -992,7 +1006,11 @@ def build_handler(
                     # allowed to touch) — when this is ~0, a ▼0 is "nothing large
                     # to compress this turn", not a failure. System prompt, tool
                     # definitions, images and assistant text are never counted.
-                    "x-distil-compressible-tokens": str(_count_messages(original)),
+                    # Reuse the already-computed count rather than a third traversal
+                    # that could raise after the guarded pair above succeeded.
+                    "x-distil-compressible-tokens": str(
+                        before_tok if before_tok is not None else 0
+                    ),
                 }
                 if _dstats is not None:
                     extras["x-distil-cache-refs"] = str(_dstats.exact_refs + _dstats.delta_refs)
@@ -1022,7 +1040,11 @@ def build_handler(
                     body = inject_expand_tool(body)
                 # Accumulate GENUINE savings from real traffic into the ledger,
                 # priced per the model THIS request names (agents mix models).
-                if savings is not None:
+                # Only when the counts are real: if accounting failed above, this
+                # request goes unbooked rather than entering the ledger with a
+                # fabricated zero. A wrong number in the savings history is worse
+                # than a missing one — every published percentage derives from it.
+                if savings is not None and before_tok is not None and after_tok is not None:
                     _pending_savings = (before_tok, after_tok, body.get("model"))
                 # Output compression: gated by lossless_only (only on PAYG-style).
                 if shape_output != "off" and _lossy_ok:

--- a/distil/proxy.py
+++ b/distil/proxy.py
@@ -83,6 +83,31 @@ def _has_recoverable_stub(body: dict) -> bool:
     return _HANDLE_STUB_RE.search(blob) is not None
 
 
+def _upstream_error_type(status: int, rbody: bytes) -> str | None:
+    """The provider's error `type` for a failed request — content-free.
+
+    Anthropic and OpenAI both return ``{"error": {"type": ..., "message": ...}}``.
+    The type is a short enum (``invalid_request_error``, ``rate_limit_error``,
+    ``overloaded_error``); the message can quote request content, so it is never
+    stored. Returns None for a success or an unparseable body.
+
+    Without this a non-2xx recorded only its status, which cannot distinguish "your
+    prompt exceeded the context limit" from "distil corrupted the body" — the two
+    diagnoses with opposite fixes.
+    """
+    if 200 <= status < 300:
+        return None
+    try:
+        err = (json.loads(rbody) or {}).get("error")
+        if isinstance(err, dict):
+            t = err.get("type")
+            if isinstance(t, str) and len(t) <= 64:
+                return t
+    except (ValueError, TypeError, AttributeError):
+        pass
+    return f"http_{status}"
+
+
 def _serialize_if_changed(raw: bytes, body: dict[str, Any]) -> bytes:
     """Return the ORIGINAL bytes when the body is unchanged; re-serialize only if not.
 
@@ -1136,6 +1161,9 @@ def build_handler(
                     ),
                     duration_ms=int((time.monotonic() - t_req) * 1000),
                     usage=_usage_x,
+                    # Streaming path: the body was relayed frame-by-frame and never
+                    # buffered, so only the status is knowable here.
+                    error_type=_upstream_error_type(status_x, b""),
                 )
                 if shadow_sampled:
                     self._spawn_shadow(raw, headers, new_raw)
@@ -1188,6 +1216,7 @@ def build_handler(
                     ),
                     duration_ms=int((time.monotonic() - t_req) * 1000),
                     usage=_usage_s,
+                    error_type=_upstream_error_type(status_s, b""),
                 )
                 if shadow_sampled:
                     self._spawn_shadow(raw, headers, new_raw)
@@ -1293,6 +1322,7 @@ def build_handler(
                 ),
                 duration_ms=int((time.monotonic() - t_req) * 1000),
                 usage=_usage_b,
+                error_type=_upstream_error_type(status, rbody),
                 expanded_handles=_expanded_handles,
             )
             # Book savings only after a confirmed 2xx (P0-1): failed or SDK-retried
@@ -1317,6 +1347,7 @@ def build_handler(
             duration_ms: int | None = None,
             usage: dict[str, int] | None = None,
             expanded_handles: list[str] | None = None,
+            error_type: str | None = None,
         ) -> None:
             """Append one content-free per-request record to the wrap session's
             ``sessions/<sid>.requests.jsonl`` (read by ``distil dissect``).
@@ -1444,6 +1475,14 @@ def build_handler(
                     "stream": stream,
                     "client_stream": client_stream,
                     "status": status,
+                    # WHY a request failed, not merely that it did. 5,397 of 18,455
+                    # recorded requests were non-2xx with the reason discarded, so the
+                    # single most common question about a distil session — "what went
+                    # wrong?" — had no answer in distil's own logs. The provider's
+                    # error `type` is a short enum (invalid_request_error,
+                    # rate_limit_error, overloaded_error, …); the human message is NOT
+                    # stored, since it can quote request content.
+                    "error_type": error_type,
                     "booked": booked,
                     "duration_ms": duration_ms,
                     "usage_input_tokens": (usage or {}).get("input_tokens"),

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # (an rc must not move `latest`), so the image that tag names is never published and
 # a default `helm install` would ImagePullBackOff. rc soakers install the wheel.
 version: 0.1.1
-appVersion: "1.50.1"
+appVersion: "1.50.2"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.50.1-rc.1",
+  "version": "1.50.2",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.1-rc.1",
+  "version": "1.50.2",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.50.1rc1"
+version = "1.50.2"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.50.1rc1",
+  "version": "1.50.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.50.1rc1",
+      "version": "1.50.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_dissect.py
+++ b/tests/test_dissect.py
@@ -1293,3 +1293,94 @@ class TestEligibility:
         text = dz.render_text(dz.dissect(sid), color=False)
         assert "the design holding" in text
         assert "compressor's to explain" not in text
+
+
+class TestErrorReasons:
+    """A non-2xx must record WHY, not only that it failed."""
+
+    @staticmethod
+    def _d(requests):
+        d = dz.Dissection.__new__(dz.Dissection)
+        object.__setattr__(d, "requests", requests)
+        return d
+
+    def test_error_types_are_counted_most_frequent_first(self) -> None:
+        d = self._d(
+            [
+                {"status": 400, "error_type": "invalid_request_error"},
+                {"status": 400, "error_type": "invalid_request_error"},
+                {"status": 429, "error_type": "rate_limit_error"},
+                {"status": 200},
+            ]
+        )
+        assert d.error_reasons() == [("invalid_request_error", 2), ("rate_limit_error", 1)]
+
+    def test_sessions_recorded_before_the_field_existed_report_nothing(self) -> None:
+        """Old rows carry only a status — report no reasons rather than inventing one."""
+        d = self._d([{"status": 400}, {"status": 200}])
+        assert d.error_reasons() == []
+
+
+def test_upstream_error_type_is_content_free():
+    """The provider's error TYPE is kept; its message is not — it quotes content."""
+    from distil.proxy import _upstream_error_type
+
+    body = (
+        b'{"error":{"type":"invalid_request_error",'
+        b'"message":"prompt is too long: 231721 tokens > 200000 maximum"}}'
+    )
+    assert _upstream_error_type(400, body) == "invalid_request_error"
+    assert _upstream_error_type(200, b"{}") is None, "a success has no error type"
+    # Streaming responses are relayed frame-by-frame and never buffered.
+    assert _upstream_error_type(400, b"") == "http_400"
+    assert _upstream_error_type(500, b"<html>not json</html>") == "http_500"
+
+    # The message must never reach the record.
+    for probe in (b"", b'{"error":{"type":"x","message":"secret content"}}'):
+        got = _upstream_error_type(400, probe) or ""
+        assert "secret" not in got and "231721" not in got
+
+
+class TestRetryRecovery:
+    """A retried-and-succeeded failure is not a failure the user must act on."""
+
+    @staticmethod
+    def _d(requests):
+        d = dz.Dissection.__new__(dz.Dissection)
+        object.__setattr__(d, "requests", requests)
+        return d
+
+    def test_a_failure_followed_by_a_same_size_success_is_recovered(self) -> None:
+        """The real pattern from a live session: 400 at 420,136 tokens, then an
+        immediate 200 at the same size. The SDK retried; no work was lost."""
+        d = self._d(
+            [
+                {"ts": 1, "status": 400, "compressible_tokens": 420_000, "overhead_tokens": 136},
+                {"ts": 2, "status": 200, "compressible_tokens": 420_000, "overhead_tokens": 136},
+            ]
+        )
+        assert d.retried_and_recovered() == 1
+
+    def test_a_failure_with_no_retry_is_not_counted_as_recovered(self) -> None:
+        d = self._d([{"ts": 1, "status": 400, "compressible_tokens": 1000}])
+        assert d.retried_and_recovered() == 0
+
+    def test_an_unrelated_later_success_is_not_a_retry(self) -> None:
+        """A 2xx of a very different size is the next turn, not a retry of this one."""
+        d = self._d(
+            [
+                {"ts": 1, "status": 400, "compressible_tokens": 400_000},
+                {"ts": 2, "status": 200, "compressible_tokens": 5_000},
+            ]
+        )
+        assert d.retried_and_recovered() == 0
+
+    def test_rows_are_ordered_by_timestamp_not_file_order(self) -> None:
+        d = self._d(
+            [
+                {"ts": 9, "status": 200, "compressible_tokens": 100_000},
+                {"ts": 1, "status": 400, "compressible_tokens": 100_000},
+                {"ts": 2, "status": 200, "compressible_tokens": 100_000},
+            ]
+        )
+        assert d.retried_and_recovered() == 1

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -351,3 +351,87 @@ def test_expand_tool_is_injected_before_any_handle_exists():
     again = inject_expand_tool(out)
     assert sum(t["name"] == EXPAND_TOOL_NAME for t in again["tools"]) == 1
     assert again["tools"] == out["tools"], "the tools array must be byte-stable across turns"
+
+
+# --- session survival ---------------------------------------------------------
+# A proxy sits in the request path of a live agent session. Anything it does badly
+# ends someone's work, so the contract is narrow: distil may fail to COMPRESS, but
+# it must never fail to SERVE. These drive the real handler over a real socket, so
+# they fail if any layer between the client and upstream drops the request.
+def test_a_crash_inside_compression_still_serves_the_request(
+    servers: Any, monkeypatch: Any
+) -> None:
+    """If distil's own compressor raises, the turn must still complete uncompressed.
+
+    This is the difference between "we saved fewer tokens today" and "the user's
+    session died". A guarded try/except in the source is a claim; this drives the
+    real request path over a socket to make it a measurement.
+    """
+    import distil.adapters.anthropic as an
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise RuntimeError("synthetic compressor failure")
+
+    # Fault-inject inside the adapter the proxy actually calls. Patching the proxy's
+    # module-level alias would not reach the handler, which resolved it at import.
+    monkeypatch.setattr(an, "_compress_tool_result_text", _boom)
+
+    proxy_port, _ = servers
+    payload = {
+        "model": "claude-opus-4-5",
+        "max_tokens": 256,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": _LONG_TOOL_RESULT}
+                ],
+            },
+            {"role": "user", "content": "next"},
+            {"role": "user", "content": "next"},
+        ],
+    }
+    with urllib.request.urlopen(_post(proxy_port, "/v1/messages", payload)) as resp:
+        assert resp.status == 200, "a compressor crash must not fail the request"
+        echoed = json.loads(resp.read())
+    # The full conversation must reach upstream. Whether this particular turn ended
+    # up compressed is not the point — no message may be lost, and the turn must
+    # complete. Asserting byte-verbatim content would over-specify: other digest
+    # paths remain live, and any of them producing a RECOVERABLE digest is fine.
+    assert len(echoed["messages"]) == 3, "no message may be dropped by a failure"
+    assert echoed["messages"][1]["content"] == "next"
+    assert echoed["messages"][2]["content"] == "next"
+
+
+def test_a_crash_in_token_counting_still_serves_the_request(servers: Any, monkeypatch: Any) -> None:
+    """Accounting is bookkeeping. It must never be load-bearing for the response."""
+    import distil.proxy as px
+
+    def _boom(*_a: Any, **_kw: Any) -> int:
+        raise RuntimeError("synthetic counter failure")
+
+    monkeypatch.setattr(px, "_count_messages", _boom, raising=True)
+
+    proxy_port, _ = servers
+    payload = {
+        "model": "claude-opus-4-5",
+        "max_tokens": 256,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    with urllib.request.urlopen(_post(proxy_port, "/v1/messages", payload)) as resp:
+        assert resp.status == 200
+        assert json.loads(resp.read())["messages"][0]["content"] == "hello"
+
+
+def test_a_malformed_body_is_forwarded_rather_than_rejected(servers: Any) -> None:
+    """distil is not the API's validator. A body it cannot parse goes upstream as-is,
+    so the provider's own error reaches the agent instead of distil inventing one."""
+    proxy_port, _ = servers
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{proxy_port}/v1/messages",
+        data=b"{not valid json at all",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 200, "the echo upstream accepted it — distil did not block"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.50.1rc1"
+version = "1.50.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## The missing field

distil recorded **5,397 non-2xx requests across 18,455** and discarded the reason every time. Only the status survived.

So the question a broken session actually raises — *why?* — had no answer in distil's own logs, and `dissect` guessed on the user's behalf:

> "upstream errors or rate limiting"

That guess spans two opposite diagnoses. *"The conversation outgrew the context window"* means nothing is wrong with distil. *"distil sent a malformed body"* means everything is. A tool whose pitch is proof rather than trust should not be unable to tell them apart.

**This is not hypothetical.** The missing field caused a real misdiagnosis of a live session: a size correlation (every 400 above 284k tokens, no 400 below) looked causal, and was not.

## What gets recorded now

**1. The provider's error `type`** — `invalid_request_error`, `rate_limit_error`, … A short enum.

The human message is deliberately **not** stored, because it quotes request content: `"prompt is too long: 231721 tokens > 200000"`. A test asserts the message cannot leak into the record.

Streaming responses are relayed frame-by-frame and never buffered, so those record `http_<status>` from the status alone rather than pretending to parse a body that was never held.

**2. Whether a retry already recovered it.** A non-2xx immediately followed by a same-size 2xx is the SDK doing its job:

```
400   420,136 tokens    822ms   ← fails fast
200   420,136 tokens  32,313ms  ← same request, succeeds
```

On the session that prompted this, **100% of the 400s were retried and succeeded** — a ~30% "failure rate" in which nothing was ever lost. Reporting that as failure sends people hunting a bug that already healed itself.

Sessions recorded before this release report **no** reasons rather than an invented one.

## Verified

`make gate` clean. **3521 tests pass, 95.16% coverage.** ruff + mypy clean. Seven new tests, including content-freedom of the recorded type and the ordering rule (rows sorted by timestamp, not file order).