### PR TITLE
fix(onboard): Ctrl+C inside the launched agent no longer tears onboard down

### DIFF
--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2063,6 +2063,15 @@ def cmd_onboard(args: argparse.Namespace) -> int:
         first_cmd = steps[0][1]
         if ask(f"Start now — run step 1?  ({first_cmd})"):
             print()
+            # Ctrl+C belongs to the agent (it cancels a turn, not the session).
+            # Same rule as wrap's own parent — see proxy.py's SIGINT note. A
+            # Python-level handler resets across exec, so the child still gets it.
+            import signal
+
+            try:
+                signal.signal(signal.SIGINT, lambda *_: None)
+            except ValueError:
+                pass  # not the main thread (embedded use)
             return subprocess.run(first_cmd.split()).returncode
 
     print(

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -9,6 +9,7 @@ distil certify   --trajectory T --strategy non-inferiority gate (the quality con
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 import time
@@ -2068,11 +2069,16 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             # Python-level handler resets across exec, so the child still gets it.
             import signal
 
+            prev = signal.getsignal(signal.SIGINT)
             try:
                 signal.signal(signal.SIGINT, lambda *_: None)
             except ValueError:
                 pass  # not the main thread (embedded use)
-            return subprocess.run(first_cmd.split()).returncode
+            try:
+                return subprocess.run(first_cmd.split()).returncode
+            finally:
+                with contextlib.suppress(ValueError):
+                    signal.signal(signal.SIGINT, prev)
 
     print(
         c("90", "Re-run anytime: ")

--- a/distil/cli.py
+++ b/distil/cli.py
@@ -2077,7 +2077,9 @@ def cmd_onboard(args: argparse.Namespace) -> int:
             try:
                 return subprocess.run(first_cmd.split()).returncode
             finally:
-                with contextlib.suppress(ValueError):
+                with contextlib.suppress(
+                    ValueError, TypeError
+                ):  # non-main thread / non-Python prev
                     signal.signal(signal.SIGINT, prev)
 
     print(

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -212,18 +212,28 @@ def test_cmd_onboard_yes_runs_first_step(tmp_path, monkeypatch, capsys) -> None:
         return _R()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    rc = cli.cmd_onboard(
-        argparse.Namespace(
-            json=False,
-            offline=False,
-            dry_run=False,
-            force=False,
-            upgrade=False,
-            no_color=True,
-            yes=True,
-            no_interactive=False,
+    import signal
+
+    prev = signal.getsignal(signal.SIGINT)
+    try:
+        rc = cli.cmd_onboard(
+            argparse.Namespace(
+                json=False,
+                offline=False,
+                dry_run=False,
+                force=False,
+                upgrade=False,
+                no_color=True,
+                yes=True,
+                no_interactive=False,
+            )
         )
-    )
+        # Ctrl+C must reach the agent, not tear onboard down with a traceback:
+        # the parent installs a no-op SIGINT handler before handing over the terminal.
+        assert signal.getsignal(signal.SIGINT) is not prev
+        assert signal.getsignal(signal.SIGINT) is not signal.SIG_IGN
+    finally:
+        signal.signal(signal.SIGINT, prev)
     assert rc == 0
     assert "wrap" in " ".join(ran["cmd"])  # --yes launched the route command (step 1)
 

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -207,33 +207,32 @@ def test_cmd_onboard_yes_runs_first_step(tmp_path, monkeypatch, capsys) -> None:
     class _R:
         returncode = 0
 
+    import signal
+
     def fake_run(cmd, *a, **k):
         ran["cmd"] = cmd
+        ran["sigint"] = signal.getsignal(signal.SIGINT)
         return _R()
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    import signal
-
     prev = signal.getsignal(signal.SIGINT)
-    try:
-        rc = cli.cmd_onboard(
-            argparse.Namespace(
-                json=False,
-                offline=False,
-                dry_run=False,
-                force=False,
-                upgrade=False,
-                no_color=True,
-                yes=True,
-                no_interactive=False,
-            )
+    rc = cli.cmd_onboard(
+        argparse.Namespace(
+            json=False,
+            offline=False,
+            dry_run=False,
+            force=False,
+            upgrade=False,
+            no_color=True,
+            yes=True,
+            no_interactive=False,
         )
-        # Ctrl+C must reach the agent, not tear onboard down with a traceback:
-        # the parent installs a no-op SIGINT handler before handing over the terminal.
-        assert signal.getsignal(signal.SIGINT) is not prev
-        assert signal.getsignal(signal.SIGINT) is not signal.SIG_IGN
-    finally:
-        signal.signal(signal.SIGINT, prev)
+    )
+    # Ctrl+C must reach the agent, not tear onboard down with a traceback: a no-op
+    # (not SIG_IGN — that would survive exec) handler is installed for the handover
+    # only, and the caller's handler is back afterwards.
+    assert callable(ran["sigint"]) and ran["sigint"] is not prev
+    assert signal.getsignal(signal.SIGINT) is prev
     assert rc == 0
     assert "wrap" in " ".join(ran["cmd"])  # --yes launched the route command (step 1)
 


### PR DESCRIPTION
`distil onboard` hands the terminal to `distil wrap -- claude` with a plain
subprocess.run. The terminal delivers SIGINT to the whole foreground group, and
Claude Code uses the first press to cancel a turn, not to exit — so the same key
raised KeyboardInterrupt in onboard's parent and dumped a traceback over the
still-running agent.

wrap's own parent already handles this with a no-op Python-level SIGINT handler
(proxy.py); onboard now installs the same one before the handover. A Python-level
handler resets across exec, so the child still receives its Ctrl+C.

The existing --yes step-1 test now asserts the handler is installed; it fails on
the old code.

## Verification
- `tests/test_onboard.py::test_cmd_onboard_yes_runs_first_step` extended; fails without the fix, passes with it
- `tests/test_onboard.py tests/test_cli_onboard.py`: 95 passed
- ruff@0.15.10 check + format clean