### PR TITLE
release(1.51.1): the first representative shadow measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 All notable changes to Distil are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is [SemVer](https://semver.org/).
 
-## [Unreleased]
-
-### Shadow mode was measuring the wrong subset of your traffic
+## [1.51.1] — shadow mode was measuring the wrong subset of your traffic
 
 Every shadow replay carrying a prior-turn `thinking` block failed with
 `400 Invalid signature in thinking block`. A thinking block is signed and bound to

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
     email: chandu1221@gmail.com
 repository-code: "https://github.com/dshakes/distil"
 license: Apache-2.0
-version: 1.51.0
-date-released: 2026-08-25
+version: 1.51.1
+date-released: 2026-08-30
 keywords:
   - llm
   - context-compression

--- a/packaging/helm/distil-gateway/Chart.yaml
+++ b/packaging/helm/distil-gateway/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # (an rc must not move `latest`), so the image that tag names is never published and
 # a default `helm install` would ImagePullBackOff. rc soakers install the wheel.
 version: 0.1.1
-appVersion: "1.51.0"
+appVersion: "1.51.1"
 home: https://dshakes.github.io/distil/
 sources:
   - https://github.com/dshakes/distil

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distil-llm",
-  "version": "1.51.0",
+  "version": "1.51.1",
   "description": "Compress your AI agent's context and prove its decisions don't change \u2014 cache-aware, reversible, certified. JS/TS bridge to the distil CLI + proxy helpers.",
   "keywords": [
     "llm",

--- a/plugins/distil/.claude-plugin/plugin.json
+++ b/plugins/distil/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "distil",
   "description": "Live session-first savings status line, /distil commands (stats, dashboard, shadow equivalence, doctor, onboard, trajectory certificate, savings badge) for distil \u2014 certified context compression",
-  "version": "1.51.0",
+  "version": "1.51.1",
   "author": {
     "name": "Distil",
     "email": "chandu1221@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Import package and CLI are `distil`; the PyPI distribution is `distil-llm`
 # (the bare `distil` name is already taken on PyPI).
 name = "distil-llm"
-version = "1.51.0"
+version = "1.51.1"
 description = "Compression with a quality contract — cache-aware, causally-pruned context compression for agentic runtimes, gated by a statistical non-inferiority test."
 readme = "README.md"
 # Python floor is 3.9 — the version macOS still ships as the system `python3`. The

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/dshakes/distil",
     "source": "github"
   },
-  "version": "1.51.0",
+  "version": "1.51.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "distil-llm",
-      "version": "1.51.0",
+      "version": "1.51.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ nvtx = [
 
 [[package]]
 name = "distil-llm"
-version = "1.51.0"
+version = "1.51.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What this ships

The shadow-replay fix from #156, plus its double-counted failure metric.

**Patch, not minor** — no new capability. This fixes what shadow could *see*.

## Why it matters more than the version number suggests

Every replay carrying a prior-turn `thinking` block failed with `400 Invalid signature in thinking block` (reproduced against the live API, then verified fixed: same body, 400 → 200).

Claude Code runs extended thinking **by default**, so shadow could only sample the minority of turns that had none. That did not merely shrink the sample — it **biased** it. Every live decision-equivalence figure distil has published, on every version, was computed over whichever turns happened to be thinking-free.

`SIG_VERSION` → **4**, so pre-fix rows are discarded rather than pooled. Existing shadow history resets, which is the point.

## After this lands

The next `distil shadow-stats` reading is the first representative decision-equivalence measurement distil has produced on live traffic — on any version.

## Verified

`make gate` exit 0. **3537 tests, 95.14% coverage.** All 16 packaging guards green. ruff + mypy clean.