### PR TITLE
release(1.50.2rc2): soak the session-survival fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ a crash inside compression, a crash inside accounting, and a body distil cannot
 parse (forwarded as-is, so the provider's own error reaches the agent rather than
 one distil invented).
 
-## [1.50.2] — a failure that healed itself was still reported as a failure
+### A failure that healed itself was still reported as a failure
 
 distil recorded **5,397 non-2xx requests across 18,455** and discarded the reason
 every time. Only the status survived, so the one question a broken session raises —

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.50.2",
+  "version": "1.50.2-rc.2",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.2",
+  "version": "1.50.2-rc.2",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.50.2"
+version = "1.50.2rc2"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.50.2",
+  "version": "1.50.2rc2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.50.2",
+      "version": "1.50.2rc2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.50.2"
+version = "1.50.2rc2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why rc2 rather than soaking rc1

`v1.50.1rc1` is on PyPI, but it carries a **known session-killer**: token accounting ran unguarded in the request path, so an exception in a counter closed the connection and lost the turn (`RemoteDisconnected`). Soaking that build would be soaking the wrong one.

1.50.2 fixes it, and adds three end-to-end survival tests that drive the real handler over a real socket — a `try/except` in source is a claim; only a served response is a measurement.

## Versioning (per the v1.47.0rc1 precedent, plus what the last audit caught)

| surface | value | why |
|---|---|---|
| pyproject, server.json | `1.50.2rc2` | PEP 440 |
| npm, plugin.json | `1.50.2-rc.2` | SemVer — a non-SemVer string risks marketplace rejection |
| helm `appVersion` | `1.50.2` (last GA) | **release.yml builds no image for rc tags** — an rc appVersion points a default `helm install` at an image that never exists |
| CITATION.cff | `1.50.2` | stays at the last citable final |

The release script now enforces all four on rcs; before the previous audit it skipped these checks entirely when `IS_RC=1`.

## Also here

The two `## [1.50.2]` changelog entries were written separately and collided on the same version heading. Merged under one, with the second finding as a subsection.

## Verified

`make gate` exit 0. **3524 tests pass, 95.16% coverage.** All 16 packaging guards green. ruff + mypy clean.