### PR TITLE
release(1.51.0): promote the correctness line to GA, with the embedded-JSON fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [1.51.0] — the shape every fold missed
 
-### Embedded JSON — the shape every fold missed
+Promotes the 1.50.x line to GA and adds one new compression path. The correctness
+work (1.49.0–1.50.2) soaked as `v1.50.1rc1`/`v1.50.2rc2`; the embedded-JSON fold
+below landed after rc2 and so ships on its tests and the certificate gate rather
+than on soak time.
+
+### Embedded JSON
 
 distil's columnar folds required the **whole block** to be a JSON array. Real tool
 output rarely is: a `gh api` dump, an MCP result, a `curl | jq` tail and most CLI

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.50.2
-date-released: 2026-08-24
+version: 1.51.0
+date-released: 2026-08-25
 keywords:
   - llm
   - context-compression

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # (an rc must not move `latest`), so the image that tag names is never published and
 # a default `helm install` would ImagePullBackOff. rc soakers install the wheel.
 version: 0.1.1
-appVersion: "1.50.2"
+appVersion: "1.51.0"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.50.2-rc.2",
+  "version": "1.51.0",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.50.2-rc.2",
+  "version": "1.51.0",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.50.2rc2"
+version = "1.51.0"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.50.2rc2",
+  "version": "1.51.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.50.2rc2",
+      "version": "1.51.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.50.2rc2"
+version = "1.51.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What ships

Promotes 1.49.0–1.50.2 to GA and adds one new compression path.

| version | content | soak |
|---|---|---|
| 1.49.0 | agent-loop correctness — empty diffs, truncated streams, digested file reads, cache writes | rc1 + rc2 |
| 1.50.0 | salience training that can run, `distil memory` | rc1 + rc2 |
| 1.50.1 | extended-thinking accounting | rc1 + rc2 |
| 1.50.2 | error-reason recording, **session-survival guard** | rc2 |
| 1.51.0 | **embedded-JSON fold** | **none — post-rc2** |

## Why minor, not patch

The embedded-JSON fold is a new capability, not a fix. Semver should say so.

## The honest caveat, stated in the changelog too

The fold landed **after** rc2, so it ships on its tests and the certificate gate rather than on soak time. Everything above it soaked as `v1.50.1rc1` / `v1.50.2rc2`.

What that rests on instead:
- `GATE: PASS — every trajectory certified non-inferior` (the check that matters for a new compression path)
- 8 tests, all verified to fail without the feature
- A cross-audit finding already fixed: it accepted `emit_handle` and ignored it, so reversible-tier folds carried no `handle=` — content stored but unreachable

## Versioning

All seven surfaces on `1.51.0`. Helm `appVersion` tracks the release again — `release.yml` builds a container for final tags, so unlike an rc the chart's default image exists.

## Verified

`make gate` exit 0. **3532 tests pass, 95.16% coverage.** All 16 packaging guards green. ruff + mypy clean.