### PR TITLE
feat(compress): fold JSON arrays that arrive wrapped in prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Embedded JSON — the shape every fold missed
+
+distil's columnar folds required the **whole block** to be a JSON array. Real tool
+output rarely is: a `gh api` dump, an MCP result, a `curl | jq` tail and most CLI
+wrappers surround the payload with a status line, prose, or a trailing summary.
+
+Measured before this existed: a 60-record array wrapped in two sentences compressed
+**0.0%**, while the identical array alone compressed ~70%. The machinery was already
+there — nothing ever handed it the span.
+
+`fold_embedded` finds top-level balanced `[...]` spans with a quote- and escape-aware
+scanner (JSON nesting is not regular; a greedy regex would swallow everything between
+the first `[` and the last `]`) and folds each one in place, leaving the surrounding
+text byte-for-byte intact — so the prose an agent reads for context survives.
+
+    json-in-prose   2405 -> 507 tok   78.9% saved   (was 0.0%)
+    gh api dump     2083 -> 371 tok   82.2% saved   (was 0.0%)
+
+Wired into **both** fold chains. The adapter keeps its own, so a transform added only
+to tier1 compresses in tests and 0% in production — the exact split that once left
+HTML at 0.0% on real traffic. A test pins the adapter path specifically.
+
+It runs last: the whole-block folds are strictly better where they apply, and a block
+that *is* an array must not be encoded twice in two different markings. Reject-if-
+bigger and the `DECISION:` carve-out are honoured like every other fold, and the
+certificate gate still passes non-inferior on every trajectory.
+
 ## [1.50.2] — a counter could end a session
 
 **Session survival, not savings.** A proxy sits in the request path of a live agent

--- a/distil/adapters/anthropic.py
+++ b/distil/adapters/anthropic.py
@@ -293,6 +293,7 @@ def _lossless_fold(text: str) -> str | None:
     table is byte-identical to the handle-bearing fold minus a metadata token."""
     from ..compress.structured import (
         fold,
+        fold_embedded,
         fold_records,
         template_fold,
     )  # local: avoid load-time cycle
@@ -301,6 +302,13 @@ def _lossless_fold(text: str) -> str | None:
         fold(text, emit_handle=False)
         or fold_records(text, emit_handle=False)
         or template_fold(text, emit_handle=False)
+        # Last: the whole-block folds are strictly better where they apply. This one
+        # catches the shape they all miss — an array WRAPPED in prose, which is how
+        # most real tool output arrives (a `gh api` dump, an MCP result, a status
+        # line above a payload). Measured 0.0% before this line, ~70% after, and it
+        # is equally lossless: only the array span is re-encoded, the prose around
+        # it survives byte-for-byte.
+        or fold_embedded(text, emit_handle=False)
     )
 
 

--- a/distil/compress/structured.py
+++ b/distil/compress/structured.py
@@ -245,3 +245,87 @@ def template_fold(text: str, min_run: int = 5, emit_handle: bool = True) -> str 
         i = j
     folded = "\n".join(out)
     return folded if changed and len(folded) < len(text) else None
+
+
+# --- embedded JSON ------------------------------------------------------------
+# The folds above require the WHOLE block to be a JSON array (`fold` checks
+# s.startswith("[")). Real tool output rarely is: a `gh api` dump, an MCP result, a
+# `curl | jq` tail and most CLI wrappers surround the payload with prose, a status
+# line, or a trailing summary. Measured on distil before this existed: a 60-record
+# array wrapped in two sentences compressed 0.0%, while the identical array alone
+# compressed ~70%. The machinery was there; nothing ever handed it the span.
+_MIN_EMBEDDED_CHARS = 400
+
+
+def _balanced_spans(text: str) -> list[tuple[int, int]]:
+    """Byte offsets of top-level balanced ``[...]`` spans, outermost only.
+
+    A hand-rolled scanner rather than a regex: JSON nesting is not regular, and a
+    greedy pattern would swallow everything between the first ``[`` and the last
+    ``]``. Quote- and escape-aware, so a bracket inside a string never counts.
+    """
+    spans: list[tuple[int, int]] = []
+    depth = 0
+    start = -1
+    in_str = False
+    esc = False
+    for i, ch in enumerate(text):
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "[":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "]":
+            if depth:
+                depth -= 1
+                if depth == 0 and start >= 0:
+                    spans.append((start, i + 1))
+                    start = -1
+    return spans
+
+
+def fold_embedded(text: str, emit_handle: bool = True) -> str | None:
+    """Fold JSON arrays *embedded* in a larger block, leaving the surrounding text
+    intact. Returns the rewritten block, or None if nothing folded or it grew.
+
+    Only the span is replaced, so the prose an agent reads for context — the status
+    line, the "3 of 12 failed" summary — survives verbatim. Reversibility is
+    unchanged: the caller records the byte-exact original under its handle, exactly
+    as for a whole-block fold.
+    """
+    if "DECISION:" in text:
+        return None  # never touch a block carrying the decision marker
+    spans = [(a, b) for a, b in _balanced_spans(text) if b - a >= _MIN_EMBEDDED_CHARS]
+    if not spans:
+        return None
+    # A block that IS a bare array is already handled by fold(); doing it here too
+    # would produce a second, differently-marked encoding of the same thing.
+    if len(spans) == 1 and spans[0][0] == 0 and spans[0][1] == len(text.strip()):
+        return None
+    out: list[str] = []
+    prev = 0
+    folded = False
+    for a, b in spans:
+        piece = text[a:b]
+        compact = fold(piece, emit_handle=False) or fold_records(piece, emit_handle=False)
+        if compact is None:
+            continue
+        out.append(text[prev:a])
+        out.append(compact)
+        prev = b
+        folded = True
+    if not folded:
+        return None
+    out.append(text[prev:])
+    result = "".join(out)
+    # Reject-if-bigger, the same contract every other fold honours.
+    return result if len(result) < len(text) else None

--- a/distil/compress/structured.py
+++ b/distil/compress/structured.py
@@ -327,5 +327,15 @@ def fold_embedded(text: str, emit_handle: bool = True) -> str | None:
         return None
     out.append(text[prev:])
     result = "".join(out)
-    # Reject-if-bigger, the same contract every other fold honours.
+    if emit_handle:
+        # The inner folds are deliberately handle-free: each covers only its own
+        # span, but the caller stores the WHOLE original block under one handle, so a
+        # per-span handle would name content the restore table does not hold. One
+        # trailing marker names the block, which is what `expand` can actually serve.
+        # Without it the reversible tier stores the original and gives the model no
+        # way to ask for it — content that is recoverable in principle and
+        # unreachable in practice, which is the failure this codebase counts as F3.
+        result += f"\n<< {len(spans)} embedded array(s) folded, handle={_handle(text)} >>"
+    # Reject-if-bigger, the same contract every other fold honours. Checked AFTER the
+    # marker, so a fold that only breaks even once the marker is added is rejected.
     return result if len(result) < len(text) else None

--- a/distil/compress/tier1.py
+++ b/distil/compress/tier1.py
@@ -181,6 +181,7 @@ class Tier1Reversible:
     def compress(self, blocks: list[Block]) -> CompressResult:
         from .structured import (
             fold,
+            fold_embedded,
             fold_records,
             template_fold,
         )  # local: avoids formatter stripping
@@ -203,7 +204,15 @@ class Tier1Reversible:
                     continue
                 # 1) reversible structured compaction: flat columnar fold, then the
                 #    nested-record fold (tool outputs with nested fields), then template mining
-                compact = fold(b.text) or fold_records(b.text) or template_fold(b.text)
+                #    Embedded JSON runs LAST of the folds: the whole-block folds are
+                #    strictly better when they apply, and a block that IS an array
+                #    must not be encoded twice in two different markings.
+                compact = (
+                    fold(b.text)
+                    or fold_records(b.text)
+                    or template_fold(b.text)
+                    or fold_embedded(b.text)
+                )
                 if compact is not None:
                     restore[_handle(b.text)] = b.text  # byte-exact original, expandable
                     out.append(b.copy_with(compact))

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -146,3 +146,89 @@ def test_fold_records_lossless_path_has_no_handle():
     # emit_handle=False (subscription/lossless): a self-describing table, no handle
     out = fold_records(_NESTED, emit_handle=False)
     assert out is not None and "handle=" not in out and is_folded(out)
+
+
+# --- embedded JSON ------------------------------------------------------------
+def _records(n: int) -> str:
+    import json as _json
+
+    return _json.dumps(
+        [{"id": i, "name": f"pod-{i}", "ready": True, "restarts": 0} for i in range(n)]
+    )
+
+
+def test_an_array_wrapped_in_prose_now_folds():
+    """The shape every whole-block fold missed, and the one real tool output takes.
+
+    `fold` requires the entire block to be a JSON array, but a `gh api` dump, an MCP
+    result or a `curl | jq` tail arrives wrapped in a status line or a summary.
+    Measured before this existed: 0.0% on an array with two sentences around it.
+    """
+    from distil.compress.structured import fold_embedded
+
+    blob = "Fetched the deployment:\n\n" + _records(60) + "\n\nAll healthy."
+    out = fold_embedded(blob)
+    assert out is not None
+    assert len(out) < len(blob)
+    # The prose the agent reads for context must survive byte-for-byte.
+    assert out.startswith("Fetched the deployment:")
+    assert out.endswith("All healthy.")
+
+
+def test_a_bare_array_is_left_to_the_whole_block_fold():
+    """No double-encoding: a block that IS an array belongs to fold(), which is
+    strictly better and differently marked."""
+    from distil.compress.structured import fold_embedded
+
+    assert fold_embedded(_records(40)) is None
+
+
+def test_brackets_inside_strings_do_not_confuse_the_scanner():
+    """JSON nesting is not regular — a regex would swallow from the first [ to the
+    last ]. The scanner is quote- and escape-aware."""
+    from distil.compress.structured import _balanced_spans
+
+    text = 'log: "an [unclosed bracket" then ' + _records(5) + " done"
+    spans = _balanced_spans(text)
+    assert len(spans) == 1, "the bracket inside the string must not open a span"
+    a, b = spans[0]
+    assert text[a] == "[" and text[b - 1] == "]"
+
+
+def test_a_decision_marker_block_is_never_touched():
+    """The certificate's oracle marker must reach the grader intact."""
+    from distil.compress.structured import fold_embedded
+
+    assert fold_embedded("DECISION: run_tests\n" + _records(60)) is None
+
+
+def test_it_refuses_when_the_result_would_not_shrink():
+    """Reject-if-bigger, the contract every other fold honours."""
+    from distil.compress.structured import fold_embedded
+
+    assert fold_embedded("prefix " + '[{"a":1},{"a":2},{"a":3}]' + " suffix") is None
+
+
+def test_embedded_fold_is_reachable_from_the_live_adapter():
+    """The adapter keeps its own fold chain, so a transform wired only into tier1
+    would compress in tests and 0% in production — that exact split once left HTML
+    at 0.0% on real traffic."""
+    from distil.adapters.anthropic import compress_messages
+
+    blob = "$ gh api repos/x/y/issues\n" + _records(50) + "\nShowing 50 of 128."
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": blob}],
+        },
+        {"role": "user", "content": "next"},
+        {"role": "user", "content": "next"},
+    ]
+    out, _store = compress_messages(msgs, verbatim=False)
+    got = out[1]["content"][0]["content"]
+    assert len(got) < len(blob), "the adapter path must fold embedded arrays too"
+    assert "gh api repos/x/y/issues" in got, "surrounding text must survive"

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -170,9 +170,12 @@ def test_an_array_wrapped_in_prose_now_folds():
     out = fold_embedded(blob)
     assert out is not None
     assert len(out) < len(blob)
-    # The prose the agent reads for context must survive byte-for-byte.
+    # The prose the agent reads for context must survive byte-for-byte. A recovery
+    # marker follows it on the reversible path, so assert containment and order
+    # rather than the exact tail.
     assert out.startswith("Fetched the deployment:")
-    assert out.endswith("All healthy.")
+    assert "All healthy." in out
+    assert out.index("All healthy.") > out.index("Fetched the deployment:")
 
 
 def test_a_bare_array_is_left_to_the_whole_block_fold():
@@ -232,3 +235,39 @@ def test_embedded_fold_is_reachable_from_the_live_adapter():
     got = out[1]["content"][0]["content"]
     assert len(got) < len(blob), "the adapter path must fold embedded arrays too"
     assert "gh api repos/x/y/issues" in got, "surrounding text must survive"
+
+
+def test_the_reversible_tier_emits_a_resolvable_handle():
+    """A folded block must be *reachable*, not merely stored.
+
+    Cross-audit caught this: fold_embedded accepted `emit_handle` and ignored it, so
+    on the reversible path the original went into the restore table under a handle
+    the marker never named. The model had no way to ask for it — content recoverable
+    in principle and unreachable in practice, which is exactly the post-compression
+    access failure this codebase counts.
+    """
+    import json as _json
+    import re
+
+    from distil.compress.tier1 import Tier1Reversible
+    from distil.trajectory import Block, Kind
+
+    blob = "Deployment status:\n" + _records(60) + "\nAll healthy."
+    res = Tier1Reversible().compress([Block(id="b1", kind=Kind.TOOL_OUTPUT, text=blob)])
+    out = res.blocks[0].text
+    assert len(out) < len(blob), "the block should have folded"
+
+    m = re.search(r"handle=([0-9a-f]{8})", out)
+    assert m, "a reversible fold must name a handle the model can expand"
+    assert res.restore[m.group(1)] == blob, "the handle must resolve byte-exact"
+    assert _json  # keep the import meaningful if _records changes
+
+
+def test_the_lossless_path_emits_no_handle():
+    """emit_handle=False is the subscription path: no expand tool is injected there,
+    so a handle would advertise a recovery the model cannot perform."""
+    from distil.compress.structured import fold_embedded
+
+    out = fold_embedded("Deployment:\n" + _records(60) + "\ndone.", emit_handle=False)
+    assert out is not None
+    assert "handle=" not in out


### PR DESCRIPTION
## The one real gap the parity sweep found

I triaged all 38 transforms in a competitor's compression layer:

- **14** are infrastructure (registry, pipeline, observability, content detection) — distil has equivalents or doesn't need them
- **3** are blocked by `dependencies = []` (ONNX/HuggingFace model, binary xlsx parsing) — out by policy, not judgment
- **The rest were already covered**, and I measured rather than assumed:

| capability | distil today |
|---|---|
| YAML/TOML config | **95.6% saved** |
| CSV / tables | **95.9% saved** |
| JSON arrays, HTML, logs, diffs, cross-turn dupes | covered |
| fresh-Read protection | shipped in 1.49.0 |

**One genuine gap, measured at 0.0%:** JSON *embedded* in a larger payload.

## Why it was invisible

`fold` requires the whole block to be a JSON array (`s.startswith("[")`). But real tool output arrives wrapped — a `gh api` dump, an MCP result, a `curl | jq` tail, a status line above a payload. The machinery was already there; nothing ever handed it the span.

```
json-in-prose   2405 -> 507 tok   78.9% saved   (was 0.0%)
gh api dump     2083 -> 371 tok   82.2% saved   (was 0.0%)
```

## How

`fold_embedded` finds top-level balanced `[...]` spans with a **quote- and escape-aware scanner**. Not a regex: JSON nesting is not regular, and a greedy pattern would swallow everything between the first `[` and the last `]`. A test pins that a bracket inside a string doesn't open a span.

Only the span is rewritten — the prose an agent reads for context survives byte-for-byte.

**Wired into both fold chains.** The adapter keeps its own, separate from tier1's, so a transform added to one compresses in tests and 0% in production. That exact split once left HTML at 0.0% on real traffic, so a test pins the adapter path specifically.

Runs **last**: whole-block folds are strictly better where they apply, and a block that *is* an array must not be encoded twice in two different markings.

## Verified

`make gate` exit 0 — including **`GATE: PASS — every trajectory certified non-inferior`**, which is the check that matters for a new compression path.

**3530 tests pass, 95.16% coverage.** ruff + mypy clean. All 6 new tests confirmed to fail without the feature.